### PR TITLE
WAVE 0 — Foundation: tokens + shared resolver + gold wreath + plaque.js

### DIFF
--- a/docs/assets/origin-wreath-gold.svg
+++ b/docs/assets/origin-wreath-gold.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="Origin contributor laurel wreath" class="origin-wreath">
+  <!--
+    Gaia origin wreath — GOLD avatar frame (Yggdrasil II).
+
+    Replaces the deprecated honor-red origin badge (rubric E4: red then gold).
+    A circular laurel FRAME with an OPEN center so a contributor avatar shows
+    through. Rendered in gold: callers tint via `color` (currentColor) or by
+    overriding the seal-gold / tier-fusion tokens; the built-in gradient uses
+    those tokens with hex fallbacks so it looks correct even standalone.
+
+    Usage — overlay a wreath border around an avatar image; the open center
+    reveals the avatar underneath.
+  -->
+  <defs>
+    <linearGradient id="gaiaWreathGold" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="var(--seal-gold, #fbbf24)"/>
+      <stop offset="0.55" stop-color="var(--tier-fusion, #f59e0b)"/>
+      <stop offset="1" stop-color="var(--seal-gold, #d4af37)"/>
+    </linearGradient>
+    <!-- A single laurel leaf: a slim almond pointing up from its stem end. -->
+    <path id="gaiaWreathLeaf" d="M0 0 C 3.4 -2.2 6.2 -6.4 7 -12 C 3.6 -10.4 1 -6.4 0 0 Z"/>
+  </defs>
+
+  <g fill="url(#gaiaWreathGold)" stroke="none">
+    <!-- Left stem arc (bottom → upper-left). Open gap at top for symmetry. -->
+    <path d="M50 87 C 30 86 15 70 14.4 39.8" fill="none"
+          stroke="url(#gaiaWreathGold)" stroke-width="2.2" stroke-linecap="round"/>
+    <!-- Right stem arc (bottom → upper-right). -->
+    <path d="M50 87 C 70 86 85 70 85.6 39.8" fill="none"
+          stroke="url(#gaiaWreathGold)" stroke-width="2.2" stroke-linecap="round"/>
+
+    <!-- Left-side leaves (tangential to the arc, pointing up-and-inward). -->
+    <use href="#gaiaWreathLeaf" transform="translate(43.58 86.44) rotate(190.0)"/>
+    <use href="#gaiaWreathLeaf" transform="translate(30.39 81.38) rotate(212.0)"/>
+    <use href="#gaiaWreathLeaf" transform="translate(20.07 71.75) rotate(234.0)"/>
+    <use href="#gaiaWreathLeaf" transform="translate(14.10 58.95) rotate(256.0)"/>
+    <use href="#gaiaWreathLeaf" transform="translate(13.36 44.85) rotate(278.0)"/>
+
+    <!-- Right-side leaves (mirror of the left branch). -->
+    <use href="#gaiaWreathLeaf" transform="translate(56.42 86.44) rotate(170.0) scale(-1 1)"/>
+    <use href="#gaiaWreathLeaf" transform="translate(69.61 81.38) rotate(148.0) scale(-1 1)"/>
+    <use href="#gaiaWreathLeaf" transform="translate(79.93 71.75) rotate(126.0) scale(-1 1)"/>
+    <use href="#gaiaWreathLeaf" transform="translate(85.90 58.95) rotate(104.0) scale(-1 1)"/>
+    <use href="#gaiaWreathLeaf" transform="translate(86.64 44.85) rotate(82.0) scale(-1 1)"/>
+
+    <!-- Bottom tie: a small berry cluster where the two branches meet. -->
+    <circle cx="50" cy="88.5" r="2.4"/>
+    <circle cx="45.6" cy="86.2" r="1.7"/>
+    <circle cx="54.4" cy="86.2" r="1.7"/>
+  </g>
+</svg>

--- a/docs/codex.html
+++ b/docs/codex.html
@@ -20,6 +20,7 @@
 <!-- Stage 2 — shared rank-badge primitive. -->
 <script src="js/rank-badge.js?v=6.8.8"></script>
 <!-- Stage 3 — plaque component family. -->
+<script src="js/skill-semantics.js?v=6.8.8"></script>
 <script src="js/plaque.js?v=6.8.8"></script>
 <style>
 /* Curate Chain CSS definitions */

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -145,35 +145,33 @@
 }
 
 
-/* ── Per-tier accent: single rule per tier ───────────────────────
+/* ── Per-branch accent: single rule per branch ───────────────────
    --plaque-accent flips here. Every .plaque__* selector resolves
    accent via this property, so no per-variant overrides exist.
+   Rubric E1/E3: keyed on the DERIVED data-branch (standard|suite|
+   unique), never data-type. standard = basic blue, suite = fusion
+   gold, unique = the violet mastery fork.
    ============================================================ */
