### PR TITLE
docs+ci: clarify `gaia dev docs --check` is not read-only + sync AGENTS.md MCP command

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,8 +72,14 @@ jobs:
       #   run: gaia dev validate --intake
 
       - name: Check generated docs
+        # NOTE: `gaia dev docs --check` is NOT read-only. It regenerates the
+        # Class P (gitignored) + Class S (tracked docs/graph/*) artifacts, then
+        # fails (exit 1) if the tracked Class S output drifts from what's
+        # committed. On drift, run `gaia dev docs` locally and commit the
+        # regenerated docs/graph/* files. See CLAUDE.md § "Class P vs Class S".
         run: |
           echo "Equivalent python command for local use: python scripts/build_docs.py --check"
+          echo "(This regenerates + compares generated docs; it is not a read-only verify.)"
           gaia dev docs --check
 
       # NOTE: the full pytest suite (`gaia dev test all`) is owned exclusively by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,4 +69,4 @@ Not you if you are a fresh visiting agent. Playbook lives in `docs/agent.md` §5
 
 If your harness speaks MCP:
 
-    claude mcp add gaia -- npx @gaia-registry/mcp-server
+    claude mcp add gaia -- npx -y @gaia-research/mcp@0.1.0

--- a/DEV.md
+++ b/DEV.md
@@ -86,7 +86,7 @@ pip install -e ".[docs]"
 |---|---|
 | `gaia dev validate` | Validate schema, identifiers, DAG cycles, and timelines (`gaia validate` is a deprecated shim) |
 | `gaia dev docs` | Regenerate documentation and assets locally (`gaia docs build` is a deprecated shim) |
-| `gaia dev docs --check` | Verify if generated documentation is up to date (runs in CI) |
+| `gaia dev docs --check` | Regenerate + compare generated docs; fails (exit 1) on drift. NOT read-only — rewrites Class P/S artifacts locally (runs in CI) |
 | `gaia init --user <username>` | Initialize your local Gaia user profile |
 | `gaia scan` | Scan configured paths for skill evidence and generate promotion candidates |
 | `gaia promote <skillId>` | Promote a skill in your tree after a scan |
