### PR TITLE
docs: Update MCP installation command to point to @gaia-research/mcp@0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ A GitHub issue opens automatically. Don't worry, we thoroughly review every inta
 **4. MCP Server**
 
 ```bash
-claude mcp add gaia -- npx @gaia-registry/mcp-server
+claude mcp add gaia -- npx -y @gaia-research/mcp@0.1.0
 ```
 
-If you wanna be fancy and do all sorts of agentic MCP goodness.
+Connects your AI agent to the public Gaia Skill Tree registry over stdio.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ A GitHub issue opens automatically. Don't worry, we thoroughly review every inta
 claude mcp add gaia -- npx -y @gaia-research/mcp@0.1.0
 ```
 
-Connects your AI agent to the public Gaia Skill Tree registry over stdio.
+Connects your AI agent to the public Gaia Skill Tree registry over stdio. Full configuration guidance and planned features are documented on the [Gaia MCP Page](https://research.gaiaskilltree.com/mcp).
 
 ---
 


### PR DESCRIPTION
Updates the README to use the correct published package name `@gaia-research/mcp` and pins it to version `0.1.0`, matching the newly released standalone package.