### PR TITLE
design(ygg2-w1.5): N-13 medallion propagation — wreath art + profile hero + heroes stamp

### DIFF
--- a/docs/assets/origin-wreath-gold.svg
+++ b/docs/assets/origin-wreath-gold.svg
@@ -10,6 +10,12 @@
 
     Usage — overlay a wreath border around an avatar image; the open center
     reveals the avatar underneath.
+
+    N-13 remediation: the leaf glyph is now a VEINED, PAIRED laurel leaf —
+    a fuller lanceolate blade split by a central vein (the sliver gap between
+    the two half-blades reads as the midrib), plus a smaller companion leaf at
+    every node so the ring reads as recognizable paired laurel at avatar-frame
+    size, not thin radiating slivers.
   -->
   <defs>
     <linearGradient id="gaiaWreathGold" x1="0" y1="0" x2="0" y2="1">
@@ -17,8 +23,24 @@
       <stop offset="0.55" stop-color="var(--tier-fusion, #f59e0b)"/>
       <stop offset="1" stop-color="var(--seal-gold, #d4af37)"/>
     </linearGradient>
-    <!-- A single laurel leaf: a slim almond pointing up from its stem end. -->
-    <path id="gaiaWreathLeaf" d="M0 0 C 3.4 -2.2 6.2 -6.4 7 -12 C 3.6 -10.4 1 -6.4 0 0 Z"/>
+
+    <!-- A single laurel leaf blade, pointing straight up from its base at the
+         origin. A fuller lanceolate outline (pointed at both base and apex,
+         bulging to ±2.7u, ~13.5u long) with a thin diamond MIDRIB carved out
+         along the axis via fill-rule="evenodd" — the negative-space vein is
+         what makes it read as a real laurel leaf, not a flat sliver. -->
+    <path id="gaiaLeafBlade" fill-rule="evenodd"
+          d="M0 -0.5 C 2.7 -3.6 2.7 -10 0 -14 C -2.7 -10 -2.7 -3.6 0 -0.5 Z
+             M0 -2.6 L 0.42 -7.2 L 0 -11.8 L -0.42 -7.2 Z"/>
+
+    <!-- A laurel NODE = a primary leaf (rotated up-and-inward to match the
+         stem tangent the old placements were computed for) PAIRED with a
+         smaller companion leaf fanned beside it. Every wreath position renders
+         this pair, so leaves come in recognizable laurel pairs along the stem. -->
+    <g id="gaiaWreathLeaf">
+      <use href="#gaiaLeafBlade" transform="rotate(30.26)"/>
+      <use href="#gaiaLeafBlade" transform="rotate(6) scale(0.58)"/>
+    </g>
   </defs>
 
   <g fill="url(#gaiaWreathGold)" stroke="none">
@@ -29,14 +51,14 @@
     <path d="M50 87 C 70 86 85 70 85.6 39.8" fill="none"
           stroke="url(#gaiaWreathGold)" stroke-width="2.2" stroke-linecap="round"/>
 
-    <!-- Left-side leaves (tangential to the arc, pointing up-and-inward). -->
+    <!-- Left-side leaf pairs (tangential to the arc, pointing up-and-inward). -->
     <use href="#gaiaWreathLeaf" transform="translate(43.58 86.44) rotate(190.0)"/>
     <use href="#gaiaWreathLeaf" transform="translate(30.39 81.38) rotate(212.0)"/>
     <use href="#gaiaWreathLeaf" transform="translate(20.07 71.75) rotate(234.0)"/>
     <use href="#gaiaWreathLeaf" transform="translate(14.10 58.95) rotate(256.0)"/>
     <use href="#gaiaWreathLeaf" transform="translate(13.36 44.85) rotate(278.0)"/>
 
