### PR TITLE
infra: fix skip-author-identity-check label + first-time-contributor advisory crash (#1196)

### DIFF
--- a/.github/workflows/pr-author-identity.yml
+++ b/.github/workflows/pr-author-identity.yml
@@ -15,7 +15,11 @@ name: PR Author Identity
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # 'labeled'/'unlabeled' are required so that applying the
+    # 'skip-author-identity-check' bypass label re-triggers this workflow with
+    # an event payload that actually contains the label. Without them, adding
+    # the label has no effect (re-runs reuse the original label-less payload).
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   verify-author-identity:

--- a/.github/workflows/pr-first-time-contributor.yml
+++ b/.github/workflows/pr-first-time-contributor.yml
@@ -80,5 +80,10 @@ jobs:
           EOF
           )
 
-          gh pr comment "$PR_NUMBER" --body "$BODY"
-          echo "✓ Advisory posted on PR #$PR_NUMBER."
+          # gh pr comment needs explicit repo context: this workflow never
+          # checks out the repo, so gh cannot infer it from a local git remote
+          # (would fail with "not a git repository"). Pass -R explicitly, and
+          # never let a comment failure red the PR — this guard is advisory only.
+          gh pr comment "$PR_NUMBER" -R "$REPO" --body "$BODY" \
+            || echo "⚠ advisory comment could not be posted (non-fatal)"
+          echo "✓ Advisory step complete for PR #$PR_NUMBER."


### PR DESCRIPTION
Fixes #1196.

Two CI guards from the #986 family were misbehaving on fork PRs (surfaced while merging #1188). Neither issue related to the PR's actual code.

## 1. `skip-author-identity-check` label was inert
`pr-author-identity.yml` only triggered on `[opened, synchronize, reopened]`, gating at the job level with `if: !contains(labels, 'skip-author-identity-check')`. Adding the label never re-fired the workflow, and re-running a job reuses the **original label-less event payload** — so the bypass label had no effect.

**Fix:** add `labeled, unlabeled` to `on.pull_request.types` so applying the label re-triggers the workflow with a payload that contains it.

## 2. First-Time Contributor Advisory crashed (`not a git repository`)
`pr-first-time-contributor.yml` is documented as *non-blocking* but exited 1 with `fatal: not a git repository`. Root cause: `gh pr comment` had no repo context because the workflow (correctly, for fork safety) never checks out.

**Fix:** pass `-R "$REPO"` explicitly, and wrap the call in `|| echo …` so a comment failure can never red a PR again.

## Note on activation
These live under `.github/workflows/`, so for `pull_request` events GitHub runs the definitions from the **base branch**. The fixes therefore take effect for subsequent PRs (incl. #1188) only after this merges to `main`.

## Validation
- Both YAML files parse cleanly.
- No logic change beyond triggers + repo context.