@@ -249,6 +249,7 @@ Refer to [CLAUDE.md](file:///Users/marcotiongson/Documents/gaia-skill-tree/CLAUD
 
 ### A. Stale Documentation Crash (`gaia dev docs --check` fails)
 * **Symptom:** Modifying `registry/named/` or `registry/nodes/` triggers a CI failure on the docs check.
+* **Heads-up — `--check` is not read-only:** despite the name, it *regenerates* the Class P (gitignored `registry/gaia.json`) and Class S (tracked `docs/graph/*`) artifacts, then fails if the committed Class S output drifts. So running it locally will leave modified files in your working tree — that is expected. Commit the Class S changes; leave Class P (gitignored) alone. See CLAUDE.md § "Class P vs Class S".
 * **Fix (Local):** Run the documentation build locally and commit the regenerated assets with a `[skip-gen]` commit tag so the auto-sync workflow does not double-regenerate:
   ```bash
   gaia dev docs

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1456,7 +1456,7 @@ def build_docs_graph_assets(check: bool) -> bool:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build generated Gaia docs regions.")
-    parser.add_argument("--check", action="store_true", help="Fail if generated docs are stale")
+    parser.add_argument("--check", action="store_true", help="Fail (exit 1) if generated docs drift from source. Not read-only: regenerates Class P/S artifacts before comparing (commit any docs/graph/* Class S changes).")
     parser.add_argument("--auto-clean", action="store_true", help="(Opt-in) In write mode, remove left-only generated files in safe bundles (use cautiously)")
     parser.add_argument(
         "--cache-bust-only",
@@ -1620,9 +1620,9 @@ def main(argv: list[str] | None = None) -> int:
         if changed or warnings:
             if warnings:
                 print("\nError: Documentation build encountered errors in --check mode.", file=sys.stderr)
-            print("Generated documentation is stale. Run `gaia dev docs --check` locally.")
-            print("If it reports drift, run `gaia dev docs` and commit the updated files.")
-            print("Validation checks can be run with `gaia dev validate`.")
+            print("Generated documentation is stale (source changed but committed docs/graph/* did not).")
+            print("Note: --check is NOT read-only — it already regenerated the Class S artifacts locally.")
+            print("Run `gaia dev docs` and commit the updated docs/graph/* files (see CLAUDE.md § Class P vs Class S).")
             return 1
         print("Documentation is up to date.")
         return 0

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -3748,7 +3748,9 @@ def get_parser():
         "build", help="Regenerate generated documentation regions"
     )
     docs_build.add_argument(
-        "--check", action="store_true", help="Fail if docs are stale without writing"
+        "--check",
+        action="store_true",
+        help="Fail (exit 1) if generated docs drift from source. NOTE: not read-only — it regenerates Class P/S artifacts, then compares; commit any docs/graph/* (Class S) changes it produces.",
     )
     lookup_parser = subparsers.add_parser(
         "lookup", help="Look up a canonical skill and its named implementations"
@@ -4237,7 +4239,9 @@ def get_parser():
         "docs", help="Regenerate generated documentation regions"
     )
     dev_docs.add_argument(
-        "--check", action="store_true", help="Fail if docs are stale without writing"
+        "--check",
+        action="store_true",
+        help="Fail (exit 1) if generated docs drift from source. NOTE: not read-only — it regenerates Class P/S artifacts, then compares; commit any docs/graph/* (Class S) changes it produces.",
     )
 
     dev_mcp = dev_sub.add_parser(

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -68,6 +68,10 @@ def test_build_docs_check_message_uses_copyable_python_command(monkeypatch, caps
     assert build_docs.main(["--check"]) == 1
 
     output = capsys.readouterr().out
-    assert "gaia dev docs --check" in output
+    # On drift, the message must point to the FIX command (`gaia dev docs`,
+    # write mode) and the Class S artifacts to commit — not the circular
+    # "run --check again". `--check` is not read-only; it already regenerated.
+    assert "gaia dev docs" in output
+    assert "docs/graph" in output
 
 


### PR DESCRIPTION
Follow-up to the CD/cache-bust unblock work (#1198). Wording-only; **no behavior change**.

## 1. Clarify the docs-check contract (the recurring déjà-vu)
`gaia dev docs --check` **regenerates** the Class P (gitignored `registry/gaia.json`) and Class S (tracked `docs/graph/*`) artifacts and *then* compares — it is **not read-only**. This is the settled design (Epic #780 / PR #798, "Class P vs Class S" in CLAUDE.md), but every surface that *describes* the command implied read-only:

- `src/gaia_cli/impl.py` — both `--check` help strings literally said *"Fail if docs are stale **without writing**"* (wrong). Now: *"Fail (exit 1) if generated docs drift from source. NOTE: not read-only — regenerates Class P/S artifacts, then compares; commit any docs/graph/* (Class S) changes."*
- `scripts/build_docs.py` — `--check` help + the stale-drift message now name Class S / `docs/graph` and point at CLAUDE.md instead of the circular "run --check again".
- `.github/workflows/validate.yml` — the *Check generated docs* step gains a comment + echo noting it regenerates (not a read-only verify).
- `DEV.md` — command table + *Stale Documentation* troubleshooting get a "not read-only" heads-up.

Motivation: this cost real confusion mid-#1198 (`--check` dirtied the working tree with `docs/graph/gaia.json`), and it's come up before. Documenting the contract at each surface stops the loop. Confirmed via scout that there is **no** prior decision to make it read-only — the behavior is intended; only the wording was misleading.

## 2. Sync AGENTS.md MCP command (matches #1199)
`npx @gaia-registry/mcp-server` → `npx -y @gaia-research/mcp@0.1.0`.

## Note for your other-surfaces pass
`README.md:344` (the *Claude Code* row in the harness table) still carries the old `npx @gaia-registry/mcp-server` command — left untouched per your plan to sweep the remaining surfaces yourself.

## Validation
- `impl.py` / `build_docs.py` parse clean; `validate.yml` is valid YAML.
- `build_docs.py --help` shows the corrected text.