-    <!-- Right-side leaves (mirror of the left branch). -->
+    <!-- Right-side leaf pairs (mirror of the left branch). -->
     <use href="#gaiaWreathLeaf" transform="translate(56.42 86.44) rotate(170.0) scale(-1 1)"/>
     <use href="#gaiaWreathLeaf" transform="translate(69.61 81.38) rotate(148.0) scale(-1 1)"/>
     <use href="#gaiaWreathLeaf" transform="translate(79.93 71.75) rotate(126.0) scale(-1 1)"/>

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -2026,6 +2026,34 @@ button.plaque__slug:focus-visible {
   margin: 0 auto;
   text-align: center;
 }
+/* Profile-hero medallion (N-13 item 4) — the contributor's wreathed GitHub
+   avatar centered above the handle, with the AOV4 rank stamp orb overlapping
+   its lower edge. Routed through the shared _field_avatar + _field_orb path
+   (server-rendered by generateProfilePages.build_hero_medallion) so it stays
+   byte-identical to the plaque medallion vocabulary. */
+.profile-hero-medallion {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem;
+}
+.profile-hero-medallion .plaque__avatar {
+  --avatar-size: 96px;
+}
+/* The rank stamp orb sits at the lower-right of the avatar, half-overlapping
+   its edge — the same composition the tile/settled medallion header implies. */
+.profile-hero-medallion .plaque-orb--medallion {
+  position: absolute;
+  right: -6%;
+  bottom: -6%;
+  width: 42%;
+  height: 42%;
+}
+.profile-hero-medallion .plaque-orb__stamp {
+  width: 100%;
+  height: 100%;
+}
 /* Back link — mirrors the Explorer modal's se-btn-ghost back affordance:
    flows in-document above the hero so the fixed top-nav never overlaps it. */
 .profile-back {

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -691,6 +691,32 @@
   transition: transform 0.4s ease, border-color 0.4s ease, box-shadow 0.4s ease;
 }
 
+/* E3 — the AOV4 medallion stamp fills the crest seal. When present it
+   supersedes the legacy ◆ glyph (hidden below); the seal grows slightly so
+   the rank medallion reads. The shared .plaque-orb--medallion img fills it. */
+.hero-card__crest-seal:has(.plaque-orb--medallion) {
+  width: 42px;
+  height: 42px;
+  bottom: -18px;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+.hero-card__crest-seal .plaque-orb--medallion {
+  width: 100%;
+  height: 100%;
+}
+.hero-card__crest-seal .plaque-orb__stamp {
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 3px 10px rgba(0, 0, 0, 0.72));
+}
+/* Legacy glyph is the fallback only — hidden whenever the stamp rendered. */
+.hero-card__crest-seal:has(.plaque-orb--medallion:not([data-stamp-fail])) .hero-card__crest-seal-glyph {
+  display: none;
+}
+
 .hero-card__crest-seal-glyph {
   font-family: var(--heroes-font-mono);
   font-size: 0.95rem;

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -181,6 +181,11 @@
     contributor.topSkill.type = named.type || contributor.topSkill.type || 'basic';
     contributor.topSkill.name = named.name || contributor.topSkill.name;
     contributor.topSkill.origin = named.origin;
+    // Carry suiteComponents + links so the AOV4 medallion stamp (crest seal)
+    // resolves the correct branch (suite vs unique) via GaiaSemantics — the
+    // contributors API topSkill blob omits them (E1: branch is read-time).
+    if (named.suiteComponents) contributor.topSkill.suiteComponents = named.suiteComponents;
+    if (named.links) contributor.topSkill.links = named.links;
     return contributor;
   }
 
@@ -247,6 +252,28 @@
       '</span>';
   }
 