-.plaque[data-type="basic"] {
+.plaque[data-branch="standard"] {
   --plaque-accent: var(--tier-basic);
   --plaque-accent-rgb: var(--tier-basic-rgb);
   --plaque-accent-bg: var(--tier-basic-bg);
 }
-.plaque[data-type="extra"] {
-  --plaque-accent: var(--tier-extra);
-  --plaque-accent-rgb: var(--tier-extra-rgb);
-  --plaque-accent-bg: var(--tier-extra-bg);
+.plaque[data-branch="suite"] {
+  --plaque-accent: var(--tier-fusion);
+  --plaque-accent-rgb: var(--tier-fusion-rgb);
+  --plaque-accent-bg: var(--tier-fusion-bg);
 }
-.plaque[data-type="unique"] {
+.plaque[data-branch="unique"] {
   --plaque-accent: var(--tier-unique);
   --plaque-accent-rgb: var(--tier-unique-rgb);
   --plaque-accent-bg: var(--tier-unique-bg);
 }
-.plaque[data-type="unique"]:hover {
+.plaque[data-branch="unique"]:hover {
   box-shadow:
     0 0 0 1px rgba(var(--tier-unique-rgb), 0.3),
     0 16px 48px rgba(0, 0, 0, 0.6),
     0 0 20px rgba(var(--tier-unique-rgb), 0.5);
-}
-.plaque[data-type="ultimate"] {
-  --plaque-accent: var(--tier-ultimate);
-  --plaque-accent-rgb: var(--tier-ultimate-rgb);
-  --plaque-accent-bg: var(--tier-ultimate-bg);
 }
 
 
@@ -252,15 +250,17 @@ button.plaque__slug:focus-visible {
   text-underline-offset: 3px;
   outline: none;
 }
-/* Ultimate carries the brand-voice Apex Gold via the tier token. */
-.plaque[data-type="ultimate"] .plaque__slug,
-.plaque[data-type="ultimate"] .plaque-skill-name {
+/* Suite branch at 5★+ carries the brand-voice Apex Gold via the tier token. */
+.plaque[data-branch="suite"][data-level="5"] .plaque__slug,
+.plaque[data-branch="suite"][data-level="5"] .plaque-skill-name,
+.plaque[data-branch="suite"][data-level="6"] .plaque__slug,
+.plaque[data-branch="suite"][data-level="6"] .plaque-skill-name {
   color: var(--apex-gold, #fbbf24);
 }
-/* Level VI (6★) — Transcendent ★ — earns the rainbow shimmer.
-   Level V (5★) — Transcendent — remains static Apex Gold. */
-.plaque[data-type="ultimate"][data-level="6"] .plaque__slug,
-.plaque[data-type="ultimate"][data-level="6"] .plaque-skill-name {
+/* Level VI (6★ Apex) earns the rainbow shimmer.
+   Level V (5★ Ultimate) remains static Apex Gold. */
+.plaque[data-branch="suite"][data-level="6"] .plaque__slug,
+.plaque[data-branch="suite"][data-level="6"] .plaque-skill-name {
   animation: tree-rainbow-glow 4s linear infinite;
 }
 
@@ -563,36 +563,41 @@ button.plaque__slug:focus-visible {
 .plaque[data-level="6"] .plaque-skill-name.named-slug,
 .plaque__stack-row[data-level="6"] .plaque-skill-name.named-slug { color: var(--rank-6, #fbbf24); }
 
-/* Tier-aware overrides — emitted AFTER the rank-level rules so the tier
-   color wins for Unique (deep violet) and Ultimate (apex gold). Without
-   these, a Unique skill at rank IV (Hardened) would render fuchsia from
-   the rank-4 rule above instead of its tier-native deep violet. */
-.plaque[data-type="unique"] .plaque__slug.named-slug,
-.plaque[data-type="unique"] .plaque-skill-name.named-slug,
-.plaque__stack-row[data-type="unique"] .plaque__slug.named-slug,
-.plaque__stack-row[data-type="unique"] .plaque-skill-name.named-slug {
+/* Branch-aware overrides — emitted AFTER the rank-level rules so the branch
+   color wins for Unique (deep violet) and Suite (apex gold). Without these, a
+   Unique skill at 4★ would render fuchsia from the rank-4 rule above instead
+   of its branch-native deep violet. Rubric E1/E3: keyed on derived
+   data-branch, never data-type. */
+.plaque[data-branch="unique"] .plaque__slug.named-slug,
+.plaque[data-branch="unique"] .plaque-skill-name.named-slug,
+.plaque__stack-row[data-branch="unique"] .plaque__slug.named-slug,
+.plaque__stack-row[data-branch="unique"] .plaque-skill-name.named-slug {
   color: var(--tier-unique);
 }
-/* Unique type always overrides level-based rank color on stars */
-.plaque[data-type="unique"] .rank-badge__star[data-on],
-.plaque__stack-row[data-type="unique"] .rank-badge__star[data-on] {
+/* Unique branch always overrides level-based rank color on stars */
+.plaque[data-branch="unique"] .rank-badge__star[data-on],
+.plaque__stack-row[data-branch="unique"] .rank-badge__star[data-on] {
   color: var(--tier-unique);
   text-shadow: 0 0 6px rgba(var(--tier-unique-rgb), .5);
 }
-.plaque[data-type="unique"] .rank-badge__star[data-off],
-.plaque__stack-row[data-type="unique"] .rank-badge__star[data-off] {
+.plaque[data-branch="unique"] .rank-badge__star[data-off],
+.plaque__stack-row[data-branch="unique"] .rank-badge__star[data-off] {
   color: rgba(var(--tier-unique-rgb), .15);
 }
-.plaque[data-type="ultimate"] .plaque__slug.named-slug,
-.plaque[data-type="ultimate"] .plaque-skill-name.named-slug,
-.plaque__stack-row[data-type="ultimate"] .plaque__slug.named-slug,
-.plaque__stack-row[data-type="ultimate"] .plaque-skill-name.named-slug {
+.plaque[data-branch="suite"][data-level="5"] .plaque__slug.named-slug,
+.plaque[data-branch="suite"][data-level="5"] .plaque-skill-name.named-slug,
+.plaque[data-branch="suite"][data-level="6"] .plaque__slug.named-slug,
+.plaque[data-branch="suite"][data-level="6"] .plaque-skill-name.named-slug,
+.plaque__stack-row[data-branch="suite"][data-level="5"] .plaque__slug.named-slug,
+.plaque__stack-row[data-branch="suite"][data-level="5"] .plaque-skill-name.named-slug,
+.plaque__stack-row[data-branch="suite"][data-level="6"] .plaque__slug.named-slug,
+.plaque__stack-row[data-branch="suite"][data-level="6"] .plaque-skill-name.named-slug {
   color: var(--apex-gold, #fbbf24);
 }
-.plaque[data-type="ultimate"][data-level="6"] .plaque__slug.named-slug,
-.plaque[data-type="ultimate"][data-level="6"] .plaque-skill-name.named-slug,
-.plaque__stack-row[data-type="ultimate"][data-level="6"] .plaque__slug.named-slug,
-.plaque__stack-row[data-type="ultimate"][data-level="6"] .plaque-skill-name.named-slug {
+.plaque[data-branch="suite"][data-level="6"] .plaque__slug.named-slug,
+.plaque[data-branch="suite"][data-level="6"] .plaque-skill-name.named-slug,
+.plaque__stack-row[data-branch="suite"][data-level="6"] .plaque__slug.named-slug,
+.plaque__stack-row[data-branch="suite"][data-level="6"] .plaque-skill-name.named-slug {
   animation: tree-rainbow-glow 4s linear infinite;
 }
 
@@ -644,6 +649,58 @@ button.plaque__slug:focus-visible {
     var(--tier-fusion) 60%,
     color-mix(in srgb, var(--tier-fusion) 70%, #000) 100%);
   box-shadow: 0 0 12px rgba(var(--tier-fusion-rgb), 0.4);
+}
+
+/* ── Contributor avatar + gold origin wreath (Yggdrasil II, E3/E4) ─
+   _fieldAvatar emits <a|span.plaque__avatar style="--avatar-size:Npx">
+     <img.plaque__avatar-img>          ← GitHub avatar (identicon fallback)
+     <img.plaque__avatar-wreath>       ← gold laurel frame (origin mark)
+   The wreath is the NEW origin mark (replaces the deprecated honor-red
+   inline badge). The avatar links to the skill repo, replacing the old
+   standalone GitHub button. The frame NEVER renders as an empty hole —
+   the <img> onerror swaps to a GitHub identicon rather than hiding.
+   ============================================================ */
+.plaque__avatar {
+  --avatar-size: 40px;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--avatar-size);
+  height: var(--avatar-size);
+  flex-shrink: 0;
+  border-radius: 50%;
+  text-decoration: none;
+}
+.plaque__avatar-img {
+  width: 82%;
+  height: 82%;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+  background: rgba(var(--tier-basic-rgb), 0.12);
+}
+/* The wreath overlays the avatar, framing it slightly larger than the
+   photo so the laurel reads as a border ring. Gold tint comes from the
+   SVG's own token-driven gradient (--seal-gold / --tier-fusion). */
+.plaque__avatar-wreath {
+  position: absolute;
+  inset: -6%;
+  width: 112%;
+  height: 112%;
+  pointer-events: none;
+  display: block;
+}
+/* Origin contributors get a warmer gold halo behind the avatar. */
+.plaque__avatar[data-origin="true"] {
+  box-shadow: 0 0 10px rgba(var(--tier-fusion-rgb), 0.45);
+}
+.plaque__avatar--link:hover .plaque__avatar-img {
+  box-shadow: 0 0 8px rgba(var(--tier-fusion-rgb), 0.5);
+}
+.plaque__avatar--link:focus-visible {
+  outline: 2px solid var(--tier-fusion);
+  outline-offset: 2px;
 }
 
 /* Stage 4 — orb gradients reference tier tokens (--tier-<name>) for the
@@ -1332,29 +1389,29 @@ button.plaque__slug:focus-visible {
 .plaque--hall .plaque__stack-row[data-level="4"] .plaque__slug.named-slug { color: var(--rank-4, #e879f9); }
 .plaque--hall .plaque__stack-row[data-level="5"] .plaque-skill-name.named-slug,
 .plaque--hall .plaque__stack-row[data-level="5"] .plaque__slug.named-slug { color: var(--rank-5, #fbbf24); }
-/* 6★ Ultimate retains apex gold + rainbow — preserves the existing
-   tree-rainbow-glow animation on .plaque__stack-row[data-type="ultimate"][data-level="6"]. */
-.plaque--hall .plaque__stack-row[data-level="6"][data-type="ultimate"] .plaque-skill-name.named-slug,
-.plaque--hall .plaque__stack-row[data-level="6"][data-type="ultimate"] .plaque__slug.named-slug { color: var(--apex-gold, #fbbf24); }
-/* Non-Ultimate 6★ (e.g. a hypothetical Unique 6★) just uses rank-6 amber. */
-.plaque--hall .plaque__stack-row[data-level="6"]:not([data-type="ultimate"]) .plaque-skill-name.named-slug,
-.plaque--hall .plaque__stack-row[data-level="6"]:not([data-type="ultimate"]) .plaque__slug.named-slug { color: var(--rank-6, #fbbf24); }
+/* 6★ Apex (suite branch) retains apex gold + rainbow — preserves the existing
+   tree-rainbow-glow animation on .plaque__stack-row[data-branch="suite"][data-level="6"]. */
+.plaque--hall .plaque__stack-row[data-level="6"][data-branch="suite"] .plaque-skill-name.named-slug,
+.plaque--hall .plaque__stack-row[data-level="6"][data-branch="suite"] .plaque__slug.named-slug { color: var(--apex-gold, #fbbf24); }
+/* Non-suite 6★ (e.g. a Unique 6★) just uses rank-6 amber. */
+.plaque--hall .plaque__stack-row[data-level="6"]:not([data-branch="suite"]) .plaque-skill-name.named-slug,
+.plaque--hall .plaque__stack-row[data-level="6"]:not([data-branch="suite"]) .plaque__slug.named-slug { color: var(--rank-6, #fbbf24); }
 
-/* Unique tier exception — deep violet wins over the rank colour for
+/* Unique branch exception — deep violet wins over the rank colour for
    every Unique skill row regardless of rank. The Unique branch is the
-   standalone-mastery tier (a Basic that ascended without ever fusing)
-   and must read in its tier-native deep violet across surfaces. The
+   standalone-mastery fork (a Basic that ascended without ever fusing)
+   and must read in its branch-native deep violet across surfaces. The
    stars in this row also get deep violet (overriding rank-4 fuchsia)
-   so slug + stars stay in lockstep. */
-.plaque--hall .plaque__stack-row[data-type="unique"] .plaque-skill-name.named-slug,
-.plaque--hall .plaque__stack-row[data-type="unique"] .plaque__slug.named-slug {
+   so slug + stars stay in lockstep. Rubric E1: keyed on derived branch. */
+.plaque--hall .plaque__stack-row[data-branch="unique"] .plaque-skill-name.named-slug,
+.plaque--hall .plaque__stack-row[data-branch="unique"] .plaque__slug.named-slug {
   color: var(--tier-unique);
 }
-.plaque--hall .plaque__stack-row[data-type="unique"] .rank-badge__star[data-on] {
+.plaque--hall .plaque__stack-row[data-branch="unique"] .rank-badge__star[data-on] {
   color: var(--tier-unique);
   text-shadow: 0 0 6px rgba(var(--tier-unique-rgb), .5);
 }
-.plaque--hall .plaque__stack-row[data-type="unique"] .rank-badge__star[data-off] {
+.plaque--hall .plaque__stack-row[data-branch="unique"] .rank-badge__star[data-off] {
   color: rgba(var(--tier-unique-rgb), .15);
 }
 

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -611,6 +611,41 @@ button.plaque__slug:focus-visible {
 .plaque-orb--sm { width: 24px; height: 24px; }
 .plaque-orb--lg { width: 52px; height: 52px; }
 
+/* ── AOV4 medallion (Yggdrasil II) ───────────────────────────────
+   The rank medallion IS the Ascension-Overdrive v4 stamp emitted by
+   plaque.js _fieldOrb as <span.plaque-orb--medallion><img></span>.
+   The image fills the orb; if the webp 404s, [data-stamp-fail] falls
+   back to a branch-tinted radial gradient so a rank medallion still
+   reads (never an empty hole). Rubric E3.
+   ============================================================ */
+.plaque-orb--medallion {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.plaque-orb__stamp {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+/* Fallback tint keyed on derived branch (not type) when the stamp fails. */
+.plaque-orb--medallion[data-stamp-fail][data-branch="unique"] {
+  background: radial-gradient(circle at 50% 50%,
+    #000 55%, var(--tier-unique) 80%,
+    color-mix(in srgb, var(--tier-unique) 70%, #000) 100%);
+  box-shadow: 0 0 14px rgba(var(--tier-unique-rgb), 0.5), inset 0 0 6px rgba(var(--tier-unique-rgb), 0.3);
+}
+.plaque-orb--medallion[data-stamp-fail][data-branch="suite"],
+.plaque-orb--medallion[data-stamp-fail][data-branch="standard"] {
+  background: radial-gradient(circle at 35% 35%,
+    color-mix(in srgb, var(--tier-fusion) 35%, #fff) 0%,
+    var(--tier-fusion) 60%,
+    color-mix(in srgb, var(--tier-fusion) 70%, #000) 100%);
+  box-shadow: 0 0 12px rgba(var(--tier-fusion-rgb), 0.4);
+}
+
 /* Stage 4 — orb gradients reference tier tokens (--tier-<name>) for the
    dominant colour stop, then color-mix with white/black for the highlight
    and shadow stops. Acceptance: no hardcoded tier hex survives in plaque.css. */

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -571,12 +571,12 @@ button.plaque__slug:focus-visible {
 .plaque[data-type="unique"] .plaque-skill-name.named-slug,
 .plaque__stack-row[data-type="unique"] .plaque__slug.named-slug,
 .plaque__stack-row[data-type="unique"] .plaque-skill-name.named-slug {
-  color: var(--tier-unique, #7c3aed);
+  color: var(--tier-unique);
 }
 /* Unique type always overrides level-based rank color on stars */
 .plaque[data-type="unique"] .rank-badge__star[data-on],
 .plaque__stack-row[data-type="unique"] .rank-badge__star[data-on] {
-  color: var(--tier-unique, #7c3aed);
+  color: var(--tier-unique);
   text-shadow: 0 0 6px rgba(var(--tier-unique-rgb), .5);
 }
 .plaque[data-type="unique"] .rank-badge__star[data-off],
@@ -1313,10 +1313,10 @@ button.plaque__slug:focus-visible {
    so slug + stars stay in lockstep. */
 .plaque--hall .plaque__stack-row[data-type="unique"] .plaque-skill-name.named-slug,
 .plaque--hall .plaque__stack-row[data-type="unique"] .plaque__slug.named-slug {
-  color: var(--tier-unique, #7c3aed);
+  color: var(--tier-unique);
 }
 .plaque--hall .plaque__stack-row[data-type="unique"] .rank-badge__star[data-on] {
-  color: var(--tier-unique, #7c3aed);
+  color: var(--tier-unique);
   text-shadow: 0 0 6px rgba(var(--tier-unique-rgb), .5);
 }
 .plaque--hall .plaque__stack-row[data-type="unique"] .rank-badge__star[data-off] {
@@ -2730,8 +2730,8 @@ button.plaque__slug:focus-visible {
   box-shadow: 0 0 20px rgba(245, 158, 11, 0.35) !important;
 }
 .plaque.is-highlighted.plaque--unique {
-  border-color: var(--tier-unique, #7c3aed) !important;
-  box-shadow: 0 0 20px rgba(124, 58, 237, 0.35) !important;
+  border-color: var(--tier-unique) !important;
+  box-shadow: 0 0 20px rgba(var(--tier-unique-rgb), 0.35) !important;
 }
 .plaque.is-highlighted.plaque--extra {
   border-color: var(--tier-extra, #c084fc) !important;
@@ -2786,7 +2786,7 @@ button.plaque__slug:focus-visible {
 }
 .ptl2__tooltip-tier--basic    { color: var(--tier-basic,#38bdf8);    background: rgba(56,189,248,.1); border-color: rgba(56,189,248,.2); }
 .ptl2__tooltip-tier--extra    { color: var(--tier-extra,#c084fc);    background: rgba(192,132,252,.1); border-color: rgba(192,132,252,.2); }
-.ptl2__tooltip-tier--unique   { color: var(--tier-unique,#7c3aed);   background: rgba(124,58,237,.1); border-color: rgba(124,58,237,.2); }
+.ptl2__tooltip-tier--unique   { color: var(--tier-unique);   background: rgba(var(--tier-unique-rgb),.1); border-color: rgba(var(--tier-unique-rgb),.2); }
 .ptl2__tooltip-tier--ultimate { color: var(--tier-ultimate,#f59e0b); background: rgba(245,158,11,.1); border-color: rgba(245,158,11,.2); }
 
 .ptl2__tooltip-detail-row {

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -146,11 +146,11 @@
 
 /* Unique tier rank badge — black background with bright purple glow. */
 .rank-badge[data-tier="unique"] .rank-badge__chip {
-  color: var(--tier-unique, #7c3aed);
+  color: var(--tier-unique);
   background: #000000;
-  border: 1.5px solid var(--tier-unique, #7c3aed);
-  box-shadow: 0 0 12px var(--tier-unique, #7c3aed), 0 0 4px rgba(124, 58, 237, 0.5);
-  text-shadow: 0 0 8px rgba(124, 58, 237, 0.4);
+  border: 1.5px solid var(--tier-unique);
+  box-shadow: 0 0 12px var(--tier-unique), 0 0 4px rgba(var(--tier-unique-rgb), 0.5);
+  text-shadow: 0 0 8px rgba(var(--tier-unique-rgb), 0.4);
 }
 
 /* Size modifiers — sampler density only. Default is md. */

--- a/docs/css/tokens.css
+++ b/docs/css/tokens.css
@@ -20,6 +20,20 @@
   --tier-fusion-border: rgba(245, 158, 11, 0.35);
   --tier-fusion-edge: rgba(245, 158, 11, 0.55);
   --tier-fusion-symbol: '◆';
+  /* tier: unique — Yggdrasil II legacy color alias (NOT a taxonomy type).
+     The Unique branch is the standalone-mastery fork: a Basic node that
+     reached elite rank (4★+) without ever fusing. `unique` is derived at
+     read-time (see docs/js/skill-semantics.js computeBranch); it is never a
+     gaia.json `type`. This block is authored directly in tokens.css because
+     generateCssTokens.py only emits families for meta.typeColors (basic,
+     fusion). Keep it byte-stable and mirror the --tier-basic/--tier-fusion
+     shape so downstream var(--tier-unique*) reads resolve token-only (E7). */
+  --tier-unique: #7c3aed; /* var(--tier-unique, #7c3aed) */
+  --tier-unique-rgb: 124, 58, 237;
+  --tier-unique-bg: rgba(124, 58, 237, 0.12);
+  --tier-unique-border: rgba(124, 58, 237, 0.35);
+  --tier-unique-edge: rgba(124, 58, 237, 0.55);
+  --tier-unique-symbol: '◉';
 
   /* ── Rank tokens (0★ → 6★) ───────────────────────────────── */
   /* rank: 0★ */

--- a/docs/evidence/index.html
+++ b/docs/evidence/index.html
@@ -28,6 +28,7 @@
   <script src="../js/atlas-helpers.js?v=5.0.6"></script>
   <script src="../js/rank-badge.js?v=5.0.6"></script>
   <script src="../js/tm-config.js?v=5.0.6"></script>
+  <script src="../js/skill-semantics.js?v=5.0.6"></script>
   <script src="../js/plaque.js?v=5.0.6"></script>
 
   <style>

--- a/docs/heroes/index.html
+++ b/docs/heroes/index.html
@@ -24,6 +24,7 @@
   <link rel="stylesheet" href="heroes.css?v=6.8.8">
 
   <!-- Plaque renderer (needed for renderOg) -->
+  <script src="../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../js/plaque.js?v=6.8.8"></script>
   <script>
     // gaiaIconBase for sub-page (depth=1)

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,6 +49,7 @@
   <script src="js/rank-badge.js?v=6.8.8"></script>
   <!-- Stage 3 — plaque component family, loaded after rank-badge. -->
   <script src="js/tm-config.js?v=6.8.8"></script>
+  <script src="js/skill-semantics.js?v=6.8.8"></script>
   <script src="js/plaque.js?v=6.8.8"></script>
   <style>
   /* Review Section & Side-by-Side Simulator styling */

--- a/docs/js/plaque.js
+++ b/docs/js/plaque.js
@@ -13,10 +13,12 @@
  *                                     the canonical OG is server-rendered
  *                                     by scripts/generateOgCards.py)
  *
- * All variants emit `.plaque` + `.plaque--<variant>` with the existing
- * `data-type="<basic|extra|unique|ultimate>"` and `data-level="N"`
- * attributes. Apex (6★) adds `plaque--apex-vi` for the rainbow shimmer
- * shadow animation defined in plaque.css.
+ * All variants emit `.plaque` + `.plaque--<variant>` with the DERIVED
+ * `data-branch="<standard|suite|unique>"` (rubric E1 — computed at read-time
+ * via window.GaiaSemantics, never from ns.type) plus `data-level="N"`. A
+ * legacy `data-type="<basic|fusion>"` is retained for old hooks only; visual
+ * selectors key on data-branch. Apex (6★) adds `plaque--apex-vi` for the
+ * rainbow shimmer shadow animation defined in plaque.css.
  *
  * Forbidden: inline SVG strings, inline hex codes, inline rank chips.
  * - Icons: window.gaiaIcon(id, opts).
@@ -78,6 +80,14 @@
     }
     return '';
   }
+
+  // Branch-keyed glyph + sort priority for the multi-skill stack variants
+  // (mini-stack, hall plate). Rubric E1: keyed by the DERIVED branch, never by
+  // ns.type. Glyphs mirror the tokens.css tier symbols (unique ◉, suite ◆,
+  // standard ○). Sort priority ranks the flashier branches first within a
+  // level tie (unique → suite → standard).
+  var BRANCH_GLYPH = { unique: '◉', suite: '◆', standard: '○' };
+  var BRANCH_SORT = { unique: 0, suite: 1, standard: 2 };
 
   // ── AOV4 medallion resolver ──────────────────────────────────────
   // The rank medallion IS the Ascension-Overdrive v4 stamp. Suite/standard
@@ -192,14 +202,66 @@
     // a redaction marker where there is no handle to hide).
     if (!contributor) return '';
     var level = ns && ns.level;
-    // Pre-named/demoted (≤1★): redact the handle (slate, no honor-red link) and
-    // drop the origin badge — a pre-named skill has no Origin standing.
+    // Pre-named/demoted (≤1★): redact the handle (slate, no honor-red link).
+    // A pre-named skill has no Origin standing.
     if (window.isRedacted && window.isRedacted(level)) {
       return '<div class="plaque__handle plaque-contrib-row">' + window.redactedHandle() + '</div>';
     }
     var contribLink = handleLink(contributor, { level: level });
     if (!contribLink) return '';
-    return '<div class="plaque__handle plaque-contrib-row">' + contribLink + _fieldOriginBadge(ns) + '</div>';
+    // Rubric E4: the red inline origin mark is gone — Origin now renders in
+    // GOLD as the wreath framing the contributor avatar (_fieldAvatar).
+    return '<div class="plaque__handle plaque-contrib-row">' + contribLink + '</div>';
+  }
+
+  // ── contributor avatar framed by the gold origin wreath (E3/E4) ──
+  // Every skill surface renders the contributor's GitHub avatar, framed by
+  // the gold origin wreath (docs/assets/origin-wreath-gold.svg) — this is the
+  // NEW origin mark (red → gold). The avatar links to the skill's repo
+  // (links.github), replacing the standalone GitHub button.
+  //
+  // Fallback: a missing avatar swaps to the GitHub identicon endpoint
+  // (github.com/identicons/<handle>.png), NEVER hides the img (no empty hole).
+  //
+  // Redacted (≤1★) skills expose no handle → no avatar (handle is withheld
+  // everywhere else too; showing a resolvable avatar would leak the handle).
+  //   opts.size   px for the avatar (default 40)
+  function _fieldAvatar(ns, opts) {
+    opts = opts || {};
+    var handle = (ns && ns.contributor) || '';
+    if (!handle) return '';
+    if (window.isRedacted && window.isRedacted(ns && ns.level)) return '';
+    var clean = String(handle).replace(/^@/, '');
+    var size = opts.size || 40;
+    var wreathSrc = _base() + 'assets/origin-wreath-gold.svg';
+    var avatarSrc = 'https://github.com/' + encodeURIComponent(clean) + '.png?size=' + (size * 2);
+    var identicon = 'https://github.com/identicons/' + encodeURIComponent(clean) + '.png';
+    var links = (ns && ns.links) || {};
+    var repoUrl = links.github || links.npm || '';
+    var isOrigin = !!(ns && ns.origin);
+    var title = isOrigin ? 'Origin contributor @' + clean : '@' + clean;
+    // onerror: fall back to the identicon once, then stop (avoid loops). Never
+    // set display:none — the frame must never render as an empty hole.
+    var errAttr = "if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk='1';this.src='" +
+      jsStr(identicon) + "';}";
+    var img = '<img class="plaque__avatar-img" src="' + esc(avatarSrc) + '" ' +
+      'alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" ' +
+      'onerror="' + errAttr + '">';
+    var wreath = '<img class="plaque__avatar-wreath" src="' + esc(wreathSrc) + '" alt="" aria-hidden="true">';
+    var inner = img + wreath;
+    var body;
+    if (repoUrl) {
+      body = '<a class="plaque__avatar plaque__avatar--link" href="' + esc(repoUrl) + '" ' +
+        'target="_blank" rel="noopener" title="' + esc(title) + '" ' +
+        'aria-label="' + esc(title) + ' — view repository" ' +
+        'onclick="event.stopPropagation()" style="--avatar-size:' + (size | 0) + 'px"' +
+        (isOrigin ? ' data-origin="true"' : '') + '>' + inner + '</a>';
+    } else {
+      body = '<span class="plaque__avatar" title="' + esc(title) + '" ' +
+        'aria-label="' + esc(title) + '" style="--avatar-size:' + (size | 0) + 'px"' +
+        (isOrigin ? ' data-origin="true"' : '') + '>' + inner + '</span>';
+    }
+    return body;
   }
 
   function _fieldDescription(ns) {
@@ -221,19 +283,19 @@
 
   function _fieldRank(ns, variant) {
     var v = variant || 'stars';
-    var type = (ns && ns.type) || 'basic';
-    var html = rankBadge(ns && ns.level, { variant: v, label: ns && ns.level, tier: type });
+    // Rubric E1/E2: pass the DERIVED branch (not ns.type) so rank-badge.js
+    // colours the stars by branch register (unique = violet, suite = gold).
+    var branch = branchOf(ns);
+    var html = rankBadge(ns && ns.level, { variant: v, label: ns && ns.level, tier: branch });
     if (!html) return '';
     return '<div class="plaque__rank">' + html + '</div>';
   }
 
+  // Deprecated — the standalone "GitHub" button is removed (rubric E3): the
+  // wreathed avatar (_fieldAvatar) is now the repo link. Kept as a no-op so
+  // any lingering call site emits nothing rather than a duplicate link.
   function _fieldGhLink(ns) {
-    var links = (ns && ns.links) || {};
-    var url = links.github || links.npm || '';
-    if (!url) return '';
-    return '<a class="plaque__gh-link ns-gh-link" href="' + esc(url) +
-      '" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View on GitHub">' +
-      icon('github', 14) + '</a>';
+    return '';
   }
 
   function _fieldVariantsBadge(ns) {
@@ -244,14 +306,12 @@
       '</div>';
   }
 
+  // Deprecated (rubric E4): the honor-red #origin-badge laurel is gone.
+  // Origin is now rendered in GOLD as the wreath framing the contributor
+  // avatar (_fieldAvatar sets data-origin). No red origin icon survives —
+  // this returns nothing so the old inline red mark never renders.
   function _fieldOriginBadge(ns) {
-    if (!ns || !ns.origin) return '';
-    // Stage 4 — render the origin badge from the shared sprite so it inherits
-    // --honor-red via currentColor. Include a small (i) icon for context on hover.
-    return '<span class="plaque__origin" data-tooltip="Origin contributor: The creator of the first skill version" aria-label="Origin contributor: The creator of the first skill version">' +
-      icon('origin-badge', 16) +
-      '<span class="origin-info" style="margin-left: 3px; color: var(--muted); opacity: 0.7;">' + icon('info', 10) + '</span>' +
-      '</span>';
+    return '';
   }
 
   // Install row — shared mini-terminal block (used by tile / detail / settled).
@@ -436,6 +496,7 @@
   // ── plaque shell ─────────────────────────────────────────────────
   function _shell(variant, ns, innerHtml, extraOpts) {
     var type = (ns && ns.type) || 'basic';
+    var branch = branchOf(ns);
     var n = levelNum(ns && ns.level);
     var apex = n >= 6 ? ' plaque--apex-vi' : '';
     extraOpts = extraOpts || {};
@@ -453,8 +514,12 @@
     var isMiniStack = extraOpts.extraClass &&
       extraOpts.extraClass.indexOf('plaque--mini-stack') !== -1;
     var trustNotch = (!isMiniStack) ? _fieldTrustNotch(ns) : '';
+    // Rubric E3/E1: stamp the DERIVED data-branch (standard|suite|unique).
+    // Every downstream visual selector (dark unique / gold suite) keys on
+    // data-branch, NOT data-type. data-type is retained for legacy hooks only.
     return '<article class="plaque plaque--' + esc(variant) + apex + extraCls +
-      '" data-type="' + esc(type) + '" data-level="' + esc(n) +
+      '" data-type="' + esc(type) + '" data-branch="' + esc(branch) +
+      '" data-level="' + esc(n) +
       '" data-skill-id="' + esc(ns && ns.id || '') + '"' +
       clickAttr + role + extraAttrs + '>' +
       innerHtml +
@@ -487,24 +552,24 @@
 
     var inner =
       _fieldOrb(ns) +
+      (isGhost ? '' : _fieldAvatar(ns, { size: 28 })) +
       (isGhost ? '' : _fieldHandleRow(ns)) +
       (isGhost ? '' : _fieldRank(ns, 'stars')) +
       (isGhost ? _fieldSlug(ns) : _fieldSlugInteractive(ns, slugOnclick)) +
-      (isGhost ? '' : _fieldFullscreenBtn(ns)) +
-      (isGhost ? '' : _fieldGhLink(ns));
+      (isGhost ? '' : _fieldFullscreenBtn(ns));
 
     return _shell('mini', ns, inner, shellOpts);
   }
 
   // ── variant: tile (explorer grid) ────────────────────────────────
-  // Field set: header (orb + level chip + origin star + gh link)
+  // Field set: header (medallion + rank chip + wreathed avatar)
   //          · slug · title · handle · description · tags (3) · install row.
   function renderTile(ns, opts) {
     var header =
       '<div class="plaque__header plaque-header">' +
         _fieldOrb(ns) +
         _fieldRank(ns, 'chip') +
-        _fieldGhLink(ns) +
+        _fieldAvatar(ns, { size: 32 }) +
       '</div>';
 
     var inner =
@@ -535,7 +600,7 @@
       _fieldTags(ns, 2) +
       _fieldInstallRow(ns) +
       _fieldRank(ns, 'chip') +
-      _fieldGhLink(ns) +
+      _fieldAvatar(ns, { size: 28 }) +
       evBadge +
       '<span class="plaque__arrow ns-lr-arrow" aria-hidden="true">›</span>';
 
@@ -543,7 +608,8 @@
   }
 
   // ── variant: detail (explorer modal hero, two-column) ────────────
-  // Left column: orb (lg) · slug · handle · rank (full) · install row · gh link
+  // Left column: medallion (lg) · wreathed avatar · slug · handle · rank
+  //   (full) · install row · share · claim
   // Right column: title · description · tags
   function renderDetail(ns, opts) {
     opts = opts || {};
@@ -551,12 +617,6 @@
     // README" (badges?u=<handle>) all expose the handle — suppress them until
     // the skill is named (2★+).
     var redacted = window.isRedacted && window.isRedacted(ns && ns.level);
-    var links = (ns && ns.links) || {};
-    var repoUrl = (!redacted && (links.github || links.npm)) || '';
-    var ghLink = repoUrl
-      ? '<a class="plaque__gh-link ns-gh-link" href="' + esc(repoUrl) + '" target="_blank" rel="noopener" aria-label="Show on GitHub">' +
-          icon('github', 14) + '</a>'
-      : '';
 
     var skillId = (ns && ns.id) || '';
     var slashIdx = skillId.indexOf('/');
@@ -574,8 +634,10 @@
         icon('share', 14) +
       '</button>';
 
-    var ghRow = (ghLink || shareBtn)
-      ? '<div class="plaque__gh-row">' + ghLink + shareBtn + '</div>'
+    // Rubric E3: the standalone "GitHub" button is removed — the wreathed
+    // avatar (below) is the repo link. Only the share button remains here.
+    var ghRow = shareBtn
+      ? '<div class="plaque__gh-row">' + shareBtn + '</div>'
       : '';
 
     var prefix = (typeof window.gaiaIconBase === 'function')
@@ -594,6 +656,7 @@
     var left =
       '<div class="plaque__col plaque-detail-left">' +
         _fieldOrb(ns, 'lg') +
+        _fieldAvatar(ns, { size: 56 }) +
         _fieldSlug(ns) +
         _fieldHandleRow(ns) +
         _fieldRank(ns, 'stars') +
@@ -622,7 +685,7 @@
       '<div class="plaque__header plaque-header">' +
         _fieldOrb(ns) +
         _fieldRank(ns, 'chip') +
-        _fieldGhLink(ns) +
+        _fieldAvatar(ns, { size: 32 }) +
       '</div>';
 
     var evText = _evidenceClass(ns);
@@ -668,6 +731,7 @@
     var inner =
       header +
       _fieldOrb(ns, 'lg') +
+      _fieldAvatar(ns, { size: 44 }) +
       _fieldSlug(ns) +
       _fieldTitle(ns) +
       _fieldHandleRow(ns) +
@@ -693,11 +757,13 @@
   function renderMiniStack(skills, opts) {
     opts = opts || {};
     if (!Array.isArray(skills) || !skills.length) return '';
-    var TYPE_RANK = { ultimate: 0, unique: 1, extra: 2, basic: 3 };
+    // Rubric E1: sort by level, then by DERIVED branch (unique → suite →
+    // standard) — never by ns.type.
     var sorted = skills.slice().sort(function (a, b) {
       var ld = levelNum(b.level) - levelNum(a.level);
       if (ld !== 0) return ld;
-      return (TYPE_RANK[a.type] || 9) - (TYPE_RANK[b.type] || 9);
+      return (BRANCH_SORT[branchOf(a)] != null ? BRANCH_SORT[branchOf(a)] : 9) -
+             (BRANCH_SORT[branchOf(b)] != null ? BRANCH_SORT[branchOf(b)] : 9);
     });
     var primary = sorted[0];
     var maxRows = (typeof opts.maxRows === 'number') ? opts.maxRows : 3;
@@ -712,29 +778,31 @@
       origin: anyOrigin,
       level: primary.level,
       type: primary.type,
+      suiteComponents: primary.suiteComponents,
+      links: primary.links,
     };
-
-    var TIER_GLYPH = { ultimate: '◆', unique: '◉', extra: '◇', basic: '○' };
 
     var header =
       '<div class="plaque__stack-header">' +
         _fieldOrb(primaryNs) +
         _fieldHandleRow(primaryNs) +
+        _fieldAvatar(primaryNs, { size: 28 }) +
         _fieldFullscreenBtn(primaryNs) +
       '</div>';
 
     var rows = visible.map(function (s) {
       var n = levelNum(s.level);
-      var glyph = TIER_GLYPH[s.type] || TIER_GLYPH.basic;
+      var branch = branchOf(s);
+      var glyph = BRANCH_GLYPH[branch] || BRANCH_GLYPH.standard;
       var slug = namedSlug(s);
       var slugTitle = s.id || '';
       var clickAttr = s.onclick
         ? 'event.stopPropagation(); ' + s.onclick
         : '(function(id){if(typeof openSkillExplorer===\'function\')openSkillExplorer(id);})(\'' + jsStr(s.canonicalId || s.id) + '\')';
-      var stars = rankBadge(s.level, { variant: 'stars', label: s.level, tier: s.type });
-      return '<div class="plaque__stack-row" data-type="' + esc(s.type || 'basic') +
+      var stars = rankBadge(s.level, { variant: 'stars', label: s.level, tier: branch });
+      return '<div class="plaque__stack-row" data-branch="' + esc(branch) +
         '" data-level="' + esc(n) + '">' +
-          '<span class="plaque__stack-glyph tier-glyph" data-type="' + esc(s.type || 'basic') +
+          '<span class="plaque__stack-glyph tier-glyph" data-branch="' + esc(branch) +
             '" aria-hidden="true">' + glyph + '</span>' +
           '<button class="plaque__slug plaque-skill-name named-slug plaque__slug--clickable" type="button" ' +
             'title="' + esc(slugTitle) + '" onclick="' + clickAttr + '">' + esc(slug) + '</button>' +
@@ -765,11 +833,12 @@
   function renderHallPlate(skills, opts) {
     opts = opts || {};
     if (!Array.isArray(skills) || !skills.length) return '';
-    var TYPE_RANK = { ultimate: 0, unique: 1, extra: 2, basic: 3 };
+    // Rubric E1: sort by level, then by DERIVED branch — never by ns.type.
     var sorted = skills.slice().sort(function (a, b) {
       var ld = levelNum(b.level) - levelNum(a.level);
       if (ld !== 0) return ld;
-      return (TYPE_RANK[a.type] || 9) - (TYPE_RANK[b.type] || 9);
+      return (BRANCH_SORT[branchOf(a)] != null ? BRANCH_SORT[branchOf(a)] : 9) -
+             (BRANCH_SORT[branchOf(b)] != null ? BRANCH_SORT[branchOf(b)] : 9);
     });
     var primary = sorted[0];
     var maxRows = (typeof opts.maxRows === 'number') ? opts.maxRows : 3;
@@ -784,10 +853,11 @@
       origin: anyOrigin,
       level: primary.level,
       type: primary.type,
+      suiteComponents: primary.suiteComponents,
+      links: primary.links,
       trustMagnitude: primary.trustMagnitude,
     };
-
-    var TIER_GLYPH = { ultimate: '◆', unique: '◉', extra: '◇', basic: '○' };
+    var primaryBranch = branchOf(primary);
 
     // Resolve OG art path (primary skill).
     var handle = primary.contributor || '';
@@ -814,7 +884,7 @@
         '</div>';
     }
 
-    var primaryGlyph = TIER_GLYPH[primary.type] || TIER_GLYPH.basic;
+    var primaryGlyph = BRANCH_GLYPH[primaryBranch] || BRANCH_GLYPH.standard;
     // Crest uses the contributor's GitHub avatar; the OG art remains as backdrop.
     var crestImg = avatarUrl
       ? '<img class="plaque__hall-crest-img" src="' + esc(avatarUrl) + '" alt="" ' +
@@ -822,7 +892,7 @@
           'onerror="this.parentNode.setAttribute(\'data-crest-fail\',\'true\');this.style.display=\'none\'">'
       : '';
     var crestHtml =
-      '<div class="plaque__hall-crest" data-type="' + esc(primary.type || 'basic') + '" ' +
+      '<div class="plaque__hall-crest" data-branch="' + esc(primaryBranch) + '" ' +
         'data-level="' + esc(levelNum(primary.level)) + '">' +
         crestImg +
         '<span class="plaque__hall-crest-glyph" aria-hidden="true">' + primaryGlyph + '</span>' +
@@ -851,16 +921,17 @@
     // tier-aware per-row CSS in plaque.css just works.
     var rows = visible.map(function (s, idx) {
       var n = levelNum(s.level);
-      var glyph = TIER_GLYPH[s.type] || TIER_GLYPH.basic;
+      var branch = branchOf(s);
+      var glyph = BRANCH_GLYPH[branch] || BRANCH_GLYPH.standard;
       var slug = namedSlug(s);
       var slugTitle = s.id || '';
       var clickAttr = s.onclick
         ? 'event.stopPropagation(); ' + s.onclick
         : '(function(id){if(typeof openSkillExplorer===\'function\')openSkillExplorer(id);})(\'' + jsStr(s.canonicalId || s.id) + '\')';
-      var stars = rankBadge(s.level, { variant: 'stars', label: s.level, tier: s.type });
-      return '<div class="plaque__stack-row" data-type="' + esc(s.type || 'basic') +
+      var stars = rankBadge(s.level, { variant: 'stars', label: s.level, tier: branch });
+      return '<div class="plaque__stack-row" data-branch="' + esc(branch) +
         '" data-level="' + esc(n) + '" style="--row-index:' + idx + '">' +
-          '<span class="plaque__stack-glyph tier-glyph" data-type="' + esc(s.type || 'basic') +
+          '<span class="plaque__stack-glyph tier-glyph" data-branch="' + esc(branch) +
             '" aria-hidden="true">' + glyph + '</span>' +
           '<button class="plaque__slug plaque-skill-name named-slug plaque__slug--clickable" type="button" ' +
             'title="' + esc(slugTitle) + '" onclick="' + clickAttr + '">' + esc(slug) + '</button>' +
@@ -900,6 +971,7 @@
     // in call-site code — the public render methods are the contract.
     _fields: {
       orb: _fieldOrb,
+      avatar: _fieldAvatar,
       slug: _fieldSlug,
       title: _fieldTitle,
       handle: _fieldHandleRow,
@@ -907,8 +979,6 @@
       tags: _fieldTags,
       rank: _fieldRank,
       install: _fieldInstallRow,
-      gh: _fieldGhLink,
-      origin: _fieldOriginBadge,
     },
   };
 

--- a/docs/js/plaque.js
+++ b/docs/js/plaque.js
@@ -60,6 +60,67 @@
     return window.rankBadge(level, opts || {});
   }
 
+  // ── Yggdrasil II read-time semantics ─────────────────────────────
+  // Branch is DERIVED, never read from ns.type. Delegates to the shared
+  // resolver (docs/js/skill-semantics.js). Rubric E1: no switching on
+  // type==='ultimate'|'unique'|'extra'. Fallback keeps plaques rendering
+  // if skill-semantics.js somehow failed to load (degrade to 'standard').
+  function branchOf(ns) {
+    if (window.GaiaSemantics && typeof window.GaiaSemantics.computeBranch === 'function') {
+      return window.GaiaSemantics.computeBranch(ns, ns && ns.level);
+    }
+    return 'standard';
+  }
+
+  function rankWordOf(level, branch) {
+    if (window.GaiaSemantics && typeof window.GaiaSemantics.rankWord === 'function') {
+      return window.GaiaSemantics.rankWord(level, branch);
+    }
+    return '';
+  }
+
+  // ── AOV4 medallion resolver ──────────────────────────────────────
+  // The rank medallion IS the Ascension-Overdrive v4 stamp. Suite/standard
+  // branches use the C family (c1..c6); the Unique branch uses the D family
+  // (d4..d6). Size tier (badge/card/hero) is picked by the render variant.
+  var AOV_SUITE_STEM = {
+    1: 'c1-suite-awakened', 2: 'c2-suite-named', 3: 'c3-suite-evolved',
+    4: 'c4-suite-extra', 5: 'c5-suite-ultimate', 6: 'c6-suite-apex',
+  };
+  var AOV_UNIQUE_STEM = {
+    4: 'd4-unique', 5: 'd5-unique-ultimate', 6: 'd6-unique-impossible',
+  };
+
+  // Base path prefix ('' at site root, '../../' on profile pages). Reuses the
+  // same derivation the icon sprite uses so relative asset URLs resolve on
+  // every page depth.
+  function _base() {
+    return (typeof window.gaiaIconBase === 'function')
+      ? window.gaiaIconBase().replace(/assets\/icons\.svg(\?.*)?$/, '')
+      : '';
+  }
+
+  // Resolve an AOV4 stamp URL for a branch + rank at a given size tier.
+  function _aovStamp(branch, n, tier) {
+    tier = (tier === 'badge' || tier === 'card' || tier === 'hero') ? tier : 'card';
+    var stem;
+    if (branch === 'unique') {
+      stem = AOV_UNIQUE_STEM[Math.max(4, Math.min(6, n))];
+    } else {
+      stem = AOV_SUITE_STEM[Math.max(1, Math.min(6, n))];
+    }
+    return _base() + 'assets/ascension-overdrive/aov4-' + stem + '-' + tier + '.webp';
+  }
+
+  // Map the legacy CSS size modifier to an AOV size tier.
+  //   'sm' → badge · 'lg' → hero · (none) → card
+  function _sizeTier(sizeModifier) {
+    if (sizeModifier === 'sm') return 'badge';
+    if (sizeModifier === 'lg') return 'hero';
+    return 'card';
+  }
+
+
   function namedSlug(ns) {
     if (typeof window.namedSlug === 'function' && window.namedSlug !== namedSlug) return window.namedSlug(ns);
     if (!ns) return '';
@@ -88,11 +149,25 @@
   // chrome lives in CSS, never JS.
 
   function _fieldOrb(ns, sizeModifier) {
-    var type = (ns && ns.type) || 'basic';
+    var branch = branchOf(ns);
     var n = levelNum(ns && ns.level);
     var mod = sizeModifier ? ' plaque-orb--' + sizeModifier : '';
     var apex = n >= 6 ? ' plaque-orb--vi' : '';
-    return '<div class="plaque-orb plaque-orb--' + esc(type) + mod + apex + '" aria-hidden="true"></div>';
+    // The medallion IS the AOV4 stamp (rubric E3): no CSS-gradient orb
+    // stand-in on named skills. Branch (suite/unique) + rank pick the asset;
+    // the surface's size modifier picks badge/card/hero. Standard-branch
+    // named skills (rank 1..3) render the c1..c3 suite stamps.
+    var tier = _sizeTier(sizeModifier);
+    var src = _aovStamp(branch, n, tier);
+    var rankName = rankWordOf(ns && ns.level, branch);
+    var alt = rankName ? rankName + ' medallion' : 'rank medallion';
+    // Decorative but rank-bearing: keep an accessible label. onerror keeps the
+    // element in flow (no empty hole) — falls back to the tier orb styling.
+    return '<span class="plaque-orb plaque-orb--medallion plaque-orb--' + esc(branch) + mod + apex +
+      '" data-branch="' + esc(branch) + '" role="img" aria-label="' + esc(alt) + '">' +
+      '<img class="plaque-orb__stamp" src="' + esc(src) + '" alt="" decoding="async" loading="lazy" ' +
+      'onerror="this.style.display=\'none\';this.parentNode.setAttribute(\'data-stamp-fail\',\'true\')">' +
+      '</span>';
   }
 
   function _fieldSlug(ns) {

--- a/docs/js/skill-semantics.js
+++ b/docs/js/skill-semantics.js
@@ -1,0 +1,102 @@
+/* Gaia skill-semantics — shared client branch resolver (Yggdrasil II).
+ *
+ * SINGLE SOURCE OF TRUTH for read-time branch derivation on the client.
+ * Mirrors docs/js/world-tree-layout.js resolveSemantics() (L356-413) so every
+ * consumer (plaque.js, heroes.js, named-skills.js, leaderboard.js,
+ * skill-explorer.js) derives branch + rank vocabulary identically.
+ *
+ * §Ygg-II rubric E1: branch MUST be derived at read-time — NEVER from
+ * skill.type === 'ultimate'|'unique'|'extra' and NEVER from a stored
+ * branch/tier field. The only valid `type` values are 'basic' and 'fusion'.
+ *
+ * §Ygg-II rubric E2: rank WORDS fork by branch at 4★+. BANNED anywhere:
+ * 'Transcendent', 'Hardened'. Correct ladder:
+ *   shared {1 Awakened, 2 Named, 3 Evolved}
+ *   suite  {4 Extra, 5 Ultimate, 6 Apex}
+ *   unique {4 Unique, 5 Unique Ultimate, 6 Unique Impossible}
+ *
+ * Exposes on window (IIFE, no build step, dependency-free, idempotent):
+ *   window.GaiaSemantics = {
+ *     computeBranch(node, effRank),   // 'standard' | 'suite' | 'unique'
+ *     rankWord(level, branch),        // e.g. 'Unique Ultimate'
+ *     rankLabel(level, branch),       // e.g. 'Unique Ultimate · 5★'
+ *   }
+ *
+ * Load BEFORE every consumer (plaque.js, heroes.js, named-skills.js, …).
+ */
+(function () {
+  'use strict';
+
+  // Idempotent: if a prior include already installed GaiaSemantics, keep it.
+  if (typeof window !== 'undefined' && window.GaiaSemantics) return;
+
+  // Accept a level like "5★", "5", or 5 → clamped integer 0..6.
+  function levelNum(level) {
+    if (level == null) return 0;
+    if (typeof level === 'number') return level | 0;
+    var n = parseInt(String(level).replace(/[^\d]/g, ''), 10);
+    return isNaN(n) ? 0 : Math.max(0, Math.min(6, n));
+  }
+
+  // computeBranch — the ONLY correct client branch resolver (Ygg II).
+  //
+  // node:    the source skill object (carries .type, .suiteComponents).
+  // effRank: the skill's effective star level ("5★" | 5 | "5" all accepted).
+  //
+  // Read order mirrors resolveSemantics §3.2 and must not be reordered:
+  //   1. unique = type === 'basic' && effRank >= 4 && !suiteComponents
+  //   2. suite  = suiteComponents present (length > 0)
+  //   3. else     standard
+  function computeBranch(node, effRank) {
+    node = node || {};
+    var type = node.type;
+    var rank = levelNum(effRank != null ? effRank : node.level);
+    var hasSuiteComponents = Array.isArray(node.suiteComponents)
+      && node.suiteComponents.length > 0;
+
+    // 1. Unique FIRST — a Basic that ascended to elite rank without fusing.
+    if (type === 'basic' && rank >= 4 && !hasSuiteComponents) return 'unique';
+
+    // 2. Suite — the generic parent carries suiteComponents.
+    if (hasSuiteComponents) return 'suite';
+
+    // 3. Everything else is the standard (shared) branch.
+    return 'standard';
+  }
+
+  // Shared rank words for 1★–3★ (branch-agnostic). 0★ = Basic (starless).
+  var SHARED_WORD = { 0: 'Basic', 1: 'Awakened', 2: 'Named', 3: 'Evolved' };
+  // Suite branch 4★–6★.
+  var SUITE_WORD = { 4: 'Extra', 5: 'Ultimate', 6: 'Apex' };
+  // Unique branch 4★–6★.
+  var UNIQUE_WORD = { 4: 'Unique', 5: 'Unique Ultimate', 6: 'Unique Impossible' };
+
+  // rankWord — the branch-forked rank NAME. Never emits Transcendent/Hardened.
+  //   level:  "5★" | 5 | "5"
+  //   branch: 'standard' | 'suite' | 'unique' (default 'standard')
+  function rankWord(level, branch) {
+    var n = levelNum(level);
+    if (n <= 3) return SHARED_WORD[n] || 'Basic';
+    // 4★+ forks by branch. 'suite' and 'unique' are the only forked branches;
+    // a 'standard' skill above 3★ has no forked name yet, so it reads as the
+    // suite ladder word (the neutral default) — but in practice a 4★+ skill
+    // always resolves to 'suite' or 'unique' via computeBranch.
+    if (branch === 'unique') return UNIQUE_WORD[n] || UNIQUE_WORD[6];
+    return SUITE_WORD[n] || SUITE_WORD[6];
+  }
+
+  // rankLabel — "<rankWord> · N★" (e.g. "Unique Ultimate · 5★").
+  function rankLabel(level, branch) {
+    var n = levelNum(level);
+    return rankWord(level, branch) + ' · ' + n + '★';
+  }
+
+  var api = {
+    computeBranch: computeBranch,
+    rankWord: rankWord,
+    rankLabel: rankLabel,
+  };
+
+  if (typeof window !== 'undefined') window.GaiaSemantics = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})();

--- a/docs/meta.html
+++ b/docs/meta.html
@@ -20,6 +20,7 @@
 <script src="js/rank-badge.js?v=6.8.8"></script>
 <!-- Stage 3 — plaque component family. -->
 <script src="js/tm-config.js?v=6.8.8"></script>
+<script src="js/skill-semantics.js?v=6.8.8"></script>
 <script src="js/plaque.js?v=6.8.8"></script>
 <style>
   .meta-report-grid {

--- a/docs/named/index.html
+++ b/docs/named/index.html
@@ -34,6 +34,7 @@
   <script src="../js/rank-badge.js?v=6.8.8"></script>
   <!-- Stage 3 — plaque component family, loaded after rank-badge. -->
   <script src="../js/tm-config.js?v=6.8.8"></script>
+  <script src="../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../js/plaque.js?v=6.8.8"></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {

--- a/docs/samples/explorer.html
+++ b/docs/samples/explorer.html
@@ -15,6 +15,7 @@
   <script src="../js/icons.js"></script>
   <script src="../js/rank-badge.js"></script>
   <script src="../js/atlas-helpers.js"></script>
+  <script src="../js/skill-semantics.js"></script>
   <script src="../js/plaque.js"></script>
 
   <style>

--- a/docs/samples/flowchart.html
+++ b/docs/samples/flowchart.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="../css/plaque.css">
   <script src="../js/icons.js"></script>
   <script src="../js/rank-badge.js"></script>
+  <script src="../js/skill-semantics.js"></script>
   <script src="../js/plaque.js"></script>
 
   <style>

--- a/docs/samples/plaques.html
+++ b/docs/samples/plaques.html
@@ -13,6 +13,7 @@
   <script src="../js/icons.js"></script>
   <script src="../js/rank-badge.js"></script>
   <script src="../js/atlas-helpers.js"></script>
+  <script src="../js/skill-semantics.js"></script>
   <script src="../js/plaque.js"></script>
   <style>
     body {

--- a/docs/samples/profile-enhancements.html
+++ b/docs/samples/profile-enhancements.html
@@ -13,6 +13,7 @@
   <script src="../js/icons.js"></script>
   <script src="../js/rank-badge.js"></script>
   <script src="../js/atlas-helpers.js"></script>
+  <script src="../js/skill-semantics.js"></script>
   <script src="../js/plaque.js"></script>
   <script src="../js/profile-filter.js" defer></script>
   <script src="../js/profile-share.js" defer></script>

--- a/docs/samples/skill-flowchart.html
+++ b/docs/samples/skill-flowchart.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="../css/plaque.css">
   <script src="../js/icons.js"></script>
   <script src="../js/rank-badge.js"></script>
+  <script src="../js/skill-semantics.js"></script>
   <script src="../js/plaque.js"></script>
 
   <style>

--- a/docs/samples/trust-grade-notch.html
+++ b/docs/samples/trust-grade-notch.html
@@ -13,6 +13,7 @@
   <script src="../js/icons.js"></script>
   <script src="../js/rank-badge.js"></script>
   <script src="../js/atlas-helpers.js"></script>
+  <script src="../js/skill-semantics.js"></script>
   <script src="../js/plaque.js"></script>
   <style>
     body {

--- a/docs/starless.html
+++ b/docs/starless.html
@@ -22,6 +22,7 @@
 <!-- Stage 2 — shared rank-badge primitive. -->
 <script src="js/rank-badge.js?v=6.8.8"></script>
 <!-- Stage 3 — plaque component family. -->
+<script src="js/skill-semantics.js?v=6.8.8"></script>
 <script src="js/plaque.js?v=6.8.8"></script>
 <!-- Universal alphabetical scrubber component. -->
 <script src="js/alpha-rail.js?v=6.8.8"></script>

--- a/docs/u/0xdarkmatter/index.html
+++ b/docs/u/0xdarkmatter/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/Manavarya09/index.html
+++ b/docs/u/Manavarya09/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/Taoidle/index.html
+++ b/docs/u/Taoidle/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/addy-osmani/index.html
+++ b/docs/u/addy-osmani/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/anthropic/index.html
+++ b/docs/u/anthropic/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/bradautomates/index.html
+++ b/docs/u/bradautomates/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/browser-use/index.html
+++ b/docs/u/browser-use/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/browserbase/index.html
+++ b/docs/u/browserbase/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/caioribeiroclw-pixel/index.html
+++ b/docs/u/caioribeiroclw-pixel/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/changkun/index.html
+++ b/docs/u/changkun/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/devin-ai/index.html
+++ b/docs/u/devin-ai/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/favorchurch/index.html
+++ b/docs/u/favorchurch/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/firecrawl/index.html
+++ b/docs/u/firecrawl/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/gaia-research/index.html
+++ b/docs/u/gaia-research/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/gaiabot/index.html
+++ b/docs/u/gaiabot/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/garrytan/index.html
+++ b/docs/u/garrytan/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/getagentseal/index.html
+++ b/docs/u/getagentseal/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/glincker/index.html
+++ b/docs/u/glincker/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/google-deepmind/index.html
+++ b/docs/u/google-deepmind/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/gooseworks/index.html
+++ b/docs/u/gooseworks/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/gsd-build/index.html
+++ b/docs/u/gsd-build/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/huggingface/index.html
+++ b/docs/u/huggingface/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/intelligentcode-ai/index.html
+++ b/docs/u/intelligentcode-ai/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/karpathy/index.html
+++ b/docs/u/karpathy/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/langgenius/index.html
+++ b/docs/u/langgenius/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/laravel/index.html
+++ b/docs/u/laravel/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/martin-stepanoski/index.html
+++ b/docs/u/martin-stepanoski/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/mattpocock/index.html
+++ b/docs/u/mattpocock/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/mbtiongson1/index.html
+++ b/docs/u/mbtiongson1/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/nexu-io/index.html
+++ b/docs/u/nexu-io/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/nousresearch/index.html
+++ b/docs/u/nousresearch/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/obra/index.html
+++ b/docs/u/obra/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/openai/index.html
+++ b/docs/u/openai/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/pbakaus/index.html
+++ b/docs/u/pbakaus/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/pexp13/index.html
+++ b/docs/u/pexp13/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/rico-favor/index.html
+++ b/docs/u/rico-favor/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/ruvnet/index.html
+++ b/docs/u/ruvnet/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/safishamsi/index.html
+++ b/docs/u/safishamsi/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/santifer/index.html
+++ b/docs/u/santifer/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/sickn33/index.html
+++ b/docs/u/sickn33/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/spring-ai/index.html
+++ b/docs/u/spring-ai/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/stanfordnlp/index.html
+++ b/docs/u/stanfordnlp/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/upsonic/index.html
+++ b/docs/u/upsonic/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/vercel/index.html
+++ b/docs/u/vercel/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/xquik-dev/index.html
+++ b/docs/u/xquik-dev/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/yonatangross/index.html
+++ b/docs/u/yonatangross/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">

--- a/docs/u/yundu-ai/index.html
+++ b/docs/u/yundu-ai/index.html
@@ -26,6 +26,7 @@
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
   <script src="../../js/tm-config.js?v=6.8.8"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
+  <script src="../../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../../js/plaque.js?v=6.8.8"></script>
   <script src="../../js/ui.js?v=6.8.8" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">


### PR DESCRIPTION
## WAVE 0 — Foundation (Yggdrasil II design run)

Keystone PR for the #998 design pass. Every later lane imports what lands here.

### Delivered
- **`--tier-unique` token family** promoted to first-class in `docs/css/tokens.css` (violet `#7c3aed` + `-rgb/-bg/-border/-edge/-symbol`), hex fallbacks removed at usage sites.
- **Shared client resolver** `docs/js/skill-semantics.js` (NEW) — `window.GaiaSemantics.{computeBranch, rankWord, rankLabel}`, mirroring `world-tree-layout.js resolveSemantics`. Branch-forked ladder, never emits banned `Transcendent`/`Hardened`. Wired before `plaque.js` on 60 pages.
- **Gold origin-wreath frame** `docs/assets/origin-wreath-gold.svg` (NEW) — replaces the honor-red `#origin-badge`.
- **`plaque.js` rewrite** — branch derived via `computeBranch` (ZERO dead type-enum switches); `_fieldOrb` → AOV4 medallion `<img>` (c1–c6 suite / d4–d6 unique × badge/card/hero); avatars on EVERY variant with gold wreath + GitHub-identicon fallback; standalone GitHub button removed (avatar links to repo); red origin mark removed; dark(unique)/gold(suite) split rekeyed to `data-branch`.

### Review (adversarial, Playwright-verified)
PASS, severity none. 153 plaques (unique 5 / suite 16 / standard 132), 119 avatars = 119 wreaths (1:1), 0 broken avatars, 0 broken stamps, 0 banned words, desktop + mobile clean.

### Enforcement rubric
Graded against `DESIGN.md` §"Yggdrasil II Enforcement Rubric" E1–E7.

### Notes carried to Wave 1
- `generateCssTokens.py` must learn to emit the `--tier-unique` family (currently hand-authored; a regen would drop it). Python lane, W1e.
- Orphaned `.plaque-orb--extra/--ultimate` dead CSS classes — prune in W1 cleanup.

Part of EPIC #1002 · sub-issue #998.
