### PR TITLE
Ygg2 W1f — MCP sweep + homepage N-1/N-2 polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,7 @@ A GitHub issue opens automatically. Don't worry, we thoroughly review every inta
 **4. MCP Server**
 
 ```bash
-claude mcp add gaia -- npx @gaia-registry/mcp-server
-```
-
-If you wanna be fancy and do all sorts of agentic MCP goodness.
+claude mcp add gaia -- npx @gaia-registry/mcp@0.1.0
 
 ---
 
@@ -345,14 +342,14 @@ Maintainer commands:  gaia dev --help
 
 ## MCP Server Full Instructions
 
-`@gaia-registry/mcp-server` connects Gaia to MCP-compatible agents (Claude Code, Cursor, VS Code, etc.).
+`@gaia-registry/mcp@0.1.0` connects Gaia to MCP-compatible agents (Claude Code, Cursor, VS Code, etc.).
 
 | Agent | Install |
 |-------|---------|
-| Claude Code | `claude mcp add gaia -- npx @gaia-registry/mcp-server` |
-| Any MCP client | Command: `npx`, args: `@gaia-registry/mcp-server` |
+| Claude Code | `claude mcp add gaia -- npx @gaia-registry/mcp@0.1.0` |
+| Any MCP client | Command: `npx`, args: `@gaia-registry/mcp@0.1.0` |
 
-Set `GAIA_USER=your-github-username` and optionally `GITHUB_TOKEN` for PR tools. See [`packages/mcp/`](packages/mcp/) for full docs and agent-specific config examples.
+Set `GAIA_USER=your-github-username` and optionally `GITHUB_TOKEN` for PR tools. Endpoint: `research.gaiaskilltree.com/mcp`. See [`packages/mcp/`](packages/mcp/) for full docs and agent-specific config examples.
 
 ---
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -73,7 +73,7 @@ Connect Gaia natively to MCP-compatible agents (Claude Code, Cursor, VS Code, et
 
 ### Claude Code Integration
 ```bash
-claude mcp add gaia -- npx @gaia-registry/mcp-server
+claude mcp add gaia -- npx @gaia-registry/mcp@0.1.0
 ```
 
 ### Environment Variables

--- a/docs/css/ascension-overdrive-v4.css
+++ b/docs/css/ascension-overdrive-v4.css
@@ -536,6 +536,7 @@
   width: min(24vw, 25rem);
   aspect-ratio: 1.2;
   align-self: center;
+  mix-blend-mode: screen;
 }
 
 .aov-terminal-art img {

--- a/docs/css/world-tree-hero.css
+++ b/docs/css/world-tree-hero.css
@@ -372,6 +372,7 @@
 .hero-tree-install-copy {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
   gap: .5rem .7rem;
   min-width: 0;
 }

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -486,7 +486,7 @@
     <a class="docs-card" href="mcp-server.html">
       <span class="docs-card-icon">🔌</span>
       <span class="docs-card-title">MCP Server</span>
-      <span class="docs-card-desc">Use <code>@gaia-registry/mcp-server</code> to give any MCP-compatible agent access to the skill graph at runtime.</span>
+      <span class="docs-card-desc">Use <code>@gaia-registry/mcp@0.1.0</code> to give any MCP-compatible agent access to the skill graph at runtime.</span>
       <span class="docs-card-badge new">● New</span>
     </a>
     <a class="docs-card" href="share-bundles.html">

--- a/docs/en/mcp-server.html
+++ b/docs/en/mcp-server.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MCP Server — Gaia Docs</title>
-  <meta name="description" content="@gaia-registry/mcp-server: connect Gaia to Claude Code, Cursor, VS Code, and any MCP-compatible agent. Tool reference, configuration, and known issues.">
+  <meta name="description" content="@gaia-registry/mcp@0.1.0: connect Gaia to Claude Code, Cursor, VS Code, and any MCP-compatible agent. Tool reference, configuration, and known issues.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
@@ -544,7 +544,7 @@
 
     <!-- main -->
     <main class="main-content">
-      <div class="page-badge">● @gaia-registry/mcp-server · v6.4.12</div>
+      <div class="page-badge">● @gaia-registry/mcp@0.1.0</div>
       <h1 class="page-title">MCP Server</h1>
       <p class="page-lead">
         Connect Gaia to any MCP-compatible agent — Claude Code, Claude Desktop, Cursor,
@@ -557,7 +557,7 @@
         <h2 class="section-title">Overview</h2>
         <div class="section-body">
           <p>
-            <code>@gaia-registry/mcp-server</code> is a
+            <code>@gaia-registry/mcp@0.1.0</code> is a
             <a href="https://modelcontextprotocol.io" rel="noopener" target="_blank">Model Context Protocol</a>
             server that exposes Gaia's registry to your AI agent at inference time.
             Instead of copying skill IDs into prompts, the agent calls structured tools
@@ -575,7 +575,7 @@
         <div class="callout callout-info">
           <span class="callout-label">💡 Quick start</span>
           <p>Using Claude Code? Run one command and you're done:</p>
-          <p><code>claude mcp add gaia -- npx @gaia-registry/mcp-server</code></p>
+          <p><code>claude mcp add gaia -- npx @gaia-registry/mcp@0.1.0</code></p>
           <p>Then ask: <em>"Use gaia_lookup to find the rag-pipeline skill."</em></p>
         </div>
       </section>
@@ -585,9 +585,9 @@
         <h2 class="section-title">Installation</h2>
         <div class="section-body">
           <p>
-            The universal install shape is <code>npx @gaia-registry/mcp-server</code>
+            The universal install shape is <code>npx @gaia-registry/mcp@0.1.0</code>
             with an optional <code>GAIA_USER</code> env var set to your GitHub username.
-            Platform specifics follow.
+            Platform specifics follow. Research endpoint: <code>research.gaiaskilltree.com/mcp</code>.
           </p>
         </div>
 
@@ -609,10 +609,10 @@
           <div class="code-block">
             <div class="code-block-header"><span class="code-block-label">bash</span></div>
             <pre><span class="c"># project-local (adds to .claude/settings.json)</span>
-<span class="cmd">claude mcp add gaia</span> -- npx @gaia-registry/mcp-server
+<span class="cmd">claude mcp add gaia</span> -- npx @gaia-registry/mcp@0.1.0
 
 <span class="c"># global (available in every project)</span>
-<span class="cmd">claude mcp add gaia</span> --global -- npx @gaia-registry/mcp-server</pre>
+<span class="cmd">claude mcp add gaia</span> --global -- npx @gaia-registry/mcp@0.1.0</pre>
           </div>
           <div class="section-body">
             <p>To pass <code>GAIA_USER</code> and <code>GITHUB_TOKEN</code>, edit <code>.claude/settings.json</code> directly:</p>
@@ -623,7 +623,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>,
         <span class="str">"GITHUB_TOKEN"</span>: <span class="str">"ghp_..."</span>
@@ -662,7 +662,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>
       }