+  // ── AOV4 rank medallion stamp (E3) ────────────────────────────
+  // The crest rank marker IS the Ascension-Overdrive v4 stamp — the same
+  // medallion the plaques carry. Routed through the shared plaque._fields.orb
+  // so branch (suite/unique) + rank pick the asset identically everywhere;
+  // never a bespoke per-surface stamp. Falls back to '' if plaque.js is
+  // somehow absent (the legacy ◆ glyph then remains the sole rank marker).
+  function heroRankStampHtml(contributor) {
+    if (!(window.plaque && window.plaque._fields &&
+          typeof window.plaque._fields.orb === 'function')) {
+      return '';
+    }
+    var skill = (contributor && contributor.topSkill) || {};
+    var ns = {
+      contributor: contributor && contributor.handle,
+      level: skill.level,
+      type: skill.type,
+      suiteComponents: skill.suiteComponents,
+    };
+    // 'lg' size modifier → the AOV4 'hero' tier asset (largest stamp).
+    return window.plaque._fields.orb(ns, 'lg');
+  }
+
   function scrollToStage(stage) {
     if (!stage) return;
     stage.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -296,8 +323,16 @@
     html += '<div class="hero-card__crest-square-front">';
     html += heroAvatarHtml(contributor, 200);
     html += '</div>';
+    // E3: rank marker IS the AOV4 medallion stamp (shared plaque orb path).
+    // The legacy ◆ crest-seal glyph is retained as the fallback shown only
+    // when the stamp is unavailable (plaque.js absent / webp 404 → the orb's
+    // own [data-stamp-fail] tint plus this glyph keep a rank marker visible).
+    var rankStamp = heroRankStampHtml(contributor);
     html += '<div class="hero-card__crest-seal" data-level="' + esc(lvl) + '">';
-    html += '<span class="hero-card__crest-seal-glyph">' + esc(glyph) + '</span>';
+    if (rankStamp) {
+      html += rankStamp;
+    }
+    html += '<span class="hero-card__crest-seal-glyph" aria-hidden="true">' + esc(glyph) + '</span>';
     html += '</div>';
     html += '</div>';
 

--- a/docs/u/0xdarkmatter/index.html
+++ b/docs/u/0xdarkmatter/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">0xdarkmatter</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/Manavarya09/index.html
+++ b/docs/u/Manavarya09/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="@Manavarya09" aria-label="@Manavarya09" style="--avatar-size:96px"><img class="plaque__avatar-img" src="https://github.com/Manavarya09.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/Manavarya09.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">Manavarya09</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/Taoidle/index.html
+++ b/docs/u/Taoidle/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">Taoidle</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/addy-osmani/index.html
+++ b/docs/u/addy-osmani/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @addy-osmani" aria-label="Origin contributor @addy-osmani" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/addy-osmani.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/addy-osmani.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--suite plaque-orb--lg" data-branch="suite" role="img" aria-label="Ultimate medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">addy-osmani</h1>
         <div class="profile-meta">
           9 named skills · highest rank 5★

--- a/docs/u/anthropic/index.html
+++ b/docs/u/anthropic/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="@anthropic" aria-label="@anthropic" style="--avatar-size:96px"><img class="plaque__avatar-img" src="https://github.com/anthropic.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/anthropic.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Evolved medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">anthropic</h1>
         <div class="profile-meta">
           2 named skills · highest rank 3★

--- a/docs/u/bradautomates/index.html
+++ b/docs/u/bradautomates/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @bradautomates" aria-label="Origin contributor @bradautomates" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/bradautomates.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/bradautomates.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">bradautomates</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/browser-use/index.html
+++ b/docs/u/browser-use/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @browser-use" aria-label="Origin contributor @browser-use" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/browser-use.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/browser-use.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Evolved medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">browser-use</h1>
         <div class="profile-meta">
           1 named skill · highest rank 3★

--- a/docs/u/browserbase/index.html
+++ b/docs/u/browserbase/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">browserbase</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/caioribeiroclw-pixel/index.html
+++ b/docs/u/caioribeiroclw-pixel/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">caioribeiroclw-pixel</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/changkun/index.html
+++ b/docs/u/changkun/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">changkun</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/devin-ai/index.html
+++ b/docs/u/devin-ai/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @devin-ai" aria-label="Origin contributor @devin-ai" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/devin-ai.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/devin-ai.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">devin-ai</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/favorchurch/index.html
+++ b/docs/u/favorchurch/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">favorchurch</h1>
         <div class="profile-meta">
           9 named skills · highest rank 1★

--- a/docs/u/firecrawl/index.html
+++ b/docs/u/firecrawl/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @firecrawl" aria-label="Origin contributor @firecrawl" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/firecrawl.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/firecrawl.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--unique plaque-orb--lg" data-branch="unique" role="img" aria-label="Unique medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-d4-unique-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">firecrawl</h1>
         <div class="profile-meta">
           6 named skills · highest rank 4★

--- a/docs/u/gaia-research/index.html
+++ b/docs/u/gaia-research/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="@gaia-research" aria-label="@gaia-research" style="--avatar-size:96px"><img class="plaque__avatar-img" src="https://github.com/gaia-research.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/gaia-research.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">gaia-research</h1>
         <div class="profile-meta">
           2 named skills · highest rank 2★

--- a/docs/u/gaiabot/index.html
+++ b/docs/u/gaiabot/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="@gaiabot" aria-label="@gaiabot" style="--avatar-size:96px"><img class="plaque__avatar-img" src="https://github.com/gaiabot.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/gaiabot.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">gaiabot</h1>
         <div class="profile-meta">
           2 named skills · highest rank 2★

--- a/docs/u/garrytan/index.html
+++ b/docs/u/garrytan/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @garrytan" aria-label="Origin contributor @garrytan" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/garrytan.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/garrytan.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--suite plaque-orb--lg" data-branch="suite" role="img" aria-label="Ultimate medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">garrytan</h1>
         <div class="profile-meta">
           47 named skills · highest rank 5★

--- a/docs/u/getagentseal/index.html
+++ b/docs/u/getagentseal/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @getagentseal" aria-label="Origin contributor @getagentseal" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/getagentseal.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/getagentseal.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">getagentseal</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/glincker/index.html
+++ b/docs/u/glincker/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">glincker</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/google-deepmind/index.html
+++ b/docs/u/google-deepmind/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @google-deepmind" aria-label="Origin contributor @google-deepmind" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/google-deepmind.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/google-deepmind.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--unique plaque-orb--lg" data-branch="unique" role="img" aria-label="Unique medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-d4-unique-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">google-deepmind</h1>
         <div class="profile-meta">
           37 named skills · highest rank 4★

--- a/docs/u/gooseworks/index.html
+++ b/docs/u/gooseworks/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">gooseworks</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/gsd-build/index.html
+++ b/docs/u/gsd-build/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="@gsd-build" aria-label="@gsd-build" style="--avatar-size:96px"><img class="plaque__avatar-img" src="https://github.com/gsd-build.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/gsd-build.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Evolved medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">gsd-build</h1>
         <div class="profile-meta">
           6 named skills · highest rank 3★

--- a/docs/u/huggingface/index.html
+++ b/docs/u/huggingface/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="@huggingface" aria-label="@huggingface" style="--avatar-size:96px"><img class="plaque__avatar-img" src="https://github.com/huggingface.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/huggingface.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">huggingface</h1>
         <div class="profile-meta">
           7 named skills · highest rank 2★

--- a/docs/u/intelligentcode-ai/index.html
+++ b/docs/u/intelligentcode-ai/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">intelligentcode-ai</h1>
         <div class="profile-meta">
           8 named skills · highest rank 1★

--- a/docs/u/karpathy/index.html
+++ b/docs/u/karpathy/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @karpathy" aria-label="Origin contributor @karpathy" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/karpathy.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/karpathy.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">karpathy</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/langgenius/index.html
+++ b/docs/u/langgenius/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">langgenius</h1>
         <div class="profile-meta">
           5 named skills · highest rank 1★

--- a/docs/u/laravel/index.html
+++ b/docs/u/laravel/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @laravel" aria-label="Origin contributor @laravel" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/laravel.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/laravel.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">laravel</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/martin-stepanoski/index.html
+++ b/docs/u/martin-stepanoski/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="@martin-stepanoski" aria-label="@martin-stepanoski" style="--avatar-size:96px"><img class="plaque__avatar-img" src="https://github.com/martin-stepanoski.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/martin-stepanoski.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Evolved medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">martin-stepanoski</h1>
         <div class="profile-meta">
           1 named skill · highest rank 3★

--- a/docs/u/mattpocock/index.html
+++ b/docs/u/mattpocock/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @mattpocock" aria-label="Origin contributor @mattpocock" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/mattpocock.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/mattpocock.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--suite plaque-orb--lg" data-branch="suite" role="img" aria-label="Ultimate medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">mattpocock</h1>
         <div class="profile-meta">
           34 named skills · highest rank 5★

--- a/docs/u/mbtiongson1/index.html
+++ b/docs/u/mbtiongson1/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @mbtiongson1" aria-label="Origin contributor @mbtiongson1" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/mbtiongson1.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/mbtiongson1.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">mbtiongson1</h1>
         <div class="profile-meta">
           12 named skills · highest rank 2★

--- a/docs/u/nexu-io/index.html
+++ b/docs/u/nexu-io/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @nexu-io" aria-label="Origin contributor @nexu-io" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/nexu-io.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/nexu-io.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">nexu-io</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/nousresearch/index.html
+++ b/docs/u/nousresearch/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @nousresearch" aria-label="Origin contributor @nousresearch" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/nousresearch.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/nousresearch.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">nousresearch</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/obra/index.html
+++ b/docs/u/obra/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @obra" aria-label="Origin contributor @obra" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/obra.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/obra.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--suite plaque-orb--lg" data-branch="suite" role="img" aria-label="Ultimate medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">obra</h1>
         <div class="profile-meta">
           12 named skills · highest rank 5★

--- a/docs/u/openai/index.html
+++ b/docs/u/openai/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @openai" aria-label="Origin contributor @openai" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/openai.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/openai.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--unique plaque-orb--lg" data-branch="unique" role="img" aria-label="Unique medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-d4-unique-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">openai</h1>
         <div class="profile-meta">
           2 named skills · highest rank 4★

--- a/docs/u/pbakaus/index.html
+++ b/docs/u/pbakaus/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @pbakaus" aria-label="Origin contributor @pbakaus" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/pbakaus.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/pbakaus.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--unique plaque-orb--lg" data-branch="unique" role="img" aria-label="Unique medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-d4-unique-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">pbakaus</h1>
         <div class="profile-meta">
           1 named skill · highest rank 4★

--- a/docs/u/pexp13/index.html
+++ b/docs/u/pexp13/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">pexp13</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/rico-favor/index.html
+++ b/docs/u/rico-favor/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">rico-favor</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/ruvnet/index.html
+++ b/docs/u/ruvnet/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @ruvnet" aria-label="Origin contributor @ruvnet" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/ruvnet.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/ruvnet.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--suite plaque-orb--lg" data-branch="suite" role="img" aria-label="Ultimate medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">ruvnet</h1>
         <div class="profile-meta">
           48 named skills · highest rank 5★

--- a/docs/u/safishamsi/index.html
+++ b/docs/u/safishamsi/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @safishamsi" aria-label="Origin contributor @safishamsi" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/safishamsi.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/safishamsi.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Evolved medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">safishamsi</h1>
         <div class="profile-meta">
           1 named skill · highest rank 3★

--- a/docs/u/santifer/index.html
+++ b/docs/u/santifer/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @santifer" aria-label="Origin contributor @santifer" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/santifer.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/santifer.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">santifer</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/sickn33/index.html
+++ b/docs/u/sickn33/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">sickn33</h1>
         <div class="profile-meta">
           3 named skills · highest rank 1★

--- a/docs/u/spring-ai/index.html
+++ b/docs/u/spring-ai/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="@spring-ai" aria-label="@spring-ai" style="--avatar-size:96px"><img class="plaque__avatar-img" src="https://github.com/spring-ai.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/spring-ai.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">spring-ai</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/stanfordnlp/index.html
+++ b/docs/u/stanfordnlp/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @stanfordnlp" aria-label="Origin contributor @stanfordnlp" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/stanfordnlp.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/stanfordnlp.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Evolved medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">stanfordnlp</h1>
         <div class="profile-meta">
           1 named skill · highest rank 3★

--- a/docs/u/upsonic/index.html
+++ b/docs/u/upsonic/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @upsonic" aria-label="Origin contributor @upsonic" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/upsonic.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/upsonic.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">upsonic</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/vercel/index.html
+++ b/docs/u/vercel/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @vercel" aria-label="Origin contributor @vercel" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/vercel.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/vercel.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Named medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">vercel</h1>
         <div class="profile-meta">
           1 named skill · highest rank 2★

--- a/docs/u/xquik-dev/index.html
+++ b/docs/u/xquik-dev/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        <div class="profile-hero-medallion"><span class="plaque__avatar" title="Origin contributor @xquik-dev" aria-label="Origin contributor @xquik-dev" style="--avatar-size:96px" data-origin="true"><img class="plaque__avatar-img" src="https://github.com/xquik-dev.png?size=192" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" onerror="if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk=&#x27;1&#x27;;this.src=&#x27;https://github.com/identicons/xquik-dev.png&#x27;;}"><img class="plaque__avatar-wreath" src="../../assets/origin-wreath-gold.svg" alt="" aria-hidden="true"></span><span class="plaque-orb plaque-orb--medallion plaque-orb--standard plaque-orb--lg" data-branch="standard" role="img" aria-label="Evolved medallion"><img class="plaque-orb__stamp" src="../../assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" alt="" decoding="async" loading="lazy" onerror="this.style.display='none';this.parentNode.setAttribute('data-stamp-fail','true')"></span></div>
         <h1 class="profile-handle">xquik-dev</h1>
         <div class="profile-meta">
           1 named skill · highest rank 3★

--- a/docs/u/yonatangross/index.html
+++ b/docs/u/yonatangross/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">yonatangross</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/docs/u/yundu-ai/index.html
+++ b/docs/u/yundu-ai/index.html
@@ -51,6 +51,7 @@
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        
         <h1 class="profile-handle">yundu-ai</h1>
         <div class="profile-meta">
           1 named skill · highest rank 1★

--- a/scripts/generateProfilePages.py
+++ b/scripts/generateProfilePages.py
@@ -1008,6 +1008,51 @@ def _build_named_index_for_handle(skills: list) -> dict:
     return index
 
 
+def build_hero_medallion(handle: str, skills: list) -> str:
+    """Build the profile-hero medallion: wreathed GitHub avatar + AOV4 rank stamp.
+
+    N-13 item 4 — the per-user profile hero previously carried only the handle
+    and a meta line, so there was no avatar to center. This routes the hero
+    through the SAME shared medallion path the plaques use (never a bespoke
+    re-implementation): the contributor's GitHub avatar framed by the gold
+    origin wreath (_field_avatar) plus the AOV4 rank stamp orb (_field_orb),
+    picked from the contributor's highest-ranked named skill so the hero
+    reflects their peak standing.
+
+    Returns '' when the contributor has no non-redacted skill (all ≤1★) — a
+    redacted contributor exposes no handle, so showing a resolvable avatar
+    would leak it (mirrors _field_avatar's own redaction guard).
+    """
+    # Pick the highest-ranked skill to drive the medallion branch + rank.
+    def _rank_key(s: dict) -> int:
+        return level_num(s.get("level", ""))
+
+    top = max(skills, key=_rank_key, default=None)
+    if not top or is_redacted(top.get("level", "")):
+        return ""
+
+    # Synthetic ns carrying the contributor + top skill's rank/branch signal.
+    # links omitted so the hero avatar is a non-link portrait (the per-skill
+    # plaques below already link each skill to its repo).
+    ns = {
+        "contributor": handle,
+        "level": top.get("level", ""),
+        "type": top.get("type", "basic"),
+        "suiteComponents": top.get("suiteComponents"),
+        "origin": any(s.get("origin") for s in skills),
+        "links": {},
+    }
+    orb = _field_orb(ns, "lg")
+    avatar = _field_avatar(ns, 96)
+    if not avatar:
+        return ""
+    return (
+        '<div class="profile-hero-medallion">'
+        f'{avatar}{orb}'
+        '</div>'
+    )
+
+
 def build_profile_page(handle: str, skills: list, named_index: dict | None = None) -> str:
     """Build the full HTML for a contributor profile page."""
     safe_handle = html.escape(handle)
@@ -1028,6 +1073,7 @@ def build_profile_page(handle: str, skills: list, named_index: dict | None = Non
     timeline_section_html = _build_timeline_section(tree, named_index)
     hoh_modal_html = _build_hoh_modal()
     skill_explorer_modal_html = _build_skill_explorer_modal()
+    hero_medallion_html = build_hero_medallion(handle, skills)
 
     # OG image tag (vector SVG for social crawlers). Pre-named/demoted skills
     # have no OG card, so pick the first *named* (≥2★) skill; omit the tag
@@ -1096,6 +1142,7 @@ def build_profile_page(handle: str, skills: list, named_index: dict | None = Non
 
       <!-- ─── PROFILE HERO ─── -->
       <div class="profile-hero">
+        {hero_medallion_html}
         <h1 class="profile-handle">{safe_handle}</h1>
         <div class="profile-meta">
           {skill_count} named skill{'s' if skill_count != 1 else ''} · highest rank {highest_level}


### PR DESCRIPTION
## Yggdrasil II · Wave 1.5 — N-13 medallion propagation

Founder nitpick cluster (N-13): propagate the canonical medallion (gold-wreath-framed GitHub avatar + AOV4 rank stamp) from the proven `plaque.js`/`docs/named/` reference to the surfaces still missing it, and refine the wreath art. Opus solo verify→remediate→sonnet-review; **reviewer verdict PASS (severity none, 0 failures).**

### Audit → outcome (7 items)
1. **Wreath art** (partial→**fixed**, `0b24c45fd`): redrew `origin-wreath-gold.svg` leaf glyph as a veined lanceolate blade (evenodd midrib cutout) paired with a companion leaf per node — reads as recognizable paired laurel. 10 placement transforms unchanged; token-tinted gold. Propagates everywhere by path.
2. **Profile name↔badge swap + larger badge** (**pre-done in W1e** `78d485ef9`): `generateProfilePages.py` already emits `plaque-orb--medallion` + wreathed avatar. Confirmed, no action.
3. **Profile wreath+avatar** (**pre-done in W1e**): all 2★+ profiles carry the medallion; 1★ redacted contributors correctly suppressed per the redaction guard.
4. **Profile hero centered avatar** (missing→**fixed**, `3e279e4d0`): added `build_hero_medallion()` routing the highest-ranked non-redacted skill through the shared `_field_orb`+`_field_avatar` path; centered 96px wreathed medallion in each profile hero. 49 pages regenerated.
5. **/heroes AOV4 badge** (partial→**fixed**, `0dfcb5ae0`): W1a landed avatars but no wreath/stamp; now `heroRankStampHtml()` routes the crest stamp through the shared medallion path, `:has(.plaque-orb--medallion)` sizes the seal and hides the legacy glyph fallback.
6. **Named contributors** (**done** — reference implementation): 153 medallion orbs, 119 wreaths, 0 deprecated red origin.
7. **Skill graph** (**done**): loads 243 real skills (live `gaia.json` 200, not fallback); medallion is plaque-scoped, correctly absent from the canvas. `mutedRgb` nitpick already resolved on staging (valid `148,163,184` fallback).

### Root principle honored
Every surface routes through the shared plaque/medallion path (`window.plaque._fields` on JS; `_field_orb`/`_field_avatar` in Python) or the shared wreath SVG — **no bespoke per-surface re-implementation.** Homepage untouched. Tokens only, no hex fallbacks introduced.

### Entrypoints
No new pages/sections; medallion propagation onto existing reachable surfaces (`/u/*` profiles, `/heroes`). Nav/footer/mounts unchanged.

### Verification
- Sonnet adversarial reviewer (reject-by-default): all 7 items DONE, Playwright 1280+390, PASS.
- Authorship: all 3 commits `Marcus Rafael B. Tiongson <153011150+mbtiongson1@users.noreply.github.com>`.
- Diff (52 files, +210/-5): zero banned words, zero raw hex, zero dead-enum reads introduced.

Part of EPIC #1002 · #998.
