### PR TITLE
infra: unblock sync-artifacts CD (reconcile to v6.8.9 → 6.8.10) + guard /release + credit contributor

### DIFF
--- a/.agents/skills/gaia-release/SKILL.md
+++ b/.agents/skills/gaia-release/SKILL.md
@@ -60,6 +60,27 @@ If requested to update version files:
    ```
 
 ### 3. Promote GitHub Release to Latest / Production
+
+> **⚠️ Ancestry guard (mandatory — issue: split-brain release state).**
+> Before promoting **or** publishing any tag, verify the tag's commit is an
+> ancestor of `main`. Promoting/publishing a tag whose commit never landed on
+> `main` desyncs the published version from the branch manifests, which makes
+> `sync-artifacts.yml` recompute the *same* patch version on every subsequent
+> merge and hard-fail on `fatal: tag 'vX.Y.Z' already exists` (this is exactly
+> what happened with `v6.8.9`). Run this and **abort** if it fails:
+>
+> ```bash
+> git fetch --tags origin main
+> if ! git merge-base --is-ancestor "$(git rev-list -n1 <tag>)" origin/main; then
+>   echo "ABORT: <tag> commit is not on main — land the version-bump commit first."
+>   exit 1
+> fi
+> ```
+>
+> If the tag is legitimately ahead of `main` (e.g. the release commit is still
+> in flight), do **not** promote/publish yet — merge the bump to `main` first,
+> or reconcile `main`'s manifests to the tag version so the branch owns it.
+
 To change a canary or beta release to the latest production release on GitHub:
 1. Generate the changelog/notes in a markdown file (e.g. `generated-output/changelog_vX.Y.Z.md`).
 2. Run the `gh release edit` command with the appropriate flags to update the title, remove the prerelease flag, mark it as latest, and upload the notes:
@@ -70,6 +91,12 @@ To change a canary or beta release to the latest production release on GitHub:
 
 ### 4. Manually Publish to PyPI
 If the release needs to be manually published to PyPI (e.g., when bypassing automated CI triggers or for manual publication control):
+
+> **⚠️ Apply the same ancestry guard from §3 first.** Publishing a version to
+> PyPI that `main`'s `pyproject.toml` does not carry is unrecoverable (PyPI
+> versions are immutable) and strands `main` behind the published version. Only
+> publish when `main`'s version ≥ the version being published.
+>
 1. Use the GitHub CLI to trigger the `Publish gaia-cli to PyPI` workflow manually. Specify the `main` branch as the reference, which will build the version defined in `pyproject.toml` on the `main` branch:
    ```bash
    gh workflow run publish-pypi.yml --ref main

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ curl https://gaiaskilltree.com/api/v1/leaderboard.json
 **1. CLI
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `6.8.8`.
+Current Gaia CLI version: `6.8.9`.
 
 ```bash
 curl -fsSL https://gaiaskilltree.com/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -433,6 +433,12 @@ Community contributors (1–2 skills each): [@karpathy](https://github.com/karpa
 | [@kriptoburak](https://github.com/kriptoburak) | Evidence evaluator: x-twitter-automation evidence review |
 | [@fahimkarim01](https://github.com/fahimkarim01) | Curation: corrected pexp13/sentiment-analysis metadata links |
 
+### Code & Fixes
+
+| Contributor | Contribution |
+|---|---|
+| [@fazalpsinfo-cmyk](https://github.com/fazalpsinfo-cmyk) | Bug fix: resolved `UnboundLocalError` in `gaia scan` when no custom skills are detected (#1141, PR #1188) |
+
 ### Bots
 
 | Bot | Contribution |

--- a/docs/about.html
+++ b/docs/about.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>About — Gaia Skill Registry</title>
@@ -17,11 +17,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="css/plaque.css?v=6.8.8">
-  <script src="js/icons.js?v=6.8.8"></script>
-  <script src="js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="js/rank-badge.js?v=6.8.8"></script>
+  <link rel="stylesheet" href="css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="css/plaque.css?v=6.8.9">
+  <script src="js/icons.js?v=6.8.9"></script>
+  <script src="js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="js/rank-badge.js?v=6.8.9"></script>
 
   <style>
     /* ─── about.html — atlas frontispiece layout ───────────────── */
@@ -905,8 +905,8 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.8.8"></script>
-  <script src="js/site-nav.js?v=6.8.8"></script>
+  <script src="js/mounts.js?v=6.8.9"></script>
+  <script src="js/site-nav.js?v=6.8.9"></script>
 
   <!-- ─── BACK ─── -->
   <div class="profile-back-row">
@@ -1241,9 +1241,9 @@
 
   <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.8.8"></script>
+  <script src="js/site-footer.js?v=6.8.9"></script>
 
-  <script src="js/ui.js?v=6.8.8" defer></script>
+  <script src="js/ui.js?v=6.8.9" defer></script>
 
   <!-- Hydrate rank badges from the canonical component (no inline star markup). -->
   <script>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -21,12 +21,12 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
   <!-- Scripts -->
-  <script src="../js/icons.js?v=6.8.8"></script>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
+  <script src="../js/icons.js?v=6.8.9"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
 
   <style>
     /* ── API Docs Page Styles — tokens only, no hex ── */

--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -17,8 +17,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
   <style>
     a { color: inherit; }
     .bd-live {
@@ -846,7 +846,7 @@
       white-space: nowrap;
     }
   </style>
-  <link rel="stylesheet" href="../css/plaque.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.8.9">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -858,8 +858,8 @@
 </head>
 <body class="process-page">
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
 
   <main>
     <!-- ─── BACK ─── -->
@@ -1918,7 +1918,7 @@
 
   <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -1939,9 +1939,9 @@
   </dialog>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="../js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="../js/skill-explorer.js?v=6.8.8"></script>
-  <script src="../js/ui.js?v=6.8.8"></script>
-  <script src="../js/page-ia.js?v=6.8.8"></script>
+  <script src="../js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="../js/skill-explorer.js?v=6.8.9"></script>
+  <script src="../js/ui.js?v=6.8.9"></script>
+  <script src="../js/page-ia.js?v=6.8.9"></script>
 </body>
 </html>

--- a/docs/benchmarks/humaneval-v1/index.html
+++ b/docs/benchmarks/humaneval-v1/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HumanEval v1 &mdash; Methodology | Gaia Registry</title>
@@ -13,8 +13,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <script>window.gaiaIconBase = function () { return '../../assets/icons.svg'; };</script>
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.8.9">
   <style>
     /* Shares the methodology-page prose shell voice. */
     .prose-shell {
@@ -185,8 +185,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.8.8"></script>
-  <script src="../../js/site-nav.js?v=6.8.8"></script>
+  <script src="../../js/mounts.js?v=6.8.9"></script>
+  <script src="../../js/site-nav.js?v=6.8.9"></script>
   <main class="prose-shell">
     <span class="breadcrumb"><a href="../humaneval/">&larr; HumanEval Leaderboard</a></span>
 
@@ -343,6 +343,6 @@
     </footer>
   </main>
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.8.8"></script>
+  <script src="../../js/site-footer.js?v=6.8.9"></script>
 </body>
 </html>

--- a/docs/benchmarks/humaneval/index.html
+++ b/docs/benchmarks/humaneval/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HumanEval Leaderboard | Gaia Registry</title>
@@ -12,8 +12,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.8.9">
   <script>
     window.gaiaIconBase = function () { return '../../assets/icons.svg'; };
   </script>
@@ -285,8 +285,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.8.8"></script>
-  <script src="../../js/site-nav.js?v=6.8.8"></script>
+  <script src="../../js/mounts.js?v=6.8.9"></script>
+  <script src="../../js/site-nav.js?v=6.8.9"></script>
 
   <main class="lb-shell">
     <div class="lb-back"><a href="../">&larr; Benchmarks</a></div>
@@ -335,7 +335,7 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.8.8"></script>
-  <script src="../_shared/leaderboard.js?v=6.8.8" defer></script>
+  <script src="../../js/site-footer.js?v=6.8.9"></script>
+  <script src="../_shared/leaderboard.js?v=6.8.9" defer></script>
 </body>
 </html>

--- a/docs/benchmarks/index.html
+++ b/docs/benchmarks/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,8 +14,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
 
   <script>
     window.gaiaIconBase = function () { return '../assets/icons.svg'; };
@@ -405,8 +405,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
 
   <main class="bench-shell">
 
@@ -511,7 +511,7 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
   <script>
   /* Mobile-first parallax on the GSB panel per DESIGN.md §Motion.
      - RAF-driven translateY, never background-attachment:fixed

--- a/docs/benchmarks/methodology/index.html
+++ b/docs/benchmarks/methodology/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Benchmark Methodology | Gaia Registry</title>
@@ -13,8 +13,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <script>window.gaiaIconBase = function () { return '../../assets/icons.svg'; };</script>
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.8.9">
   <style>
     /* ─────────────────────────────────────────────────────────────
        METHODOLOGY — long-form prose with typographic rhythm.
@@ -215,8 +215,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.8.8"></script>
-  <script src="../../js/site-nav.js?v=6.8.8"></script>
+  <script src="../../js/mounts.js?v=6.8.9"></script>
+  <script src="../../js/site-nav.js?v=6.8.9"></script>
   <main class="prose-shell">
     <span class="breadcrumb"><a href="../">&larr; Benchmarks</a></span>
 
@@ -363,6 +363,6 @@
     </footer>
   </main>
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.8.8"></script>
+  <script src="../../js/site-footer.js?v=6.8.9"></script>
 </body>
 </html>

--- a/docs/benchmarks/mmlu-v1/index.html
+++ b/docs/benchmarks/mmlu-v1/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MMLU v1 &mdash; Methodology | Gaia Registry</title>
@@ -13,8 +13,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <script>window.gaiaIconBase = function () { return '../../assets/icons.svg'; };</script>
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.8.9">
   <style>
     /* Shares the methodology-page prose shell voice. */
     .prose-shell {
@@ -201,8 +201,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.8.8"></script>
-  <script src="../../js/site-nav.js?v=6.8.8"></script>
+  <script src="../../js/mounts.js?v=6.8.9"></script>
+  <script src="../../js/site-nav.js?v=6.8.9"></script>
   <main class="prose-shell">
     <span class="breadcrumb"><a href="../mmlu/">&larr; MMLU Leaderboard</a></span>
 
@@ -305,6 +305,6 @@
     </footer>
   </main>
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.8.8"></script>
+  <script src="../../js/site-footer.js?v=6.8.9"></script>
 </body>
 </html>

--- a/docs/benchmarks/mmlu/index.html
+++ b/docs/benchmarks/mmlu/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MMLU Leaderboard | Gaia Registry</title>
@@ -12,8 +12,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.8.9">
   <script>
     window.gaiaIconBase = function () { return '../../assets/icons.svg'; };
   </script>
@@ -208,8 +208,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.8.8"></script>
-  <script src="../../js/site-nav.js?v=6.8.8"></script>
+  <script src="../../js/mounts.js?v=6.8.9"></script>
+  <script src="../../js/site-nav.js?v=6.8.9"></script>
 
   <main class="lb-shell">
     <div class="lb-back"><a href="../">&larr; Benchmarks</a></div>
@@ -268,7 +268,7 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.8.8"></script>
-  <script src="../_shared/leaderboard.js?v=6.8.8" defer></script>
+  <script src="../../js/site-footer.js?v=6.8.9"></script>
+  <script src="../_shared/leaderboard.js?v=6.8.9" defer></script>
 </body>
 </html>

--- a/docs/codex.html
+++ b/docs/codex.html
@@ -2,7 +2,7 @@
 <!-- Codex updated to include gaia curate chain pipeline and interactive diagram -->
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,13 +14,13 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="css/styles.css?v=6.8.8">
+<link rel="stylesheet" href="css/styles.css?v=6.8.9">
 <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-<script src="js/icons.js?v=6.8.8"></script>
+<script src="js/icons.js?v=6.8.9"></script>
 <!-- Stage 2 — shared rank-badge primitive. -->
-<script src="js/rank-badge.js?v=6.8.8"></script>
+<script src="js/rank-badge.js?v=6.8.9"></script>
 <!-- Stage 3 — plaque component family. -->
-<script src="js/plaque.js?v=6.8.8"></script>
+<script src="js/plaque.js?v=6.8.9"></script>
 <style>
 /* Curate Chain CSS definitions */
 .curate-chain-section {
@@ -430,7 +430,7 @@
   }
 }
 </style>
-  <link rel="stylesheet" href="css/plaque.css?v=6.8.8">
+  <link rel="stylesheet" href="css/plaque.css?v=6.8.9">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -443,8 +443,8 @@
 <body class="process-page">
 
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.8.8"></script>
-  <script src="js/site-nav.js?v=6.8.8"></script>
+  <script src="js/mounts.js?v=6.8.9"></script>
+  <script src="js/site-nav.js?v=6.8.9"></script>
 
 <main>
   <!-- ─── BACK ─── -->
@@ -1078,7 +1078,7 @@
 
 <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.8.8"></script>
+  <script src="js/site-footer.js?v=6.8.9"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -1102,10 +1102,10 @@
   </button>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="js/skill-explorer.js?v=6.8.8"></script>
-  <script src="js/ui.js?v=6.8.8"></script>
-  <script src="js/page-ia.js?v=6.8.8"></script>
+  <script src="js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="js/skill-explorer.js?v=6.8.9"></script>
+  <script src="js/ui.js?v=6.8.9"></script>
+  <script src="js/page-ia.js?v=6.8.9"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/codex/trust-methodology.html
+++ b/docs/codex/trust-methodology.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -12,8 +12,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
-  <script src="../js/icons.js?v=6.8.8"></script>
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
+  <script src="../js/icons.js?v=6.8.9"></script>
   <style>
     /* ── Trust Methodology page — minimal additions on top of process-page tokens ── */
     .tm-formula-block {
@@ -315,8 +315,8 @@
 <body class="process-page">
 
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
 
   <main style="padding: 0 2rem; max-width: 1060px; margin: 0 auto;">
 
@@ -1334,7 +1334,7 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
 
   <!-- ─── SCROLL TO TOP ─── -->
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
@@ -1342,9 +1342,9 @@
   </button>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="../js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="../js/ui.js?v=6.8.8"></script>
-  <script src="../js/page-ia.js?v=6.8.8"></script>
+  <script src="../js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="../js/ui.js?v=6.8.9"></script>
+  <script src="../js/page-ia.js?v=6.8.9"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/heroes/index.html
+++ b/docs/heroes/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hall of Heroes | Gaia Registry</title>
   <meta name="description" content="The registry's highest-achieving contributors, celebrated in a dark ceremonial gallery.">
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
 
   <!-- Fonts: EB Garamond (display), Bricolage Grotesque (body), Departure Mono -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -16,15 +16,15 @@
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   <!-- Design tokens + plaque base -->
-  <link rel="stylesheet" href="../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/plaque.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.8.9">
 
   <!-- Page styles -->
-  <link rel="stylesheet" href="heroes.css?v=6.8.8">
+  <link rel="stylesheet" href="heroes.css?v=6.8.9">
 
   <!-- Plaque renderer (needed for renderOg) -->
-  <script src="../js/plaque.js?v=6.8.8"></script>
+  <script src="../js/plaque.js?v=6.8.9"></script>
   <script>
     // gaiaIconBase for sub-page (depth=1)
     window.gaiaIconBase = function() { return '../assets/icons.svg'; };
@@ -41,8 +41,8 @@
 <body>
   <!-- Site navigation -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
 
   <!-- ═══ GALLERY SHELL ═══ -->
   <main class="heroes-gallery" id="heroesGallery">
@@ -191,15 +191,15 @@
 
   <!-- Site footer -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
 
   <!-- Share modal wiring -->
-  <script src="../js/hoh-modal.js?v=6.8.8"></script>
+  <script src="../js/hoh-modal.js?v=6.8.9"></script>
 
   <!-- Heroes orchestrator + animations + share enhancements -->
-  <script src="heroes.js?v=6.8.8"></script>
-  <script src="hero-animations.js?v=6.8.8"></script>
-  <script src="hero-share.js?v=6.8.8"></script>
+  <script src="heroes.js?v=6.8.9"></script>
+  <script src="hero-animations.js?v=6.8.9"></script>
+  <script src="hero-share.js?v=6.8.9"></script>
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>
 <!-- impeccable-live-end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -35,17 +35,17 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="css/plaque.css?v=6.8.8">
+  <link rel="stylesheet" href="css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="css/plaque.css?v=6.8.9">
   <!-- Universal AlphaRail (page-wide section + explorer index). -->
-  <link rel="stylesheet" href="css/alpha-rail.css?v=6.8.8">
+  <link rel="stylesheet" href="css/alpha-rail.css?v=6.8.9">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="js/icons.js?v=6.8.8"></script>
+  <script src="js/icons.js?v=6.8.9"></script>
   <!-- Stage 2 — shared rank-badge primitive, loaded after icons. -->
-  <script src="js/rank-badge.js?v=6.8.8"></script>
+  <script src="js/rank-badge.js?v=6.8.9"></script>
   <!-- Stage 3 — plaque component family, loaded after rank-badge. -->
-  <script src="js/tm-config.js?v=6.8.8"></script>
-  <script src="js/plaque.js?v=6.8.8"></script>
+  <script src="js/tm-config.js?v=6.8.9"></script>
+  <script src="js/plaque.js?v=6.8.9"></script>
   <style>
   /* Review Section & Side-by-Side Simulator styling */
   .review-showcase-section {
@@ -297,8 +297,8 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.8.8"></script>
-  <script src="js/site-nav.js?v=6.8.8"></script>
+  <script src="js/mounts.js?v=6.8.9"></script>
+  <script src="js/site-nav.js?v=6.8.9"></script>
 
   <!-- ─── HERO ─── -->
   <section id="hero">
@@ -521,13 +521,13 @@
       </a>
     </div>
   </section>
-  <link rel="stylesheet" href="trust/leaderboard/leaderboard.css?v=6.8.8">
+  <link rel="stylesheet" href="trust/leaderboard/leaderboard.css?v=6.8.9">
   <!-- Tooltip — required for SVG bar hover (delegated handlers in leaderboard.js
        short-circuit when this element is absent). position:fixed so it escapes
        any overflow:hidden ancestor. -->
   <div class="lb-tooltip" id="lbTooltip" hidden aria-hidden="true"></div>
   <script>window.GAIA_LB_EMBED_HOST = true;</script>
-  <script src="trust/leaderboard/leaderboard.js?v=6.8.8"></script>
+  <script src="trust/leaderboard/leaderboard.js?v=6.8.9"></script>
 
   <div class="section-divider"></div>
 
@@ -929,7 +929,7 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.8.8"></script>
+  <script src="js/site-footer.js?v=6.8.9"></script>
 
   <!-- ─── SKILL EXPLORER OVERLAY ─── -->
   <div id="skillExplorer" class="skill-explorer" role="dialog" aria-modal="true" aria-label="Skill Explorer" tabindex="-1">
@@ -1023,17 +1023,17 @@
 
   <!-- ─── SCRIPTS ─── -->
   <!-- icons.js already loaded in <head> so gaiaIcon() is available before any of these. -->
-  <script src="js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="js/skill-graph.js?v=6.8.8"></script>
-  <script src="js/hud-toggle.js?v=6.8.8"></script>
-  <script src="js/scroll-reveal.js?v=6.8.8"></script>
+  <script src="js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="js/skill-graph.js?v=6.8.9"></script>
+  <script src="js/hud-toggle.js?v=6.8.9"></script>
+  <script src="js/scroll-reveal.js?v=6.8.9"></script>
   <!-- Universal AlphaRail component + page-wide integration (section markers
        above the explorer; dynamic type/letter/tier markers inside it). -->
-  <script src="js/alpha-rail.js?v=6.8.8"></script>
-  <script src="js/skill-explorer.js?v=6.8.8"></script>
-  <script src="js/ui.js?v=6.8.8"></script>
-  <script src="js/page-ia.js?v=6.8.8"></script>
-  <script src="js/plaque-reveal.js?v=6.8.8" defer></script>
+  <script src="js/alpha-rail.js?v=6.8.9"></script>
+  <script src="js/skill-explorer.js?v=6.8.9"></script>
+  <script src="js/ui.js?v=6.8.9"></script>
+  <script src="js/page-ia.js?v=6.8.9"></script>
+  <script src="js/plaque-reveal.js?v=6.8.9" defer></script>
 
   <!-- ── Share modal (single instance) — opened from plaque__share-btn ── -->
   <div class="share-modal" hidden role="dialog" aria-modal="true" aria-labelledby="share-modal-title" id="shareModal">
@@ -1169,8 +1169,8 @@
 
   <div id="hohFsToast" class="hoh-fs-toast" role="status" aria-live="polite">Permalink copied!</div>
 
-  <script src="js/profile-share.js?v=6.8.8"></script>
-  <script src="js/hoh-modal.js?v=6.8.8"></script>
+  <script src="js/profile-share.js?v=6.8.9"></script>
+  <script src="js/hoh-modal.js?v=6.8.9"></script>
 
   <!-- ─── REVIEW SHOWCASE SIMULATOR ─── -->
   <script>

--- a/docs/meta.html
+++ b/docs/meta.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -13,14 +13,14 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="css/styles.css?v=6.8.8">
+<link rel="stylesheet" href="css/styles.css?v=6.8.9">
 <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-<script src="js/icons.js?v=6.8.8"></script>
+<script src="js/icons.js?v=6.8.9"></script>
 <!-- Stage 2 — shared rank-badge primitive. -->
-<script src="js/rank-badge.js?v=6.8.8"></script>
+<script src="js/rank-badge.js?v=6.8.9"></script>
 <!-- Stage 3 — plaque component family. -->
-<script src="js/tm-config.js?v=6.8.8"></script>
-<script src="js/plaque.js?v=6.8.8"></script>
+<script src="js/tm-config.js?v=6.8.9"></script>
+<script src="js/plaque.js?v=6.8.9"></script>
 <style>
   .meta-report-grid {
     display: grid;
@@ -97,7 +97,7 @@
     border-color: #34d399;
   }
 </style>
-  <link rel="stylesheet" href="css/plaque.css?v=6.8.8">
+  <link rel="stylesheet" href="css/plaque.css?v=6.8.9">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -110,8 +110,8 @@
 <body class="process-page">
 
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.8.8"></script>
-  <script src="js/site-nav.js?v=6.8.8"></script>
+  <script src="js/mounts.js?v=6.8.9"></script>
+  <script src="js/site-nav.js?v=6.8.9"></script>
 
 <main>
   <!-- ─── BACK ─── -->
@@ -255,7 +255,7 @@
 
 <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.8.8"></script>
+  <script src="js/site-footer.js?v=6.8.9"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -280,10 +280,10 @@
   </button>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="js/skill-explorer.js?v=6.8.8"></script>
-  <script src="js/ui.js?v=6.8.8"></script>
-  <script src="js/page-ia.js?v=6.8.8"></script>
+  <script src="js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="js/skill-explorer.js?v=6.8.9"></script>
+  <script src="js/ui.js?v=6.8.9"></script>
+  <script src="js/page-ia.js?v=6.8.9"></script>
   <script>
   function metaReportShare(btn) {
     const rel = btn.dataset.reportUrl;

--- a/docs/named/index.html
+++ b/docs/named/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -21,20 +21,20 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/plaque.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.8.9">
   <!-- AlphaRail temporarily disabled — keep the stylesheet reference here so
        re-enabling is one uncomment away. The page-wide rail script + integration
        are commented out near the bottom of <body>. -->
-  <!-- <link rel="stylesheet" href="../css/alpha-rail.css?v=6.8.8"> -->
+  <!-- <link rel="stylesheet" href="../css/alpha-rail.css?v=6.8.9"> -->
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../js/icons.js?v=6.8.8"></script>
-  <script src="../js/atlas-helpers.js?v=6.8.8"></script>
+  <script src="../js/icons.js?v=6.8.9"></script>
+  <script src="../js/atlas-helpers.js?v=6.8.9"></script>
   <!-- Stage 2 — shared rank-badge primitive, loaded after icons. -->
-  <script src="../js/rank-badge.js?v=6.8.8"></script>
+  <script src="../js/rank-badge.js?v=6.8.9"></script>
   <!-- Stage 3 — plaque component family, loaded after rank-badge. -->
-  <script src="../js/tm-config.js?v=6.8.8"></script>
-  <script src="../js/plaque.js?v=6.8.8"></script>
+  <script src="../js/tm-config.js?v=6.8.9"></script>
+  <script src="../js/plaque.js?v=6.8.9"></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -49,8 +49,8 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
 
   <!-- ─── BACK ─── -->
   <div class="profile-back-row">
@@ -137,7 +137,7 @@
 
   <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
 
   <!-- ─── SKILL EXPLORER OVERLAY ─── -->
   <div id="skillExplorer" class="skill-explorer" role="dialog" aria-modal="true" aria-label="Skill Explorer" tabindex="-1">
@@ -210,16 +210,16 @@
 
   <!-- ─── SCRIPTS ─── -->
   <!-- icons.js already loaded in <head> so gaiaIcon() is available before any of these. -->
-  <script src="../js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="../js/scroll-reveal.js?v=6.8.8"></script>
-  <script src="../js/named-skills.js?v=6.8.8"></script>
+  <script src="../js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="../js/scroll-reveal.js?v=6.8.9"></script>
+  <script src="../js/named-skills.js?v=6.8.9"></script>
   <!-- AlphaRail temporarily disabled. Uncomment both <script> tags to re-enable
        the section + dynamic letter/tier markers inside the explorer. -->
-  <!-- <script src="../js/alpha-rail.js?v=6.8.8"></script> -->
-  <!-- <script src="../js/index-rail.js?v=6.8.8"></script> -->
-  <script src="../js/skill-explorer.js?v=6.8.8"></script>
-  <script src="../js/ui.js?v=6.8.8"></script>
-  <script src="../js/plaque-reveal.js?v=6.8.8" defer></script>
+  <!-- <script src="../js/alpha-rail.js?v=6.8.9"></script> -->
+  <!-- <script src="../js/index-rail.js?v=6.8.9"></script> -->
+  <script src="../js/skill-explorer.js?v=6.8.9"></script>
+  <script src="../js/ui.js?v=6.8.9"></script>
+  <script src="../js/plaque-reveal.js?v=6.8.9" defer></script>
 
   <!-- ─── HALL OF HEROES FULLSCREEN OG VIEW ─── -->
   <div id="hohFullscreenModal" class="hoh-fs-modal" aria-hidden="true" tabindex="-1">
@@ -315,7 +315,7 @@
   </button>
 </div>
 
-  <script src="../js/hoh-modal.js?v=6.8.8"></script>
+  <script src="../js/hoh-modal.js?v=6.8.9"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/named/report.html
+++ b/docs/named/report.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,11 +14,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/plaque.css?v=6.8.8">
-  <script src="../js/icons.js?v=6.8.8"></script>
-  <script src="../js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="../js/rank-badge.js?v=6.8.8"></script>
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.8.9">
+  <script src="../js/icons.js?v=6.8.9"></script>
+  <script src="../js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="../js/rank-badge.js?v=6.8.9"></script>
 
   <style>
     /* ── Grade color tokens (mirrors GRADE_COLORS in src/gaia_cli/formatting.py) ── */
@@ -597,9 +597,9 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
-  <script src="../js/ui.js?v=6.8.8"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
+  <script src="../js/ui.js?v=6.8.9"></script>
 
   <div class="report-back-row">
     <a class="report-back" href="./index.html" aria-label="Back to Named Skills">
@@ -616,7 +616,7 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
 
   <script>
   (function () {

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,11 +14,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="css/styles.css?v=6.8.9">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="js/icons.js?v=6.8.8"></script>
+  <script src="js/icons.js?v=6.8.9"></script>
   <!-- Stage 2 — shared rank-badge primitive. -->
-  <script src="js/rank-badge.js?v=6.8.8"></script>
+  <script src="js/rank-badge.js?v=6.8.9"></script>
   <style>
     /* ── Privacy page local overrides ── */
     .privacy-hero {
@@ -129,7 +129,7 @@
     }
     .privacy-footer-note a { color: var(--color-accent, #c084fc); }
   </style>
-  <link rel="stylesheet" href="css/plaque.css?v=6.8.8">
+  <link rel="stylesheet" href="css/plaque.css?v=6.8.9">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -143,8 +143,8 @@
 <body>
 
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.8.8"></script>
-  <script src="js/site-nav.js?v=6.8.8"></script>
+  <script src="js/mounts.js?v=6.8.9"></script>
+  <script src="js/site-nav.js?v=6.8.9"></script>
 
   <!-- ─── BACK ─── -->
   <div class="profile-back-row">
@@ -269,7 +269,7 @@
 
   <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.8.8"></script>
+  <script src="js/site-footer.js?v=6.8.9"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -290,10 +290,10 @@
   </dialog>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="js/skill-explorer.js?v=6.8.8"></script>
-  <script src="js/ui.js?v=6.8.8"></script>
-  <script src="js/page-ia.js?v=6.8.8"></script>
+  <script src="js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="js/skill-explorer.js?v=6.8.9"></script>
+  <script src="js/ui.js?v=6.8.9"></script>
+  <script src="js/page-ia.js?v=6.8.9"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -20,8 +20,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
   <link rel="alternate" type="application/json" href="/api/v1/reports/index.json">
 
   <script>
@@ -305,8 +305,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
 
   <main class="reports-shell">
 
@@ -346,6 +346,6 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
 </body>
 </html>

--- a/docs/share/index.html
+++ b/docs/share/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -16,9 +16,9 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <!-- Site-wide tokens then styles, then page-specific overrides. -->
-  <link rel="stylesheet" href="../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="styles.css?v=6.8.9">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -33,9 +33,9 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.8.8" defer></script>
-  <script src="../js/site-nav.js?v=6.8.8" defer></script>
-  <script src="../js/ui.js?v=6.8.8" defer></script>
+  <script src="../js/mounts.js?v=6.8.9" defer></script>
+  <script src="../js/site-nav.js?v=6.8.9" defer></script>
+  <script src="../js/ui.js?v=6.8.9" defer></script>
 
   <!-- ─── MAIN ─── -->
   <main class="share-main" id="share-main">
@@ -92,7 +92,7 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.8.8" defer></script>
+  <script src="../js/site-footer.js?v=6.8.9" defer></script>
 
   <!-- ─── SHARE LOGIC ─── -->
   <!--
@@ -106,7 +106,7 @@
     See docs/share/sample.json for a ready-made fixture.
     PRODUCTION: the override is never set; share.js reads ?b= from the URL.
   -->
-  <script src="share.js?v=6.8.8"></script>
+  <script src="share.js?v=6.8.9"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -20,12 +20,12 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
   <!-- Nav -->
-  <script src="../js/icons.js?v=6.8.8"></script>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
+  <script src="../js/icons.js?v=6.8.9"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -47,7 +47,7 @@
   </main>
 
   <div id="site-footer"></div>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
-  <script src="index.js?v=6.8.8"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
+  <script src="index.js?v=6.8.9"></script>
 </body>
 </html>

--- a/docs/starless.html
+++ b/docs/starless.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -13,18 +13,18 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="css/styles.css?v=6.8.8">
-<link rel="stylesheet" href="css/alpha-rail.css?v=6.8.8">
+<link rel="stylesheet" href="css/styles.css?v=6.8.9">
+<link rel="stylesheet" href="css/alpha-rail.css?v=6.8.9">
 <!-- plaque.css supplies the slate .plaque__redacted-handle styling for ≤1★ chips. -->
-<link rel="stylesheet" href="css/plaque.css?v=6.8.8">
+<link rel="stylesheet" href="css/plaque.css?v=6.8.9">
 <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-<script src="js/icons.js?v=6.8.8"></script>
+<script src="js/icons.js?v=6.8.9"></script>
 <!-- Stage 2 — shared rank-badge primitive. -->
-<script src="js/rank-badge.js?v=6.8.8"></script>
+<script src="js/rank-badge.js?v=6.8.9"></script>
 <!-- Stage 3 — plaque component family. -->
-<script src="js/plaque.js?v=6.8.8"></script>
+<script src="js/plaque.js?v=6.8.9"></script>
 <!-- Universal alphabetical scrubber component. -->
-<script src="js/alpha-rail.js?v=6.8.8"></script>
+<script src="js/alpha-rail.js?v=6.8.9"></script>
 <style>
   /* ───────────────────────────────────────────────────────────────────
      Starless taxonomy — a single-page ledger.
@@ -137,8 +137,8 @@
 <body class="process-page">
 
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.8.8"></script>
-  <script src="js/site-nav.js?v=6.8.8"></script>
+  <script src="js/mounts.js?v=6.8.9"></script>
+  <script src="js/site-nav.js?v=6.8.9"></script>
 
 <main>
   <!-- ─── BACK ─── -->
@@ -181,7 +181,7 @@
 
 <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.8.8"></script>
+  <script src="js/site-footer.js?v=6.8.9"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -450,10 +450,10 @@
   </script>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=6.8.8"></script>
-  <script src="js/skill-explorer.js?v=6.8.8"></script>
-  <script src="js/ui.js?v=6.8.8"></script>
-  <script src="js/page-ia.js?v=6.8.8"></script>
+  <script src="js/atlas-helpers.js?v=6.8.9"></script>
+  <script src="js/skill-explorer.js?v=6.8.9"></script>
+  <script src="js/ui.js?v=6.8.9"></script>
+  <script src="js/page-ia.js?v=6.8.9"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/trending/index.html
+++ b/docs/trending/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -23,10 +23,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="trending.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="trending.css?v=6.8.9">
   <!-- Icon sprite helper -->
-  <script src="../js/icons.js?v=6.8.8"></script>
+  <script src="../js/icons.js?v=6.8.9"></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.8.8"></script>
-  <script src="../js/site-nav.js?v=6.8.8"></script>
+  <script src="../js/mounts.js?v=6.8.9"></script>
+  <script src="../js/site-nav.js?v=6.8.9"></script>
 
   <!-- ─── MAIN ─── -->
   <main class="trending-main">
@@ -124,10 +124,10 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.8.8"></script>
+  <script src="../js/site-footer.js?v=6.8.9"></script>
 
   <!-- ─── PAGE SCRIPT ─── -->
-  <script src="trending.js?v=6.8.8"></script>
+  <script src="trending.js?v=6.8.9"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/trust/index.html
+++ b/docs/trust/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">

--- a/docs/trust/leaderboard/index.html
+++ b/docs/trust/leaderboard/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Trust Leaderboard — Gaia</title>
@@ -12,8 +12,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="leaderboard.css?v=6.8.8">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="leaderboard.css?v=6.8.9">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -25,8 +25,8 @@
 </head>
 <body class="lb-dark-page">
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.8.8"></script>
-  <script src="../../js/site-nav.js?v=6.8.8"></script>
+  <script src="../../js/mounts.js?v=6.8.9"></script>
+  <script src="../../js/site-nav.js?v=6.8.9"></script>
 
   <div class="lb-shell">
     <nav class="lb-toc" aria-label="Page sections">
@@ -200,7 +200,7 @@
   <div class="lb-tooltip" id="lbTooltip" hidden aria-hidden="true"></div>
 
   <footer id="site-footer"></footer>
-  <script src="../../js/site-footer.js?v=6.8.8"></script>
-  <script src="leaderboard.js?v=6.8.8"></script>
+  <script src="../../js/site-footer.js?v=6.8.9"></script>
+  <script src="leaderboard.js?v=6.8.9"></script>
 </body>
 </html>

--- a/docs/trust/ledger/index.html
+++ b/docs/trust/ledger/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -13,9 +13,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="ledger.css?v=6.8.8">
-  <script src="../../js/icons.js?v=6.8.8"></script>
+  <link rel="stylesheet" href="../../css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="ledger.css?v=6.8.9">
+  <script src="../../js/icons.js?v=6.8.9"></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -28,9 +28,9 @@
 <body class="process-page ledger-page">
 
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.8.8"></script>
-  <script src="../../js/site-nav.js?v=6.8.8"></script>
-  <script src="../../js/ui.js?v=6.8.8"></script>
+  <script src="../../js/mounts.js?v=6.8.9"></script>
+  <script src="../../js/site-nav.js?v=6.8.9"></script>
+  <script src="../../js/ui.js?v=6.8.9"></script>
 
   <main class="ledger-main">
 
@@ -127,6 +127,6 @@
 
   </main>
 
-  <script src="ledger.js?v=6.8.8"></script>
+  <script src="ledger.js?v=6.8.9"></script>
 </body>
 </html>

--- a/docs/u/index.html
+++ b/docs/u/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.8.8";</script>
+  <script>window.GAIA_VERSION = "6.8.9";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contributors Directory — Gaia Skill Registry</title>
@@ -18,14 +18,14 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../css/tokens.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/styles.css?v=6.8.8">
-  <link rel="stylesheet" href="../css/plaque.css?v=6.8.8">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/styles.css?v=6.8.9">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.8.9">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../js/icons.js?v=6.8.8"></script>
+  <script src="../js/icons.js?v=6.8.9"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../js/rank-badge.js?v=6.8.8"></script>
-  <script src="../js/ui.js?v=6.8.8" defer></script>
+  <script src="../js/rank-badge.js?v=6.8.9"></script>
+  <script src="../js/ui.js?v=6.8.9" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -38,8 +38,8 @@
 <body class="profile-directory-page">
 
   <nav id="site-nav"></nav>
-<script src="../js/mounts.js?v=6.8.8"></script>
-<script src="../js/site-nav.js?v=6.8.8"></script>
+<script src="../js/mounts.js?v=6.8.9"></script>
+<script src="../js/site-nav.js?v=6.8.9"></script>
 
   <!-- ─── PROFILE BACK ─── -->
   <div class="profile-back-row">
@@ -1447,7 +1447,7 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../js/site-footer.js?v=6.8.8"></script>
+<script src="../js/site-footer.js?v=6.8.9"></script>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "6.8.8",
+  "version": "6.8.9",
   "description": "Gaia CLI \u2014 the open, evidence-backed skill registry for AI agents.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "6.8.8",
+  "version": "6.8.9",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "6.8.8"
+version = "6.8.9"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Three related changes in one PR (per request).

### 1. Unblock the `sync-artifacts.yml` CD (the cache-bust fix)
`sync-artifacts.yml` has **hard-failed on every merge since 2026-07-14** with:
```
fatal: tag 'v6.8.9' already exists
```
**Root cause — split-brain release state:** `v6.8.9` was published (PyPI *latest* + GitHub *Latest* release, tag commit `5dce18339`) but its version-bump commit **never landed on `main`**. So `main` stayed at `6.8.8`, and the CD recomputed patch → `6.8.9` on every merge, colliding with the pre-existing published tag. Because it died before committing, the regenerated docs/cache-bust artifacts never synced → the live site is stuck serving `?v=6.8.8`.

**Fix:** bump the three version-lockstep manifests `6.8.8 → 6.8.9` to match the already-published release. On this PR's merge, the now-unblocked CD patch-bumps to a fresh **`v6.8.10`** (no collision), tags cleanly, and finally commits the cache-bust artifacts.

We cannot delete `v6.8.9` — it backs an immutable PyPI release.

### 2. Guard the `/release` (gaia-release) skill — prevents recurrence
The split-brain was created by the skill's promote (§3) / PyPI-publish (§4) steps, which act on a tag via `gh` **without checking the tag commit is an ancestor of `main`**. Added a mandatory ancestry guard (`git merge-base --is-ancestor`) to both sections with an abort path.

### 3. Credit contributor (#1195)
Added @fazalpsinfo-cmyk under a new **Code & Fixes** section for the `gaia scan` `UnboundLocalError` fix (#1141 / #1188).

## Verification
- `pyproject.toml`, `packages/cli-npm/package.json`, `packages/mcp/package.json` all at `6.8.9` (lockstep).
- `registry/gaia.json` is gitignored (regenerated by CD `--sync`), not touched.
- Expected post-merge: sync-artifacts goes green, produces `v6.8.10`, commits refreshed `?v=6.8.10` assets.

Closes #1195