@@ -688,7 +688,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>
       }
@@ -714,7 +714,7 @@
   <span class="str">"servers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>
       }
@@ -732,7 +732,7 @@
     <span class="str">"servers"</span>: {
       <span class="str">"gaia"</span>: {
         <span class="str">"command"</span>: <span class="str">"npx"</span>,
-        <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+        <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp@0.1.0"</span>],
         <span class="str">"env"</span>: { <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span> }
       }
     }
@@ -753,7 +753,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: { <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span> }
     }
   }
@@ -774,7 +774,7 @@
             <div class="code-block-header"><span class="code-block-label">universal shape</span></div>
             <pre>{
   <span class="str">"command"</span>: <span class="str">"npx"</span>,
-  <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+  <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp@0.1.0"</span>],
   <span class="str">"env"</span>: {
     <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>,
     <span class="str">"GITHUB_TOKEN"</span>: <span class="str">"ghp_..."</span>   <span class="c">// required for gaia_propose</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -700,8 +700,8 @@
               </div>
             </div>
             <div class="rite-term">
-              <pre><span class="cmd">claude mcp add</span> <span class="str">gaia</span> -- <span class="cmd">npx</span> <span class="str">@gaia-registry/mcp-server</span></pre>
-              <div class="qs-tip mt-sm"><span class="qs-tip-icon">💡</span><span>Any MCP-compatible agent: use <code>npx @gaia-registry/mcp-server</code>. See <a href="https://github.com/gaia-research/gaia-skill-tree/tree/main/packages/mcp" target="_blank" class="text-tier-basic">packages/mcp</a> for config-file examples.</span></div>
+              <pre><span class="cmd">claude mcp add</span> <span class="str">gaia</span> -- <span class="cmd">npx</span> <span class="str">@gaia-registry/mcp@0.1.0</span></pre>
+              <div class="qs-tip mt-sm"><span class="qs-tip-icon">💡</span><span>Any MCP-compatible agent: use <code>npx @gaia-registry/mcp@0.1.0</code>. Endpoint: <code>research.gaiaskilltree.com/mcp</code>. See <a href="https://github.com/gaia-research/gaia-skill-tree/tree/main/packages/mcp" target="_blank" class="text-tier-basic">packages/mcp</a> for config-file examples.</span></div>
             </div>
           </li>
           <li class="rite-step">


### PR DESCRIPTION
## Yggdrasil II Wave 1 — W1f: MCP sweep + homepage N-1/N-2 polish

Part of EPIC #1002 · #998. Targets `dev/yggdrasil-ii-staging` (merge commit, never squash).

- **N-9 MCP sweep** — canonical package `@gaia-registry/mcp@0.1.0` + endpoint `research.gaiaskilltree.com/mcp` across `docs/index.html`, `docs/en/index.html`, `docs/en/mcp-server.html`, `docs/agent.md`, `README.md`.
- **N-1 terminal edge** — soft edge treatment on the shared `.aov-terminal-art` rule so both terminals resolve with no hard seam.
- **N-2 hero install card alignment** — title+toggle baseline fix on the primary card; ghost siblings unregressed.

No hex literals in new CSS (design tokens only).

### Entrypoints
Homepage (frozen except N-1/N-2) + docs pages — existing entrypoints unchanged. Cache-bust versions bumped on touched HTML.

### Rubric
Adversarial reviewer PASS (E1–E7, Playwright desktop + mobile).

Commit identity: mbtiongson1 only.
