### PR TITLE
design(ygg2-w2a): N-8 OG card /impeccable reshape — computeBranch dispatch + AOV medallion + all-rank

### DIFF
--- a/docs/og/Manavarya09/design-extract.svg
+++ b/docs/og/Manavarya09/design-extract.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /design-extract">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/design-extract</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-Manavarya09-design-extract"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-Manavarya09-design-extract" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-Manavarya09-design-extract)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-Manavarya09-design-extract)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="226.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="77" fill="#ebe5d4" dominant-baseline="middle">/design-extract</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Token Scavenger'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@Manavarya09</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/addy-osmani/agent-skills.svg
+++ b/docs/og/addy-osmani/agent-skills.svg
@@ -1,53 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--stellar" data-plate="V" data-branch="suite" data-level="5"
-  aria-label="Ultimate · 5★ — Stellar plate">
-  <defs>
-    <radialGradient id="st-core-addy-osmani-agent-skills" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#fde2a4" stop-opacity="1"/>
-      <stop offset="55%" stop-color="#f59e0b" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--suite" data-branch="suite" data-level="5"
+  data-plate-class="STELLAR"
+  aria-label="Ultimate · 5★ — STELLAR plate for /agent-skills">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Ultimate · 5★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Two concentric orbital tracks -->
-  <circle cx="880" cy="290" r="90" fill="none" stroke="#ebe5d4" stroke-opacity="0.45" stroke-width="1" stroke-dasharray="6 4"/><circle cx="880" cy="290" r="150" fill="none" stroke="#ebe5d4" stroke-opacity="0.32" stroke-width="1" stroke-dasharray="8 6"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-addy-osmani-agent-skills"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-agent-skills" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-agent-skills)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-agent-skills)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Companion dots on the orbits -->
-  <circle cx="957.9" cy="245.0" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="796.9" cy="324.4" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="955.0" cy="419.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="744.9" cy="224.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
-  <!-- Main-sequence disc -->
-  <circle cx="880" cy="290" r="72" fill="url(#st-core-addy-osmani-agent-skills)"/>
-  <circle cx="880" cy="290" r="42" fill="#f59e0b"/>
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/agent-skills</text>
 
-  <!-- Bayer designation (catalogue prefix) -->
-  <text x="60" y="212" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">α</text>
-
-  <!-- Slash-skill slug -->
-  <text x="60" y="268" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="80" fill="#ebe5d4" dominant-baseline="middle">/agent-skills</text>
-
-  <!-- Title kicker -->
-  <text x="60" y="316" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Agent Skills'</text>
 
   <!-- Discoverer signature -->

--- a/docs/og/addy-osmani/code-review-and-quality.svg
+++ b/docs/og/addy-osmani/code-review-and-quality.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /code-review-and-quality">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/code-review-and-quality</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-addy-osmani-code-review-and-quality"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-code-review-and-quality" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-code-review-and-quality)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-code-review-and-quality)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="244.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="48" fill="#ebe5d4" dominant-baseline="middle">/code-review-and-quality</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Code Review and Quality'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@addy-osmani</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 53.1</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/addy-osmani/code-simplification.svg
+++ b/docs/og/addy-osmani/code-simplification.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /code-simplification">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/code-simplification</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-addy-osmani-code-simplification"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-code-simplification" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-code-simplification)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-code-simplification)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/code-simplification</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Code Simplification'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@addy-osmani</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 53.1</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/addy-osmani/incremental-implementation.svg
+++ b/docs/og/addy-osmani/incremental-implementation.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /incremental-implementation">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/incremental-implementation</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-addy-osmani-incremental-implementation"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-incremental-implementation" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-incremental-implementation)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-incremental-implementation)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="247.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="43" fill="#ebe5d4" dominant-baseline="middle">/incremental-implementation</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Incremental Implementation'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@addy-osmani</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 53.1</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/addy-osmani/performance-optimization.svg
+++ b/docs/og/addy-osmani/performance-optimization.svg
@@ -1,63 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--singularity" data-plate="IV" data-branch="unique" data-level="4"
-  aria-label="Unique · 4★ — Singularity plate">
-  <defs>
-    <radialGradient id="bh-void-addy-osmani-performance-optimization" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="85%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="100%" stop-color="#0e0d20" stop-opacity="1"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /performance-optimization">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Lensing-displaced stellar field -->
-  <circle cx="195" cy="215" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="180" y1="200" x2="195" y2="215" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="560" cy="200" r="1.6" fill="#ebe5d4" fill-opacity="0.5"/>
-  <circle cx="545" cy="365" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="560" y1="380" x2="545" y2="365" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="180" cy="400" r="1.6" fill="#ebe5d4" fill-opacity="0.45"/>
-  <circle cx="300" cy="130" r="1.6" fill="#ebe5d4" fill-opacity="0.4"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-addy-osmani-performance-optimization"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-performance-optimization" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-performance-optimization)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-performance-optimization)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Accretion-disk hairline ring (thin violet) -->
-  <circle cx="360" cy="290" r="96" fill="none" stroke="#7c3aed"
-    stroke-opacity="0.85" stroke-width="1.4"/>
-  <circle cx="360" cy="290" r="93.0" fill="none"
-    stroke="#7c3aed" stroke-opacity="0.35" stroke-width="0.6"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="245.5" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
-  <!-- The void itself: same colour as the page, slightly darker, no glyph -->
-  <circle cx="360" cy="290" r="80" fill="url(#bh-void-addy-osmani-performance-optimization)"/>
-
-  <!-- BH designation (catalogue prefix) -->
-  <text x="640" y="222" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">BH-</text>
-
-  <!-- Slash-skill slug -->
-  <text x="640" y="286" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="46" fill="#ebe5d4" dominant-baseline="middle">/performance-optimization</text>
 
-  <!-- Title kicker -->
-  <text x="640" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Perf Loop'</text>
 
   <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@addy-osmani</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
-  <!-- Marginal magnitude band — MAG ∞ -->
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 83.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/addy-osmani/planning-and-task-breakdown.svg
+++ b/docs/og/addy-osmani/planning-and-task-breakdown.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /planning-and-task-breakdown">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/planning-and-task-breakdown</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-addy-osmani-planning-and-task-breakdown"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-planning-and-task-breakdown" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-planning-and-task-breakdown)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-planning-and-task-breakdown)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="248.6" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="41" fill="#ebe5d4" dominant-baseline="middle">/planning-and-task-breakdown</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Planning and Task Breakdown'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@addy-osmani</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 53.1</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/addy-osmani/shipping-and-launch.svg
+++ b/docs/og/addy-osmani/shipping-and-launch.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /shipping-and-launch">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/shipping-and-launch</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-addy-osmani-shipping-and-launch"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-shipping-and-launch" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-shipping-and-launch)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-shipping-and-launch)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/shipping-and-launch</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Shipping and Launch'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@addy-osmani</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 53.1</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/addy-osmani/spec-driven-development.svg
+++ b/docs/og/addy-osmani/spec-driven-development.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /spec-driven-development">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/spec-driven-development</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-addy-osmani-spec-driven-development"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-spec-driven-development" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-spec-driven-development)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-spec-driven-development)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="244.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="48" fill="#ebe5d4" dominant-baseline="middle">/spec-driven-development</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Spec-Driven Development'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@addy-osmani</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 53.1</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/addy-osmani/test-driven-development.svg
+++ b/docs/og/addy-osmani/test-driven-development.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /test-driven-development">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/test-driven-development</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-addy-osmani-test-driven-development"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-test-driven-development" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-test-driven-development)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-test-driven-development)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="244.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="48" fill="#ebe5d4" dominant-baseline="middle">/test-driven-development</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Red-Green Oath'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@addy-osmani</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/anthropic/pptx.svg
+++ b/docs/og/anthropic/pptx.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /pptx">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/pptx</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-anthropic-pptx"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-anthropic-pptx" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-anthropic-pptx)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-anthropic-pptx)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/pptx</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Slide Artisan'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@anthropic</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/anthropic/skill-creator.svg
+++ b/docs/og/anthropic/skill-creator.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /skill-creator">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/skill-creator</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-anthropic-skill-creator"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-anthropic-skill-creator" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-anthropic-skill-creator)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-anthropic-skill-creator)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/skill-creator</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Skill Forger&#x27;s Art'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@anthropic</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 90.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/bradautomates/claude-video.svg
+++ b/docs/og/bradautomates/claude-video.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /claude-video">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/claude-video</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-bradautomates-claude-video"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-bradautomates-claude-video" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-bradautomates-claude-video)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-bradautomates-claude-video)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/claude-video</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Temporal Eye'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@bradautomates</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 37.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/browser-use/browser-harness.svg
+++ b/docs/og/browser-use/browser-harness.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /browser-harness">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/browser-harness</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-browser-use-browser-harness"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-browser-use-browser-harness" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-browser-use-browser-harness)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-browser-use-browser-harness)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/browser-harness</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Dom Whispering'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@browser-use</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 73.6</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/devin-ai/autonomous-swe.svg
+++ b/docs/og/devin-ai/autonomous-swe.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /autonomous-swe">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/autonomous-swe</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-devin-ai-autonomous-swe"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-devin-ai-autonomous-swe" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-devin-ai-autonomous-swe)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-devin-ai-autonomous-swe)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="226.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="77" fill="#ebe5d4" dominant-baseline="middle">/autonomous-swe</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Codebreaker&#x27;s Will'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@devin-ai</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 30.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/firecrawl/firecrawl-build-interact.svg
+++ b/docs/og/firecrawl/firecrawl-build-interact.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /firecrawl-build-interact">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-build-interact</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-firecrawl-firecrawl-build-interact"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-build-interact" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-build-interact)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-build-interact)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="245.5" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="46" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-build-interact</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Firecrawl Interact'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@firecrawl</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 73.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/firecrawl/firecrawl-build-onboarding.svg
+++ b/docs/og/firecrawl/firecrawl-build-onboarding.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /firecrawl-build-onboarding">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-build-onboarding</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-firecrawl-firecrawl-build-onboarding"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-build-onboarding" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-build-onboarding)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-build-onboarding)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="247.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="43" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-build-onboarding</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Firecrawl Onboarding'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@firecrawl</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 73.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/firecrawl/firecrawl-build-scrape.svg
+++ b/docs/og/firecrawl/firecrawl-build-scrape.svg
@@ -1,63 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--singularity" data-plate="IV" data-branch="unique" data-level="4"
-  aria-label="Unique · 4★ — Singularity plate">
-  <defs>
-    <radialGradient id="bh-void-firecrawl-firecrawl-build-scrape" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="85%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="100%" stop-color="#0e0d20" stop-opacity="1"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /firecrawl-build-scrape">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Lensing-displaced stellar field -->
-  <circle cx="195" cy="215" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="180" y1="200" x2="195" y2="215" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="560" cy="200" r="1.6" fill="#ebe5d4" fill-opacity="0.5"/>
-  <circle cx="545" cy="365" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="560" y1="380" x2="545" y2="365" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="180" cy="400" r="1.6" fill="#ebe5d4" fill-opacity="0.45"/>
-  <circle cx="300" cy="130" r="1.6" fill="#ebe5d4" fill-opacity="0.4"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-firecrawl-firecrawl-build-scrape"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-build-scrape" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-build-scrape)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-build-scrape)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Accretion-disk hairline ring (thin violet) -->
-  <circle cx="360" cy="290" r="96" fill="none" stroke="#7c3aed"
-    stroke-opacity="0.85" stroke-width="1.4"/>
-  <circle cx="360" cy="290" r="93.0" fill="none"
-    stroke="#7c3aed" stroke-opacity="0.35" stroke-width="0.6"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="243.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
-  <!-- The void itself: same colour as the page, slightly darker, no glyph -->
-  <circle cx="360" cy="290" r="80" fill="url(#bh-void-firecrawl-firecrawl-build-scrape)"/>
-
-  <!-- BH designation (catalogue prefix) -->
-  <text x="640" y="222" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">BH-</text>
-
-  <!-- Slash-skill slug -->
-  <text x="640" y="286" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="50" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-build-scrape</text>
 
-  <!-- Title kicker -->
-  <text x="640" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Firecrawl Scrape'</text>
 
   <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@firecrawl</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
-  <!-- Marginal magnitude band — MAG ∞ -->
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 133.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/firecrawl/firecrawl-build-search.svg
+++ b/docs/og/firecrawl/firecrawl-build-search.svg
@@ -1,63 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--singularity" data-plate="IV" data-branch="unique" data-level="4"
-  aria-label="Unique · 4★ — Singularity plate">
-  <defs>
-    <radialGradient id="bh-void-firecrawl-firecrawl-build-search" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="85%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="100%" stop-color="#0e0d20" stop-opacity="1"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /firecrawl-build-search">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Lensing-displaced stellar field -->
-  <circle cx="195" cy="215" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="180" y1="200" x2="195" y2="215" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="560" cy="200" r="1.6" fill="#ebe5d4" fill-opacity="0.5"/>
-  <circle cx="545" cy="365" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="560" y1="380" x2="545" y2="365" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="180" cy="400" r="1.6" fill="#ebe5d4" fill-opacity="0.45"/>
-  <circle cx="300" cy="130" r="1.6" fill="#ebe5d4" fill-opacity="0.4"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-firecrawl-firecrawl-build-search"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-build-search" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-build-search)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-build-search)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Accretion-disk hairline ring (thin violet) -->
-  <circle cx="360" cy="290" r="96" fill="none" stroke="#7c3aed"
-    stroke-opacity="0.85" stroke-width="1.4"/>
-  <circle cx="360" cy="290" r="93.0" fill="none"
-    stroke="#7c3aed" stroke-opacity="0.35" stroke-width="0.6"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="243.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
-  <!-- The void itself: same colour as the page, slightly darker, no glyph -->
-  <circle cx="360" cy="290" r="80" fill="url(#bh-void-firecrawl-firecrawl-build-search)"/>
-
-  <!-- BH designation (catalogue prefix) -->
-  <text x="640" y="222" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">BH-</text>
-
-  <!-- Slash-skill slug -->
-  <text x="640" y="286" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="50" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-build-search</text>
 
-  <!-- Title kicker -->
-  <text x="640" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Firecrawl Search'</text>
 
   <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@firecrawl</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
-  <!-- Marginal magnitude band — MAG ∞ -->
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 107.1</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/firecrawl/firecrawl-research-index.svg
+++ b/docs/og/firecrawl/firecrawl-research-index.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /firecrawl-research-index">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-research-index</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-firecrawl-firecrawl-research-index"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-research-index" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-research-index)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-research-index)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="245.5" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="46" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-research-index</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Firecrawl Research Index'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@firecrawl</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 73.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/firecrawl/firecrawl-skills.svg
+++ b/docs/og/firecrawl/firecrawl-skills.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /firecrawl-skills">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-skills</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-firecrawl-firecrawl-skills"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-skills" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-skills)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-skills)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="231.8" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="68" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-skills</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Web Infuser'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@firecrawl</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 223.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/gaia-research/skill-ci-churn.svg
+++ b/docs/og/gaia-research/skill-ci-churn.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /skill-ci-churn">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/skill-ci-churn</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-gaia-research-skill-ci-churn"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gaia-research-skill-ci-churn" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gaia-research-skill-ci-churn)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gaia-research-skill-ci-churn)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="226.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="77" fill="#ebe5d4" dominant-baseline="middle">/skill-ci-churn</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'CI Churn Analysis'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@gaia-research</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 41.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/gaia-research/skill-fuse.svg
+++ b/docs/og/gaia-research/skill-fuse.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /skill-fuse">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/skill-fuse</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-gaia-research-skill-fuse"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gaia-research-skill-fuse" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gaia-research-skill-fuse)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gaia-research-skill-fuse)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/skill-fuse</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Skill Fusion'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@gaia-research</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 41.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/benchmark-models.svg
+++ b/docs/og/garrytan/benchmark-models.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /benchmark-models">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/benchmark-models</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-benchmark-models"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-benchmark-models" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-benchmark-models)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-benchmark-models)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="231.8" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="68" fill="#ebe5d4" dominant-baseline="middle">/benchmark-models</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Benchmark Models — LLM Performance Profiling'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/benchmark.svg
+++ b/docs/og/garrytan/benchmark.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /benchmark">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/benchmark</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-benchmark"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-benchmark" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-benchmark)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-benchmark)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/benchmark</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Benchmark'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/browse.svg
+++ b/docs/og/garrytan/browse.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /browse">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/browse</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-browse"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-browse" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-browse)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-browse)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/browse</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Browse — Directed Browser Navigation'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 88.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/canary.svg
+++ b/docs/og/garrytan/canary.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /canary">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/canary</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-canary"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-canary" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-canary)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-canary)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/canary</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Canary'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/careful.svg
+++ b/docs/og/garrytan/careful.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /careful">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/careful</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-careful"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-careful" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-careful)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-careful)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/careful</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Careful — Conservative Execution Mode'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 66.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/codex.svg
+++ b/docs/og/garrytan/codex.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /codex">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/codex</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-codex"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-codex" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-codex)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-codex)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/codex</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Codex — Multi-Agent Code Debate'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/context-restore.svg
+++ b/docs/og/garrytan/context-restore.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /context-restore">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/context-restore</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-context-restore"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-context-restore" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-context-restore)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-context-restore)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/context-restore</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Context Restore — Session State Recovery'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/context-save.svg
+++ b/docs/og/garrytan/context-save.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /context-save">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/context-save</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-context-save"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-context-save" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-context-save)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-context-save)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/context-save</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Context Save — Session State Snapshot'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/cso.svg
+++ b/docs/og/garrytan/cso.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /cso">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/cso</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-cso"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-cso" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-cso)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-cso)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/cso</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Chief Security Officer Mode'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/design-consultation.svg
+++ b/docs/og/garrytan/design-consultation.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /design-consultation">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/design-consultation</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-design-consultation"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-design-consultation" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-design-consultation)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-design-consultation)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/design-consultation</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Design Consultation'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/design-html.svg
+++ b/docs/og/garrytan/design-html.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /design-html">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/design-html</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-design-html"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-design-html" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-design-html)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-design-html)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/design-html</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Design to Production HTML'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/design-review.svg
+++ b/docs/og/garrytan/design-review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /design-review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/design-review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-design-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-design-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-design-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-design-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/design-review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Design Review — UX Audit Pass'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/design-shotgun.svg
+++ b/docs/og/garrytan/design-shotgun.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /design-shotgun">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/design-shotgun</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-design-shotgun"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-design-shotgun" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-design-shotgun)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-design-shotgun)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="226.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="77" fill="#ebe5d4" dominant-baseline="middle">/design-shotgun</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Design Shotgun'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/devex-review.svg
+++ b/docs/og/garrytan/devex-review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /devex-review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/devex-review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-devex-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-devex-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-devex-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-devex-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/devex-review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack DevEx Review — Developer Experience Audit'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/document-generate.svg
+++ b/docs/og/garrytan/document-generate.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /document-generate">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/document-generate</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-document-generate"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-document-generate" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-document-generate)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-document-generate)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="234.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="64" fill="#ebe5d4" dominant-baseline="middle">/document-generate</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Diataxis Doc Generator'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/document-release.svg
+++ b/docs/og/garrytan/document-release.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /document-release">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/document-release</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-document-release"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-document-release" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-document-release)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-document-release)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="231.8" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="68" fill="#ebe5d4" dominant-baseline="middle">/document-release</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Document Release — Release Note Authoring'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/freeze.svg
+++ b/docs/og/garrytan/freeze.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /freeze">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/freeze</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-freeze"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-freeze" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-freeze)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-freeze)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/freeze</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Freeze — Change Freeze Enforcement'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/garrytan.svg
+++ b/docs/og/garrytan/garrytan.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /garrytan">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/garrytan</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-garrytan"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-garrytan" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-garrytan)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-garrytan)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/garrytan</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Founder Mode Autoplan'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 156.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/gstack-upgrade.svg
+++ b/docs/og/garrytan/gstack-upgrade.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /gstack-upgrade">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/gstack-upgrade</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-gstack-upgrade"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-gstack-upgrade" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-gstack-upgrade)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-gstack-upgrade)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="226.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="77" fill="#ebe5d4" dominant-baseline="middle">/gstack-upgrade</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Upgrade — Workspace Dependency Upgrade'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/gstack.svg
+++ b/docs/og/garrytan/gstack.svg
@@ -1,53 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--stellar" data-plate="V" data-branch="suite" data-level="5"
-  aria-label="Ultimate · 5★ — Stellar plate">
-  <defs>
-    <radialGradient id="st-core-garrytan-gstack" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#fde2a4" stop-opacity="1"/>
-      <stop offset="55%" stop-color="#f59e0b" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--suite" data-branch="suite" data-level="5"
+  data-plate-class="STELLAR"
+  aria-label="Ultimate · 5★ — STELLAR plate for /gstack">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Ultimate · 5★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Two concentric orbital tracks -->
-  <circle cx="880" cy="290" r="90" fill="none" stroke="#ebe5d4" stroke-opacity="0.45" stroke-width="1" stroke-dasharray="6 4"/><circle cx="880" cy="290" r="150" fill="none" stroke="#ebe5d4" stroke-opacity="0.32" stroke-width="1" stroke-dasharray="8 6"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-garrytan-gstack"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-gstack" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-gstack)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-gstack)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Companion dots on the orbits -->
-  <circle cx="957.9" cy="245.0" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="796.9" cy="324.4" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="955.0" cy="419.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="744.9" cy="224.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
-  <!-- Main-sequence disc -->
-  <circle cx="880" cy="290" r="72" fill="url(#st-core-garrytan-gstack)"/>
-  <circle cx="880" cy="290" r="42" fill="#f59e0b"/>
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/gstack</text>
 
-  <!-- Bayer designation (catalogue prefix) -->
-  <text x="60" y="212" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">α</text>
-
-  <!-- Slash-skill slug -->
-  <text x="60" y="268" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="80" fill="#ebe5d4" dominant-baseline="middle">/gstack</text>
-
-  <!-- Title kicker -->
-  <text x="60" y="316" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack — Garry Tan&#x27;s Full-Stack Agent Suite'</text>
 
   <!-- Discoverer signature -->

--- a/docs/og/garrytan/guard.svg
+++ b/docs/og/garrytan/guard.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /guard">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/guard</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-guard"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-guard" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-guard)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-guard)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/guard</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Guard — Safety Guardrail Enforcement'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/health.svg
+++ b/docs/og/garrytan/health.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /health">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/health</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-health"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-health" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-health)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-health)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/health</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Health — Automated Test Suite Runner'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/investigate.svg
+++ b/docs/og/garrytan/investigate.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /investigate">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/investigate</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-investigate"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-investigate" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-investigate)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-investigate)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/investigate</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Investigate'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/land-and-deploy.svg
+++ b/docs/og/garrytan/land-and-deploy.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /land-and-deploy">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/land-and-deploy</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-land-and-deploy"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-land-and-deploy" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-land-and-deploy)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-land-and-deploy)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/land-and-deploy</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Land and Deploy'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/landing-report.svg
+++ b/docs/og/garrytan/landing-report.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /landing-report">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/landing-report</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-landing-report"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-landing-report" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-landing-report)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-landing-report)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="226.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="77" fill="#ebe5d4" dominant-baseline="middle">/landing-report</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Landing Report — Project Status Summary'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/learn.svg
+++ b/docs/og/garrytan/learn.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /learn">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/learn</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-learn"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-learn" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-learn)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-learn)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/learn</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Learn — Persistent Memory Management'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/make-pdf.svg
+++ b/docs/og/garrytan/make-pdf.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /make-pdf">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/make-pdf</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-make-pdf"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-make-pdf" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-make-pdf)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-make-pdf)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/make-pdf</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Make PDF — Formatted Output Generator'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/office-hours.svg
+++ b/docs/og/garrytan/office-hours.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /office-hours">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/office-hours</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-office-hours"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-office-hours" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-office-hours)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-office-hours)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/office-hours</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'YC Office Hours'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 66.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/open-gstack-browser.svg
+++ b/docs/og/garrytan/open-gstack-browser.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /open-gstack-browser">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/open-gstack-browser</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-open-gstack-browser"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-open-gstack-browser" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-open-gstack-browser)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-open-gstack-browser)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/open-gstack-browser</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Open Browser — Browser Session Launch'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/pair-agent.svg
+++ b/docs/og/garrytan/pair-agent.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /pair-agent">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/pair-agent</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-pair-agent"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-pair-agent" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-pair-agent)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-pair-agent)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/pair-agent</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Pair Agent — MCP Tool Integration'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/plan-ceo-review.svg
+++ b/docs/og/garrytan/plan-ceo-review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /plan-ceo-review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/plan-ceo-review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-plan-ceo-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-plan-ceo-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-plan-ceo-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-plan-ceo-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/plan-ceo-review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'CEO Plan Review'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/plan-design-review.svg
+++ b/docs/og/garrytan/plan-design-review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /plan-design-review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/plan-design-review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-plan-design-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-plan-design-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-plan-design-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-plan-design-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="236.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="61" fill="#ebe5d4" dominant-baseline="middle">/plan-design-review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Design Plan Review'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/plan-devex-review.svg
+++ b/docs/og/garrytan/plan-devex-review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /plan-devex-review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/plan-devex-review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-plan-devex-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-plan-devex-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-plan-devex-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-plan-devex-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="234.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="64" fill="#ebe5d4" dominant-baseline="middle">/plan-devex-review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Developer Experience Review'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/plan-eng-review.svg
+++ b/docs/og/garrytan/plan-eng-review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /plan-eng-review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/plan-eng-review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-plan-eng-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-plan-eng-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-plan-eng-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-plan-eng-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/plan-eng-review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Engineering Plan Review'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 66.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/plan-tune.svg
+++ b/docs/og/garrytan/plan-tune.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /plan-tune">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/plan-tune</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-plan-tune"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-plan-tune" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-plan-tune)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-plan-tune)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/plan-tune</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Plan Tune — Prompt Refinement Pass'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/qa-only.svg
+++ b/docs/og/garrytan/qa-only.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /qa-only">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/qa-only</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-qa-only"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-qa-only" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-qa-only)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-qa-only)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/qa-only</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack QA Only — Focused E2E Test Run'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/qa.svg
+++ b/docs/og/garrytan/qa.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /qa">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/qa</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-qa"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-qa" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-qa)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-qa)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/qa</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack QA'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/retro.svg
+++ b/docs/og/garrytan/retro.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /retro">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/retro</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-retro"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-retro" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-retro)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-retro)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/retro</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Retro — Sprint Retrospective Report'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 81.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/review.svg
+++ b/docs/og/garrytan/review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Code Review'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/scrape.svg
+++ b/docs/og/garrytan/scrape.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /scrape">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/scrape</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-scrape"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-scrape" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-scrape)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-scrape)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/scrape</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Scrape — Structured Web Extraction'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/setup-browser-cookies.svg
+++ b/docs/og/garrytan/setup-browser-cookies.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /setup-browser-cookies">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/setup-browser-cookies</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-setup-browser-cookies"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-setup-browser-cookies" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-setup-browser-cookies)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-setup-browser-cookies)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="241.1" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="53" fill="#ebe5d4" dominant-baseline="middle">/setup-browser-cookies</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Setup Browser Cookies — Auth Cookie Injection'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/setup-deploy.svg
+++ b/docs/og/garrytan/setup-deploy.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /setup-deploy">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/setup-deploy</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-setup-deploy"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-setup-deploy" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-setup-deploy)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-setup-deploy)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/setup-deploy</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Setup Deploy — Deployment Environment Init'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/setup-gbrain.svg
+++ b/docs/og/garrytan/setup-gbrain.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /setup-gbrain">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/setup-gbrain</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-setup-gbrain"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-setup-gbrain" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-setup-gbrain)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-setup-gbrain)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/setup-gbrain</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Setup GBrain — Knowledge Base Initialisation'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/ship.svg
+++ b/docs/og/garrytan/ship.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /ship">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/ship</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-ship"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-ship" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-ship)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-ship)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/ship</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Ship'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/skillify.svg
+++ b/docs/og/garrytan/skillify.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /skillify">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/skillify</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-skillify"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-skillify" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-skillify)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-skillify)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/skillify</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Skillify — Skill Authoring Pipeline'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/sync-gbrain.svg
+++ b/docs/og/garrytan/sync-gbrain.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /sync-gbrain">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/sync-gbrain</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-sync-gbrain"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-sync-gbrain" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-sync-gbrain)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-sync-gbrain)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/sync-gbrain</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Sync GBrain — Knowledge Base Sync'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/unfreeze.svg
+++ b/docs/og/garrytan/unfreeze.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /unfreeze">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/unfreeze</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-garrytan-unfreeze"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-unfreeze" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-unfreeze)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-unfreeze)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/unfreeze</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Gstack Unfreeze — Change Freeze Lift'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/getagentseal/codeburn.svg
+++ b/docs/og/getagentseal/codeburn.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /codeburn">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/codeburn</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-getagentseal-codeburn"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-getagentseal-codeburn" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-getagentseal-codeburn)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-getagentseal-codeburn)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/codeburn</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Ledger of Light'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@getagentseal</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/gsd-build/discuss-phase.svg
+++ b/docs/og/gsd-build/discuss-phase.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /discuss-phase">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/discuss-phase</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-gsd-build-discuss-phase"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gsd-build-discuss-phase" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gsd-build-discuss-phase)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gsd-build-discuss-phase)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/discuss-phase</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'GSD Discuss Phase'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@gsd-build</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 52.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/gsd-build/execute-phase.svg
+++ b/docs/og/gsd-build/execute-phase.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /execute-phase">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/execute-phase</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-gsd-build-execute-phase"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gsd-build-execute-phase" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gsd-build-execute-phase)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gsd-build-execute-phase)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/execute-phase</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'GSD Execute Phase'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@gsd-build</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 52.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/gsd-build/get-shit-done.svg
+++ b/docs/og/gsd-build/get-shit-done.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /get-shit-done">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/get-shit-done</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-gsd-build-get-shit-done"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gsd-build-get-shit-done" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gsd-build-get-shit-done)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gsd-build-get-shit-done)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/get-shit-done</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Get Shit Done'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@gsd-build</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 202.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/gsd-build/plan-phase.svg
+++ b/docs/og/gsd-build/plan-phase.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /plan-phase">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/plan-phase</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-gsd-build-plan-phase"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gsd-build-plan-phase" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gsd-build-plan-phase)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gsd-build-plan-phase)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/plan-phase</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'GSD Plan Phase'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@gsd-build</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 52.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/gsd-build/ship.svg
+++ b/docs/og/gsd-build/ship.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /ship">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/ship</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-gsd-build-ship"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gsd-build-ship" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gsd-build-ship)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gsd-build-ship)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/ship</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'GSD Ship Phase'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@gsd-build</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 52.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/gsd-build/verify-work.svg
+++ b/docs/og/gsd-build/verify-work.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /verify-work">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/verify-work</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-gsd-build-verify-work"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gsd-build-verify-work" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gsd-build-verify-work)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gsd-build-verify-work)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/verify-work</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'GSD Verify Work'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@gsd-build</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 52.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/huggingface/semantic-cache.svg
+++ b/docs/og/huggingface/semantic-cache.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /semantic-cache">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/semantic-cache</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-huggingface-semantic-cache"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-huggingface-semantic-cache" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-huggingface-semantic-cache)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-huggingface-semantic-cache)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="226.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="77" fill="#ebe5d4" dominant-baseline="middle">/semantic-cache</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Neural Memory'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@huggingface</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/karpathy/autoresearch.svg
+++ b/docs/og/karpathy/autoresearch.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /autoresearch">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/autoresearch</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-karpathy-autoresearch"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-karpathy-autoresearch" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-karpathy-autoresearch)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-karpathy-autoresearch)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/autoresearch</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Scholar&#x27;s Compass'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@karpathy</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/laravel/upgrade-laravel-v13.svg
+++ b/docs/og/laravel/upgrade-laravel-v13.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /upgrade-laravel-v13">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/upgrade-laravel-v13</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-laravel-upgrade-laravel-v13"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-laravel-upgrade-laravel-v13" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-laravel-upgrade-laravel-v13)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-laravel-upgrade-laravel-v13)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/upgrade-laravel-v13</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Versionist&#x27;s Trial'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@laravel</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/martin-stepanoski/nielsen-heuristics-audit.svg
+++ b/docs/og/martin-stepanoski/nielsen-heuristics-audit.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /nielsen-heuristics-audit">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/nielsen-heuristics-audit</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-martin-stepanoski-nielsen-heuristics-audit"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-martin-stepanoski-nielsen-heuristics-audit" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-martin-stepanoski-nielsen-heuristics-audit)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-martin-stepanoski-nielsen-heuristics-audit)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="245.5" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="46" fill="#ebe5d4" dominant-baseline="middle">/nielsen-heuristics-audit</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Ten Laws of Sight'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@martin-stepanoski</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 94.9</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/caveman.svg
+++ b/docs/og/mattpocock/caveman.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /caveman">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/caveman</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-caveman"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-caveman" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-caveman)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-caveman)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/caveman</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Caveman Console'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 30.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/diagnose.svg
+++ b/docs/og/mattpocock/diagnose.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /diagnose">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/diagnose</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-diagnose"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-diagnose" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-diagnose)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-diagnose)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/diagnose</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Disciplined Diagnosis Loop'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 90.4</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/edit-article.svg
+++ b/docs/og/mattpocock/edit-article.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /edit-article">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/edit-article</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-edit-article"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-edit-article" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-edit-article)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-edit-article)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/edit-article</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Section-by-Section Rewrite'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 90.4</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/engineering.svg
+++ b/docs/og/mattpocock/engineering.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /engineering">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/engineering</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-engineering"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-engineering" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-engineering)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-engineering)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/engineering</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Matt Pocock Engineering Discipline'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 270.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/grill-me.svg
+++ b/docs/og/mattpocock/grill-me.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /grill-me">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/grill-me</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-grill-me"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-grill-me" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-grill-me)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-grill-me)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/grill-me</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Relentless Interviewer'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/grill-with-docs.svg
+++ b/docs/og/mattpocock/grill-with-docs.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /grill-with-docs">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/grill-with-docs</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-grill-with-docs"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-grill-with-docs" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-grill-with-docs)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-grill-with-docs)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/grill-with-docs</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Domain Sovereign'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/handoff.svg
+++ b/docs/og/mattpocock/handoff.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /handoff">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/handoff</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-handoff"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-handoff" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-handoff)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-handoff)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/handoff</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Handoff Protocol'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/improve-codebase-architecture.svg
+++ b/docs/og/mattpocock/improve-codebase-architecture.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /improve-codebase-architecture">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/improve-codebase-architecture</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-improve-codebase-architecture"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-improve-codebase-architecture" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-improve-codebase-architecture)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-improve-codebase-architecture)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="249.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="40" fill="#ebe5d4" dominant-baseline="middle">/improve-codebase-architecture</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Depth Seeker'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 45.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/obsidian-vault.svg
+++ b/docs/og/mattpocock/obsidian-vault.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /obsidian-vault">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/obsidian-vault</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-obsidian-vault"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-obsidian-vault" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-obsidian-vault)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-obsidian-vault)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="226.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="77" fill="#ebe5d4" dominant-baseline="middle">/obsidian-vault</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Obsidian Vault Mapper'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 90.4</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/personal.svg
+++ b/docs/og/mattpocock/personal.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /personal">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/personal</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-personal"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-personal" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-personal)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-personal)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/personal</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Matt Pocock Personal Suite'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 60.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/productivity.svg
+++ b/docs/og/mattpocock/productivity.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /productivity">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/productivity</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-productivity"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-productivity" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-productivity)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-productivity)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/productivity</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Matt Pocock Productivity Suite'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 120.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/prototype.svg
+++ b/docs/og/mattpocock/prototype.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /prototype">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/prototype</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-prototype"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-prototype" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-prototype)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-prototype)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/prototype</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Prototyping Engine'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 41.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/setup-matt-pocock-skills.svg
+++ b/docs/og/mattpocock/setup-matt-pocock-skills.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /setup-matt-pocock-skills">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/setup-matt-pocock-skills</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-setup-matt-pocock-skills"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-setup-matt-pocock-skills" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-setup-matt-pocock-skills)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-setup-matt-pocock-skills)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="245.5" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="46" fill="#ebe5d4" dominant-baseline="middle">/setup-matt-pocock-skills</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Environment Scaffolder'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 56.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/skills.svg
+++ b/docs/og/mattpocock/skills.svg
@@ -1,53 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--stellar" data-plate="V" data-branch="suite" data-level="5"
-  aria-label="Ultimate · 5★ — Stellar plate">
-  <defs>
-    <radialGradient id="st-core-mattpocock-skills" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#fde2a4" stop-opacity="1"/>
-      <stop offset="55%" stop-color="#f59e0b" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--suite" data-branch="suite" data-level="5"
+  data-plate-class="STELLAR"
+  aria-label="Ultimate · 5★ — STELLAR plate for /skills">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Ultimate · 5★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Two concentric orbital tracks -->
-  <circle cx="880" cy="290" r="90" fill="none" stroke="#ebe5d4" stroke-opacity="0.45" stroke-width="1" stroke-dasharray="6 4"/><circle cx="880" cy="290" r="150" fill="none" stroke="#ebe5d4" stroke-opacity="0.32" stroke-width="1" stroke-dasharray="8 6"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-mattpocock-skills"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-skills" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-skills)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-skills)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Companion dots on the orbits -->
-  <circle cx="957.9" cy="245.0" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="796.9" cy="324.4" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="955.0" cy="419.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="744.9" cy="224.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
-  <!-- Main-sequence disc -->
-  <circle cx="880" cy="290" r="72" fill="url(#st-core-mattpocock-skills)"/>
-  <circle cx="880" cy="290" r="42" fill="#f59e0b"/>
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/skills</text>
 
-  <!-- Bayer designation (catalogue prefix) -->
-  <text x="60" y="212" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">α</text>
-
-  <!-- Slash-skill slug -->
-  <text x="60" y="268" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="80" fill="#ebe5d4" dominant-baseline="middle">/skills</text>
-
-  <!-- Title kicker -->
-  <text x="60" y="316" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Matt Pocock Discipline'</text>
 
   <!-- Discoverer signature -->

--- a/docs/og/mattpocock/teach.svg
+++ b/docs/og/mattpocock/teach.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /teach">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/teach</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-teach"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-teach" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-teach)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-teach)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/teach</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Teach'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 2.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/to-issues.svg
+++ b/docs/og/mattpocock/to-issues.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /to-issues">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/to-issues</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-to-issues"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-to-issues" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-to-issues)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-to-issues)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/to-issues</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Vertical Slicer'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 90.4</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/to-prd.svg
+++ b/docs/og/mattpocock/to-prd.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /to-prd">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/to-prd</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-to-prd"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-to-prd" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-to-prd)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-to-prd)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/to-prd</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The PRD Synthesiser'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 63.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/triage.svg
+++ b/docs/og/mattpocock/triage.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /triage">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/triage</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-triage"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-triage" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-triage)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-triage)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/triage</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The State-Machine Triager'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 56.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/ubiquitous-language.svg
+++ b/docs/og/mattpocock/ubiquitous-language.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /ubiquitous-language">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/ubiquitous-language</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-ubiquitous-language"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-ubiquitous-language" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-ubiquitous-language)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-ubiquitous-language)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/ubiquitous-language</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Domain Linguist'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 90.4</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/write-a-skill.svg
+++ b/docs/og/mattpocock/write-a-skill.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /write-a-skill">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/write-a-skill</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mattpocock-write-a-skill"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-write-a-skill" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-write-a-skill)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-write-a-skill)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/write-a-skill</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Skill Scaffolder'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 45.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mbtiongson1/gaia-audit.svg
+++ b/docs/og/mbtiongson1/gaia-audit.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /gaia-audit">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/gaia-audit</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mbtiongson1-gaia-audit"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mbtiongson1-gaia-audit" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mbtiongson1-gaia-audit)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mbtiongson1-gaia-audit)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/gaia-audit</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Source Detective'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mbtiongson1</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mbtiongson1/gaia-curation-review.svg
+++ b/docs/og/mbtiongson1/gaia-curation-review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /gaia-curation-review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/gaia-curation-review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mbtiongson1-gaia-curation-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mbtiongson1-gaia-curation-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mbtiongson1-gaia-curation-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mbtiongson1-gaia-curation-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="239.9" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="55" fill="#ebe5d4" dominant-baseline="middle">/gaia-curation-review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Quality Gate'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mbtiongson1</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mbtiongson1/gaia-meta-audit.svg
+++ b/docs/og/mbtiongson1/gaia-meta-audit.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /gaia-meta-audit">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/gaia-meta-audit</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mbtiongson1-gaia-meta-audit"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mbtiongson1-gaia-meta-audit" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mbtiongson1-gaia-meta-audit)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mbtiongson1-gaia-meta-audit)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/gaia-meta-audit</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Triage Director'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mbtiongson1</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mbtiongson1/gaia-preview.svg
+++ b/docs/og/mbtiongson1/gaia-preview.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /gaia-preview">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/gaia-preview</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mbtiongson1-gaia-preview"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mbtiongson1-gaia-preview" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mbtiongson1-gaia-preview)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mbtiongson1-gaia-preview)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/gaia-preview</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Change Previewer'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mbtiongson1</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/mbtiongson1/graphify-triage.svg
+++ b/docs/og/mbtiongson1/graphify-triage.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /graphify-triage">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/graphify-triage</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-mbtiongson1-graphify-triage"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mbtiongson1-graphify-triage" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mbtiongson1-graphify-triage)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mbtiongson1-graphify-triage)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/graphify-triage</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Graph Surgeon'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mbtiongson1</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/nexu-io/open-design.svg
+++ b/docs/og/nexu-io/open-design.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /open-design">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/open-design</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-nexu-io-open-design"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-nexu-io-open-design" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-nexu-io-open-design)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-nexu-io-open-design)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/open-design</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Artisan&#x27;s Forge'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@nexu-io</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/nousresearch/feed-monitoring.svg
+++ b/docs/og/nousresearch/feed-monitoring.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /feed-monitoring">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/feed-monitoring</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-nousresearch-feed-monitoring"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-nousresearch-feed-monitoring" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-nousresearch-feed-monitoring)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-nousresearch-feed-monitoring)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/feed-monitoring</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Signal Scout'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@nousresearch</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/brainstorming.svg
+++ b/docs/og/obra/brainstorming.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /brainstorming">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/brainstorming</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-brainstorming"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-brainstorming" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-brainstorming)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-brainstorming)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/brainstorming</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Collaborative Blueprint'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 95.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/dispatching-parallel-agents.svg
+++ b/docs/og/obra/dispatching-parallel-agents.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /dispatching-parallel-agents">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/dispatching-parallel-agents</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-dispatching-parallel-agents"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-dispatching-parallel-agents" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-dispatching-parallel-agents)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-dispatching-parallel-agents)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="248.6" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="41" fill="#ebe5d4" dominant-baseline="middle">/dispatching-parallel-agents</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Parallel Dispatch'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 86.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/executing-plans.svg
+++ b/docs/og/obra/executing-plans.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /executing-plans">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/executing-plans</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-executing-plans"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-executing-plans" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-executing-plans)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-executing-plans)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/executing-plans</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Faithful Executor'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 95.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/finishing-a-development-branch.svg
+++ b/docs/og/obra/finishing-a-development-branch.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /finishing-a-development-branch">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/finishing-a-development-branch</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-finishing-a-development-branch"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-finishing-a-development-branch" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-finishing-a-development-branch)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-finishing-a-development-branch)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="249.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="40" fill="#ebe5d4" dominant-baseline="middle">/finishing-a-development-branch</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Clean Landing'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/receiving-code-review.svg
+++ b/docs/og/obra/receiving-code-review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /receiving-code-review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/receiving-code-review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-receiving-code-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-receiving-code-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-receiving-code-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-receiving-code-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="241.1" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="53" fill="#ebe5d4" dominant-baseline="middle">/receiving-code-review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Rigorous Revision'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/requesting-code-review.svg
+++ b/docs/og/obra/requesting-code-review.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /requesting-code-review">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/requesting-code-review</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-requesting-code-review"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-requesting-code-review" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-requesting-code-review)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-requesting-code-review)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="243.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="50" fill="#ebe5d4" dominant-baseline="middle">/requesting-code-review</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Preemptive Review'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/subagent-driven-development.svg
+++ b/docs/og/obra/subagent-driven-development.svg
@@ -1,63 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--singularity" data-plate="IV" data-branch="unique" data-level="4"
-  aria-label="Unique · 4★ — Singularity plate">
-  <defs>
-    <radialGradient id="bh-void-obra-subagent-driven-development" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="85%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="100%" stop-color="#0e0d20" stop-opacity="1"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /subagent-driven-development">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Lensing-displaced stellar field -->
-  <circle cx="195" cy="215" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="180" y1="200" x2="195" y2="215" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="560" cy="200" r="1.6" fill="#ebe5d4" fill-opacity="0.5"/>
-  <circle cx="545" cy="365" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="560" y1="380" x2="545" y2="365" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="180" cy="400" r="1.6" fill="#ebe5d4" fill-opacity="0.45"/>
-  <circle cx="300" cy="130" r="1.6" fill="#ebe5d4" fill-opacity="0.4"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-obra-subagent-driven-development"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-subagent-driven-development" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-subagent-driven-development)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-subagent-driven-development)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Accretion-disk hairline ring (thin violet) -->
-  <circle cx="360" cy="290" r="96" fill="none" stroke="#7c3aed"
-    stroke-opacity="0.85" stroke-width="1.4"/>
-  <circle cx="360" cy="290" r="93.0" fill="none"
-    stroke="#7c3aed" stroke-opacity="0.35" stroke-width="0.6"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="248.6" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
-  <!-- The void itself: same colour as the page, slightly darker, no glyph -->
-  <circle cx="360" cy="290" r="80" fill="url(#bh-void-obra-subagent-driven-development)"/>
-
-  <!-- BH designation (catalogue prefix) -->
-  <text x="640" y="222" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">BH-</text>
-
-  <!-- Slash-skill slug -->
-  <text x="640" y="286" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="41" fill="#ebe5d4" dominant-baseline="middle">/subagent-driven-development</text>
 
-  <!-- Title kicker -->
-  <text x="640" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Swarm Architect'</text>
 
   <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
-  <!-- Marginal magnitude band — MAG ∞ -->
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 117.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/superpowers.svg
+++ b/docs/og/obra/superpowers.svg
@@ -1,53 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--stellar" data-plate="V" data-branch="suite" data-level="5"
-  aria-label="Ultimate · 5★ — Stellar plate">
-  <defs>
-    <radialGradient id="st-core-obra-superpowers" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#fde2a4" stop-opacity="1"/>
-      <stop offset="55%" stop-color="#f59e0b" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--suite" data-branch="suite" data-level="5"
+  data-plate-class="STELLAR"
+  aria-label="Ultimate · 5★ — STELLAR plate for /superpowers">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Ultimate · 5★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Two concentric orbital tracks -->
-  <circle cx="880" cy="290" r="90" fill="none" stroke="#ebe5d4" stroke-opacity="0.45" stroke-width="1" stroke-dasharray="6 4"/><circle cx="880" cy="290" r="150" fill="none" stroke="#ebe5d4" stroke-opacity="0.32" stroke-width="1" stroke-dasharray="8 6"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-obra-superpowers"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-superpowers" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-superpowers)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-superpowers)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Companion dots on the orbits -->
-  <circle cx="957.9" cy="245.0" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="796.9" cy="324.4" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="955.0" cy="419.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="744.9" cy="224.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
-  <!-- Main-sequence disc -->
-  <circle cx="880" cy="290" r="72" fill="url(#st-core-obra-superpowers)"/>
-  <circle cx="880" cy="290" r="42" fill="#f59e0b"/>
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/superpowers</text>
 
-  <!-- Bayer designation (catalogue prefix) -->
-  <text x="60" y="212" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">α</text>
-
-  <!-- Slash-skill slug -->
-  <text x="60" y="268" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="80" fill="#ebe5d4" dominant-baseline="middle">/superpowers</text>
-
-  <!-- Title kicker -->
-  <text x="60" y="316" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Complete Agentic Discipline'</text>
 
   <!-- Discoverer signature -->

--- a/docs/og/obra/systematic-debugging.svg
+++ b/docs/og/obra/systematic-debugging.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /systematic-debugging">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/systematic-debugging</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-systematic-debugging"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-systematic-debugging" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-systematic-debugging)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-systematic-debugging)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="239.9" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="55" fill="#ebe5d4" dominant-baseline="middle">/systematic-debugging</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Root Cause Hunter'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 65.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/using-git-worktrees.svg
+++ b/docs/og/obra/using-git-worktrees.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /using-git-worktrees">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/using-git-worktrees</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-using-git-worktrees"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-using-git-worktrees" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-using-git-worktrees)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-using-git-worktrees)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/using-git-worktrees</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Isolated Workspace'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 117.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/verification-before-completion.svg
+++ b/docs/og/obra/verification-before-completion.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /verification-before-completion">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/verification-before-completion</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-verification-before-completion"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-verification-before-completion" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-verification-before-completion)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-verification-before-completion)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="249.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="40" fill="#ebe5d4" dominant-baseline="middle">/verification-before-completion</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Completion Gate'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 95.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/writing-plans.svg
+++ b/docs/og/obra/writing-plans.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /writing-plans">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/writing-plans</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-obra-writing-plans"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-writing-plans" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-writing-plans)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-writing-plans)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/writing-plans</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Blueprint Writer'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 110.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/openai/few-shot-learning.svg
+++ b/docs/og/openai/few-shot-learning.svg
@@ -1,63 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--singularity" data-plate="IV" data-branch="unique" data-level="4"
-  aria-label="Unique · 4★ — Singularity plate">
-  <defs>
-    <radialGradient id="bh-void-openai-few-shot-learning" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="85%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="100%" stop-color="#0e0d20" stop-opacity="1"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /few-shot-learning">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Lensing-displaced stellar field -->
-  <circle cx="195" cy="215" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="180" y1="200" x2="195" y2="215" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="560" cy="200" r="1.6" fill="#ebe5d4" fill-opacity="0.5"/>
-  <circle cx="545" cy="365" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="560" y1="380" x2="545" y2="365" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="180" cy="400" r="1.6" fill="#ebe5d4" fill-opacity="0.45"/>
-  <circle cx="300" cy="130" r="1.6" fill="#ebe5d4" fill-opacity="0.4"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-openai-few-shot-learning"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-openai-few-shot-learning" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-openai-few-shot-learning)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-openai-few-shot-learning)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Accretion-disk hairline ring (thin violet) -->
-  <circle cx="360" cy="290" r="96" fill="none" stroke="#7c3aed"
-    stroke-opacity="0.85" stroke-width="1.4"/>
-  <circle cx="360" cy="290" r="93.0" fill="none"
-    stroke="#7c3aed" stroke-opacity="0.35" stroke-width="0.6"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="234.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
-  <!-- The void itself: same colour as the page, slightly darker, no glyph -->
-  <circle cx="360" cy="290" r="80" fill="url(#bh-void-openai-few-shot-learning)"/>
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="64" fill="#ebe5d4" dominant-baseline="middle">/few-shot-learning</text>
 
-  <!-- BH designation (catalogue prefix) -->
-  <text x="640" y="222" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">BH-</text>
-
-  <!-- Slash-skill slug -->
-  <text x="640" y="286" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="65" fill="#ebe5d4" dominant-baseline="middle">/few-shot-learning</text>
-
-  <!-- Title kicker -->
-  <text x="640" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The In-Context Learner'</text>
 
   <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@openai</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
-  <!-- Marginal magnitude band — MAG ∞ -->
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 100.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/openai/self-consistency.svg
+++ b/docs/og/openai/self-consistency.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /self-consistency">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/self-consistency</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-openai-self-consistency"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-openai-self-consistency" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-openai-self-consistency)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-openai-self-consistency)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="231.8" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="68" fill="#ebe5d4" dominant-baseline="middle">/self-consistency</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Majority Consensus'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@openai</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 100.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/pbakaus/impeccable.svg
+++ b/docs/og/pbakaus/impeccable.svg
@@ -1,63 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--singularity" data-plate="IV" data-branch="unique" data-level="4"
-  aria-label="Unique · 4★ — Singularity plate">
-  <defs>
-    <radialGradient id="bh-void-pbakaus-impeccable" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="85%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="100%" stop-color="#0e0d20" stop-opacity="1"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /impeccable">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Lensing-displaced stellar field -->
-  <circle cx="195" cy="215" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="180" y1="200" x2="195" y2="215" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="560" cy="200" r="1.6" fill="#ebe5d4" fill-opacity="0.5"/>
-  <circle cx="545" cy="365" r="1.6" fill="#ebe5d4" fill-opacity="0.55"/>
-  <line x1="560" y1="380" x2="545" y2="365" stroke="#ebe5d4" stroke-opacity="0.12" stroke-width="0.6"/>
-  <circle cx="180" cy="400" r="1.6" fill="#ebe5d4" fill-opacity="0.45"/>
-  <circle cx="300" cy="130" r="1.6" fill="#ebe5d4" fill-opacity="0.4"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-pbakaus-impeccable"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-pbakaus-impeccable" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-pbakaus-impeccable)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-pbakaus-impeccable)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Accretion-disk hairline ring (thin violet) -->
-  <circle cx="360" cy="290" r="96" fill="none" stroke="#7c3aed"
-    stroke-opacity="0.85" stroke-width="1.4"/>
-  <circle cx="360" cy="290" r="93.0" fill="none"
-    stroke="#7c3aed" stroke-opacity="0.35" stroke-width="0.6"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
-  <!-- The void itself: same colour as the page, slightly darker, no glyph -->
-  <circle cx="360" cy="290" r="80" fill="url(#bh-void-pbakaus-impeccable)"/>
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/impeccable</text>
 
-  <!-- BH designation (catalogue prefix) -->
-  <text x="640" y="222" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">BH-</text>
-
-  <!-- Slash-skill slug -->
-  <text x="640" y="286" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="84" fill="#ebe5d4" dominant-baseline="middle">/impeccable</text>
-
-  <!-- Title kicker -->
-  <text x="640" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Aesthetic Shield'</text>
 
   <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@pbakaus</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
-  <!-- Marginal magnitude band — MAG ∞ -->
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 122.8</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/agentdb-advanced.svg
+++ b/docs/og/ruvnet/agentdb-advanced.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /agentdb-advanced">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/agentdb-advanced</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-agentdb-advanced"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-agentdb-advanced" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-agentdb-advanced)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-agentdb-advanced)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="231.8" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="68" fill="#ebe5d4" dominant-baseline="middle">/agentdb-advanced</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Memory Architect'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/agentdb-memory-patterns.svg
+++ b/docs/og/ruvnet/agentdb-memory-patterns.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /agentdb-memory-patterns">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/agentdb-memory-patterns</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-agentdb-memory-patterns"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-agentdb-memory-patterns" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-agentdb-memory-patterns)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-agentdb-memory-patterns)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="244.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="48" fill="#ebe5d4" dominant-baseline="middle">/agentdb-memory-patterns</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Memory Weaver'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/agentdb-optimization.svg
+++ b/docs/og/ruvnet/agentdb-optimization.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /agentdb-optimization">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/agentdb-optimization</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-agentdb-optimization"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-agentdb-optimization" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-agentdb-optimization)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-agentdb-optimization)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="239.9" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="55" fill="#ebe5d4" dominant-baseline="middle">/agentdb-optimization</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Index Tuner'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/agentdb-vector-search.svg
+++ b/docs/og/ruvnet/agentdb-vector-search.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /agentdb-vector-search">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/agentdb-vector-search</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-agentdb-vector-search"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-agentdb-vector-search" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-agentdb-vector-search)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-agentdb-vector-search)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="241.1" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="53" fill="#ebe5d4" dominant-baseline="middle">/agentdb-vector-search</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Similarity Engine'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/agentdb.svg
+++ b/docs/og/ruvnet/agentdb.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /agentdb">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/agentdb</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-agentdb"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-agentdb" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-agentdb)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-agentdb)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/agentdb</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Memory Sovereign'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 201.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/agentic-jujutsu.svg
+++ b/docs/og/ruvnet/agentic-jujutsu.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /agentic-jujutsu">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/agentic-jujutsu</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-agentic-jujutsu"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-agentic-jujutsu" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-agentic-jujutsu)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-agentic-jujutsu)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/agentic-jujutsu</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Risk Whisperer'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/dual-collect.svg
+++ b/docs/og/ruvnet/dual-collect.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /dual-collect">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/dual-collect</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-dual-collect"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-dual-collect" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-dual-collect)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-dual-collect)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/dual-collect</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Result Harvester'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/dual-coordinate.svg
+++ b/docs/og/ruvnet/dual-coordinate.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /dual-coordinate">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/dual-coordinate</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-dual-coordinate"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-dual-coordinate" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-dual-coordinate)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-dual-coordinate)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/dual-coordinate</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Hybrid Orchestrator'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/dual-mode.svg
+++ b/docs/og/ruvnet/dual-mode.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /dual-mode">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/dual-mode</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-dual-mode"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-dual-mode" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-dual-mode)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-dual-mode)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/dual-mode</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Hybrid Conductor'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 126.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/dual-spawn.svg
+++ b/docs/og/ruvnet/dual-spawn.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /dual-spawn">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/dual-spawn</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-dual-spawn"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-dual-spawn" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-dual-spawn)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-dual-spawn)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/dual-spawn</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Headless Launcher'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/flow-nexus-neural.svg
+++ b/docs/og/ruvnet/flow-nexus-neural.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /flow-nexus-neural">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/flow-nexus-neural</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-flow-nexus-neural"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-flow-nexus-neural" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-flow-nexus-neural)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-flow-nexus-neural)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="234.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="64" fill="#ebe5d4" dominant-baseline="middle">/flow-nexus-neural</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Neural Conductor'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/flow-nexus-platform.svg
+++ b/docs/og/ruvnet/flow-nexus-platform.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /flow-nexus-platform">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/flow-nexus-platform</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-flow-nexus-platform"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-flow-nexus-platform" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-flow-nexus-platform)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-flow-nexus-platform)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/flow-nexus-platform</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Queen Seraphina&#x27;s Court'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/flow-nexus.svg
+++ b/docs/og/ruvnet/flow-nexus.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /flow-nexus">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/flow-nexus</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-flow-nexus"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-flow-nexus" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-flow-nexus)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-flow-nexus)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/flow-nexus</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Grand Conductor&#x27;s Trilogy'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 96.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/github-multi-repo.svg
+++ b/docs/og/ruvnet/github-multi-repo.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /github-multi-repo">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/github-multi-repo</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-github-multi-repo"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-github-multi-repo" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-github-multi-repo)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-github-multi-repo)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="234.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="64" fill="#ebe5d4" dominant-baseline="middle">/github-multi-repo</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Repository Conductor'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/github-suite.svg
+++ b/docs/og/ruvnet/github-suite.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /github-suite">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/github-suite</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-github-suite"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-github-suite" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-github-suite)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-github-suite)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/github-suite</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The GitHub Maestro'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 66.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/hive-mind-coordination.svg
+++ b/docs/og/ruvnet/hive-mind-coordination.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /hive-mind-coordination">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/hive-mind-coordination</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-hive-mind-coordination"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-hive-mind-coordination" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-hive-mind-coordination)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-hive-mind-coordination)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="243.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="50" fill="#ebe5d4" dominant-baseline="middle">/hive-mind-coordination</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'Queen Seraphina&#x27;s Hive'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 96.1</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/pair-programming.svg
+++ b/docs/og/ruvnet/pair-programming.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /pair-programming">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/pair-programming</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-pair-programming"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-pair-programming" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-pair-programming)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-pair-programming)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="231.8" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="68" fill="#ebe5d4" dominant-baseline="middle">/pair-programming</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Coding Companion'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/reasoningbank-intelligence.svg
+++ b/docs/og/ruvnet/reasoningbank-intelligence.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /reasoningbank-intelligence">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/reasoningbank-intelligence</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-reasoningbank-intelligence"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-reasoningbank-intelligence" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-reasoningbank-intelligence)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-reasoningbank-intelligence)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="247.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="43" fill="#ebe5d4" dominant-baseline="middle">/reasoningbank-intelligence</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Strategy Optimizer'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/reasoningbank.svg
+++ b/docs/og/ruvnet/reasoningbank.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /reasoningbank">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/reasoningbank</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-reasoningbank"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-reasoningbank" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-reasoningbank)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-reasoningbank)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/reasoningbank</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Pattern Sage'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 118.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/ruflo-v3.svg
+++ b/docs/og/ruvnet/ruflo-v3.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /ruflo-v3">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/ruflo-v3</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-ruflo-v3"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-ruflo-v3" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-ruflo-v3)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-ruflo-v3)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/ruflo-v3</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The V3 Architect'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 186.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/ruflo.svg
+++ b/docs/og/ruvnet/ruflo.svg
@@ -1,53 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--stellar" data-plate="V" data-branch="suite" data-level="5"
-  aria-label="Ultimate · 5★ — Stellar plate">
-  <defs>
-    <radialGradient id="st-core-ruvnet-ruflo" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#fde2a4" stop-opacity="1"/>
-      <stop offset="55%" stop-color="#f59e0b" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-
+  class="plate plate--suite" data-branch="suite" data-level="5"
+  data-plate-class="STELLAR"
+  aria-label="Ultimate · 5★ — STELLAR plate for /ruflo">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Ultimate · 5★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Two concentric orbital tracks -->
-  <circle cx="880" cy="290" r="90" fill="none" stroke="#ebe5d4" stroke-opacity="0.45" stroke-width="1" stroke-dasharray="6 4"/><circle cx="880" cy="290" r="150" fill="none" stroke="#ebe5d4" stroke-opacity="0.32" stroke-width="1" stroke-dasharray="8 6"/>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-ruvnet-ruflo"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-ruflo" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-ruflo)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c5-suite-ultimate-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-ruflo)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <!-- Companion dots on the orbits -->
-  <circle cx="957.9" cy="245.0" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="796.9" cy="324.4" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="955.0" cy="419.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
-  <circle cx="744.9" cy="224.9" r="3" fill="#ebe5d4" fill-opacity="0.85"/>
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
-  <!-- Main-sequence disc -->
-  <circle cx="880" cy="290" r="72" fill="url(#st-core-ruvnet-ruflo)"/>
-  <circle cx="880" cy="290" r="42" fill="#f59e0b"/>
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/ruflo</text>
 
-  <!-- Bayer designation (catalogue prefix) -->
-  <text x="60" y="212" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="#ebe5d4" fill-opacity="0.7">α</text>
-
-  <!-- Slash-skill slug -->
-  <text x="60" y="268" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="80" fill="#ebe5d4" dominant-baseline="middle">/ruflo</text>
-
-  <!-- Title kicker -->
-  <text x="60" y="316" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Agentic Sovereign'</text>
 
   <!-- Discoverer signature -->

--- a/docs/og/ruvnet/stream-chain.svg
+++ b/docs/og/ruvnet/stream-chain.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /stream-chain">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/stream-chain</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-stream-chain"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-stream-chain" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-stream-chain)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-stream-chain)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/stream-chain</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Flow Conductor'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/swarm-advanced.svg
+++ b/docs/og/ruvnet/swarm-advanced.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /swarm-advanced">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/swarm-advanced</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-swarm-advanced"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-swarm-advanced" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-swarm-advanced)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-swarm-advanced)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="226.3" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="77" fill="#ebe5d4" dominant-baseline="middle">/swarm-advanced</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Grand Swarm Master'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/swarm-orchestration.svg
+++ b/docs/og/ruvnet/swarm-orchestration.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /swarm-orchestration">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/swarm-orchestration</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-swarm-orchestration"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-swarm-orchestration" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-swarm-orchestration)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-swarm-orchestration)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/swarm-orchestration</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Topology Architect'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/v3-cli-modernization.svg
+++ b/docs/og/ruvnet/v3-cli-modernization.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /v3-cli-modernization">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/v3-cli-modernization</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-v3-cli-modernization"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-v3-cli-modernization" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-v3-cli-modernization)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-v3-cli-modernization)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="239.9" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="55" fill="#ebe5d4" dominant-baseline="middle">/v3-cli-modernization</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Interface Revamp'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/v3-core-implementation.svg
+++ b/docs/og/ruvnet/v3-core-implementation.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /v3-core-implementation">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/v3-core-implementation</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-v3-core-implementation"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-v3-core-implementation" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-v3-core-implementation)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-v3-core-implementation)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="243.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="50" fill="#ebe5d4" dominant-baseline="middle">/v3-core-implementation</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Foundation Layer'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/v3-ddd-architecture.svg
+++ b/docs/og/ruvnet/v3-ddd-architecture.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /v3-ddd-architecture">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/v3-ddd-architecture</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-v3-ddd-architecture"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-v3-ddd-architecture" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-v3-ddd-architecture)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-v3-ddd-architecture)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/v3-ddd-architecture</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Domain Sculptor'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/v3-integration-deep.svg
+++ b/docs/og/ruvnet/v3-integration-deep.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /v3-integration-deep">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/v3-integration-deep</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-v3-integration-deep"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-v3-integration-deep" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-v3-integration-deep)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-v3-integration-deep)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="58" fill="#ebe5d4" dominant-baseline="middle">/v3-integration-deep</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Integration Weaver'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/verification-quality.svg
+++ b/docs/og/ruvnet/verification-quality.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /verification-quality">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/verification-quality</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-verification-quality"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-verification-quality" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-verification-quality)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-verification-quality)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="239.9" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="55" fill="#ebe5d4" dominant-baseline="middle">/verification-quality</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Quality Sentinel'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/worker-integration.svg
+++ b/docs/og/ruvnet/worker-integration.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /worker-integration">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/worker-integration</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-ruvnet-worker-integration"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-worker-integration" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-worker-integration)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-worker-integration)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="236.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="61" fill="#ebe5d4" dominant-baseline="middle">/worker-integration</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Task Dispatcher'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/safishamsi/graphify.svg
+++ b/docs/og/safishamsi/graphify.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /graphify">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/graphify</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-safishamsi-graphify"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-safishamsi-graphify" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-safishamsi-graphify)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-safishamsi-graphify)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/graphify</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Structural Muse'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@safishamsi</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 116.6</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/santifer/career-ops.svg
+++ b/docs/og/santifer/career-ops.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /career-ops">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/career-ops</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-santifer-career-ops"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-santifer-career-ops" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-santifer-career-ops)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-santifer-career-ops)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/career-ops</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Professional&#x27;s Edge'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@santifer</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/spring-ai/readme-generate.svg
+++ b/docs/og/spring-ai/readme-generate.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /readme-generate">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/readme-generate</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-spring-ai-readme-generate"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-spring-ai-readme-generate" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-spring-ai-readme-generate)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-spring-ai-readme-generate)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="73" fill="#ebe5d4" dominant-baseline="middle">/readme-generate</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Endpoint Scribe'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@spring-ai</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/stanfordnlp/dspy.svg
+++ b/docs/og/stanfordnlp/dspy.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-3" data-branch="standard" data-level="3"
-  aria-label="Evolved · 3★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="3"
+  data-plate-class="FIELD BODY"
+  aria-label="Evolved · 3★ — FIELD BODY plate for /dspy">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/dspy</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-stanfordnlp-dspy"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-stanfordnlp-dspy" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-stanfordnlp-dspy)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-stanfordnlp-dspy)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/dspy</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Programmatic Prompt Engineer'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@stanfordnlp</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 100.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/upsonic/unittest-generator.svg
+++ b/docs/og/upsonic/unittest-generator.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /unittest-generator">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/unittest-generator</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-upsonic-unittest-generator"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-upsonic-unittest-generator" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-upsonic-unittest-generator)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-upsonic-unittest-generator)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="236.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="61" fill="#ebe5d4" dominant-baseline="middle">/unittest-generator</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Test Weaver'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@upsonic</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 33.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/docs/og/vercel/find-skills.svg
+++ b/docs/og/vercel/find-skills.svg
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--default" data-plate="rank-2" data-branch="standard" data-level="2"
-  aria-label="Named · 2★ plate">
+  class="plate plate--standard" data-branch="standard" data-level="2"
+  data-plate-class="FIELD BODY"
+  aria-label="Named · 2★ — FIELD BODY plate for /find-skills">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="274.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
-  <line x1="274.0" y1="22" x2="274.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="500.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
-  <line x1="500.0" y1="22" x2="500.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="726.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
-  <line x1="726.0" y1="22" x2="726.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-  <text x="952.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −20°</text>
-  <line x1="952.0" y1="22" x2="952.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="258.7" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +10°</text>
+  <line x1="258.7" y1="22" x2="258.7" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="469.3" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— 0°</text>
+  <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
+  <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
+  <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
 <text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Named · 2★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
+  
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="60" y="290" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="72" fill="#ebe5d4" dominant-baseline="middle">/find-skills</text>
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
+  <defs><clipPath id="med-clip-vercel-find-skills"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-vercel-find-skills" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-vercel-find-skills)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c2-suite-named-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-vercel-find-skills)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
-  <text x="60" y="336" font-family="'EB Garamond',Georgia,serif" font-style="italic"
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+
+  <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
+    font-size="82" fill="#ebe5d4" dominant-baseline="middle">/find-skills</text>
+
+  <text x="60" y="342" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="#ebe5d4" fill-opacity="0.6" dominant-baseline="middle">'The Registry Scout'</text>
 
+  <!-- Discoverer signature -->
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@vercel</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
+  <!-- Marginal magnitude band -->
   <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 36.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE C</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
 </svg>

--- a/scripts/generateOgCards.py
+++ b/scripts/generateOgCards.py
@@ -5,27 +5,33 @@ For each named skill, generates a Hall Plate at:
   docs/og/{handle}/{skillId}.svg   — SVG plate (always generated)
   docs/og/{handle}/{skillId}.png   — raster render (if cairosvg or pillow available)
 
-The plates are rendered as entries in *Gaia's Celestial Atlas of Skills*. Three
-celestial subjects, three different plate compositions, **one cartographic style**:
+The plates are rendered as entries in *Gaia's Celestial Atlas of Skills*: a
+two-column engraved catalogue leaf. LEFT column carries the type — plate class,
+slash-slug, discoverer's signature. RIGHT column carries the **subject**: the
+skill's own Ascension-Overdrive V4 medallion, the exact stamp its rank and
+branch earned elsewhere in the graph. One card, one cartographic style, one
+authoritative subject.
 
-  Plate VI  · APEX SUPERNOVA   (suite branch, 6★ — Apex)
-  Plate V   · STELLAR          (suite branch, 4-5★ — Extra / Ultimate)
-  Plate IV  · SINGULARITY      (unique branch, 4★+ — standalone mastery)
-  Plate (default)              (standard branch, 1-3★ — Awakened / Named /
-                                Evolved; not yet a catalogued celestial body)
+  Class · APEX SUPERNOVA   (suite branch, 6★ — Apex)     → aov4-c6 medallion
+  Class · STELLAR          (suite branch, 4-5★)          → aov4-c4/c5 medallion
+  Class · SINGULARITY      (unique branch, 4-6★)         → aov4-d4/d5/d6 medallion
+  Class · FIELD BODY       (standard branch, 1-3★)       → aov4-c1/c2/c3 medallion
 
-Plate dispatch keys on the read-time BRANCH (computeBranch) + rank, NEVER on a
-stored type/tier field (Ygg-II rubric E1).
+The card composition, medallion asset, plate-class word, and rank label are ALL
+driven by the read-time BRANCH (computeBranch) + star rank — NEVER by a stored
+type/tier field (Ygg-II rubric E1). Every graded skill lands a proper plate;
+no skill falls to a barren type-word fallback.
 
 Reference grammar (Bode's Uranographia, Hevelius's Firmamentum):
-  RA/Dec ticks at the top, roman-numeral plate number top-right, discoverer's
-  signature in gold above an engraved rule, marginal magnitude band at
-  the foot of every plate. The reader recognises the atlas; each plate is a
-  unique entry within it.
+  RA/Dec ticks at the top, plate-class number top-right, discoverer's signature
+  in gold above an engraved rule, marginal magnitude band at the foot of every
+  plate. The reader recognises the atlas; each plate is a unique entry within it.
 
-All three plates share one ground (`INK_NIGHT`, the printed night sky) and one
-engraving colour (`CREAM_ENGRAVED`, warm cream linework + type). Each plate
-introduces a single chromatic event — the celestial body itself.
+All plates share one ground (`INK_NIGHT`, the printed night sky) and one
+engraving colour (`CREAM_ENGRAVED`, warm cream linework + type). The single
+chromatic event is the medallion, embedded as a same-origin relative image
+(`/assets/ascension-overdrive/…-hero.webp`) so it renders when the SVG is
+served from Pages, inlined into the share modal, or opened directly on-site.
 
 Usage:
     python scripts/generateOgCards.py [--named PATH] [--out-dir PATH]
@@ -59,7 +65,22 @@ MARGIN = 48                # outer plate margin (top, left, right)
 RULE_Y = 558               # y of the engraved rule above the marginal band
 SIG_Y = 538                # baseline of the discoverer's signature line
 TICK_Y = 38                # baseline of the RA/Dec tick row at the top
-PLATE_NO_Y = 38            # baseline of the roman-numeral plate number
+PLATE_NO_Y = 38            # baseline of the plate-class label
+
+# ─── Two-column engraved-leaf geometry ────────────────────────────────────────
+# The card is one catalogue leaf split into a type column (left) and a subject
+# column (right). The medallion — the skill's own AOV4 stamp — fills the former
+# dead zone on the right; the slug + signature keep the left. A hairline gutter
+# rule separates them, echoing a real atlas plate's central fold.
+COL_SPLIT_X = 720          # x of the vertical gutter rule between columns
+MEDALLION_CX = 930         # centre-x of the medallion in the right column
+MEDALLION_CY = 300         # centre-y of the medallion (optically above the rule)
+MEDALLION_R = 206          # clip radius of the embedded medallion disc
+# The AOV4 hero art is a 2048² image whose ornate ring disc spans ~77.7% of the
+# frame, centred at (1024,1024). Placing the image at 2×MEDALLION_R/0.777 wide
+# and offsetting so its centre lands on (MEDALLION_CX, MEDALLION_CY) fits the
+# full ring inside the clip circle with the black corners cropped away.
+_AOV_DISC_FRAC = 0.777
 
 # ─── Atlas palette ────────────────────────────────────────────────────────────
 # These two pigments are the entire ground+ink of every plate. They are SEALED
@@ -69,32 +90,56 @@ INK_NIGHT = "#0e0d20"          # OKLCH ~ oklch(13% 0.025 275); printed night-sky
 CREAM_ENGRAVED = "#ebe5d4"     # OKLCH ~ oklch(92% 0.015  80); warm cream ink/linework
 
 # ─── Brand voice tokens (resolved from DESIGN.md / styles.css) ────────────────
-# Yggdrasil II rubric E4: the deprecated honor-red origin mark (#ef4444) is
-# replaced by gold. The discoverer's signature + `· ORIGIN ·` token now render
-# in the same gold as the wreath / apex accent — no red anywhere.
+# Yggdrasil II rubric E4: the deprecated honor-red origin mark is replaced by
+# gold. The discoverer's signature + `· ORIGIN ·` token now render in the same
+# gold as the wreath / apex accent — no red anywhere.
 SIGNATURE_GOLD = "#fbbf24"     # discoverer's signature + origin mark (was honor-red)
-APEX_GOLD = "#fbbf24"          # supernova core + filaments (Plate VI)
-AMBER_STAR = "#f59e0b"         # main-sequence star disc (Plate V)
-VIOLET_HALO = "#7c3aed"        # black-hole accretion ring (Plate IV)
+APEX_GOLD = "#fbbf24"          # suite plate-class accent + gutter tint (gold-leaning)
+VIOLET_HALO = "#7c3aed"        # unique plate-class accent + gutter tint (darker register)
+
+# ─── AOV4 medallion resolver (mirrors docs/js/plaque.js `_aovStamp`) ──────────
+# The subject art IS the skill's Ascension-Overdrive V4 stamp — the exact
+# medallion its rank + branch earned across the graph. Suite/standard branches
+# draw from the C family (c1..c6); the Unique branch from the D family (d4..d6).
+# OG is a large surface, so every plate uses the `-hero` size tier.
+AOV_SUITE_STEM = {
+    1: "c1-suite-awakened", 2: "c2-suite-named", 3: "c3-suite-evolved",
+    4: "c4-suite-extra", 5: "c5-suite-ultimate", 6: "c6-suite-apex",
+}
+AOV_UNIQUE_STEM = {
+    4: "d4-unique", 5: "d5-unique-ultimate", 6: "d6-unique-impossible",
+}
+
+
+def aov_medallion_href(branch: str, rank: int) -> str:
+    """Same-origin relative href to the AOV4 `-hero` stamp for branch+rank.
+
+    Root-relative (`/assets/…`) so the medallion resolves identically whether
+    the SVG is served standalone at `/og/<handle>/<slug>.svg`, inlined into the
+    share modal via innerHTML, or opened from a locally-served `docs/` root.
+    """
+    if branch == "unique":
+        stem = AOV_UNIQUE_STEM[max(4, min(6, rank))]
+    else:
+        stem = AOV_SUITE_STEM[max(1, min(6, rank))]
+    return f"/assets/ascension-overdrive/aov4-{stem}-hero.webp"
 
 
 # ─── Branch / rank resolution helpers (Yggdrasil II — read-time) ──────────────
-# Plate dispatch + labels are driven by read-time BRANCH + rank. The old
-# tier-color helpers (tier_palette / rank_palette / resolve_type_for_og) keyed
-# on the dead `type == 'extra'|'ultimate'|'unique'` enum and were removed with
-# the enum dispatch — each plate now hard-codes its own celestial palette
-# (APEX_GOLD / AMBER_STAR / VIOLET_HALO above), so no gaia.json color lookup is
-# needed here.
+# Plate dispatch + labels are driven by read-time BRANCH + rank via
+# computeBranch — never a stored type/tier field. Each plate draws the skill's
+# own AOV4 medallion (see aov_medallion_href) and tints its accent from the
+# derived branch (gold for suite/standard, violet for unique), so no gaia.json
+# colour lookup is needed here.
 
 
 def og_branch(entry: dict) -> str:
     """Read-time branch for a named-skill entry ('standard'|'suite'|'unique').
 
     Delegates to gaia_cli.trustMagnitude.computeBranch (Ygg-II rubric E1) — the
-    plate composition and labels are driven by branch+rank, NEVER by the dead
-    `type == 'ultimate'|'unique'|'extra'` enum that used to key dispatch and
-    sent EVERY named skill to the barren "Basic Skill" fallback plate. The entry
-    carries level+suiteComponents, so no genericSkillMap thread is needed.
+    plate composition and labels are driven by branch+rank, never a stored type
+    enum. The entry carries level+suiteComponents, so no genericSkillMap thread
+    is needed.
     """
     return _compute_branch(entry)
 
@@ -104,12 +149,26 @@ def og_rank_label(rank: int, branch: str) -> str:
 
     Mirrors docs/js/skill-semantics.js rankWord — shared 1-3★
     (Awakened/Named/Evolved), suite 4-6★ (Extra/Ultimate/Apex), unique 4-6★
-    (Unique/Unique Ultimate/Unique Impossible). NEVER emits banned
-    'Hardened'/'Transcendent'. The label reads e.g. "Extra · 4★" so the plate's
-    top-right stamp is meaningful rather than a flat "Basic Skill" fallback.
+    (Unique/Unique Ultimate/Unique Impossible). Never emits a banned legacy rank
+    word. The label reads e.g. "Extra · 4★" so the plate's top-right stamp is
+    meaningful — a graded skill is never labelled a flat type word.
     """
     word = _rank_word(f"{rank}★", branch)
     return f"{word} · {rank}★" if rank > 0 else "Basic"
+
+
+# Plate-class word — the atlas classification for the card's SUBJECT column,
+# keyed on the read-time branch + rank (never a stored type). Reads in the
+# top-left kicker above the plate-class rule; the celestial noun tells the
+# reader what kind of body the medallion depicts.
+def og_plate_class(rank: int, branch: str) -> str:
+    if branch == "unique":
+        return "SINGULARITY"
+    if rank >= 6:
+        return "APEX · SUPERNOVA"
+    if rank >= 4:
+        return "STELLAR"
+    return "FIELD BODY"
 
 
 def level_num(level: str) -> int:
@@ -192,9 +251,12 @@ def autoscale_font(text: str, default_px: int, available_w: float, avg_glyph_rat
 # ─── Shared atlas grammar (every plate uses these) ────────────────────────────
 
 def _radec_ticks() -> str:
-    """Top RA/Dec tick row — five labels in cream Departure Mono at 28% alpha."""
-    labels = ["+20°", "+10°", "0°", "−10°", "−20°"]
-    inner_w = OG_W - MARGIN * 2 - 200  # leave room for PLATE NUMBER on the right
+    """Top RA/Dec tick row — cream Departure Mono labels at 28% alpha.
+
+    Confined to the type column (left of the gutter) so they never collide with
+    the top-right rank label that lives in the subject column."""
+    labels = ["+20°", "+10°", "0°", "−10°"]
+    inner_w = COL_SPLIT_X - MARGIN - 40   # stay left of the gutter
     step = inner_w / (len(labels) - 1)
     parts = []
     for i, lab in enumerate(labels):
@@ -305,219 +367,167 @@ def _shared_frame(plate_label: str) -> str:
     )
 
 
-# ─── Plate VI · APEX SUPERNOVA ────────────────────────────────────────────────
-
-def build_supernova_plate(skill: dict) -> str:
-    """Plate VI — supernova remnant.
-
-    Composition: hot white core disc (left-of-centre) with six radial gold
-    filaments — one per star earned at apex tier — plus the slug, italic
-    kicker, gold signature, and marginal magnitude band reading
-    `MAG 6.0 · CLASS A · ★★★★★★ · α 6 OBS · YYYY`.
-    """
-    contributor = skill.get("contributor", "")
-    title_text = skill.get("title") or skill.get("name") or ""
-    title = html.escape(truncate(title_text, 64))
-    slug_raw = slug_after_slash(skill)
-    slug = html.escape(slug_raw)
-    year = designation_year(skill)
-    is_origin = bool(skill.get("origin"))
-    n_lvl = level_num(skill.get("level", "6★"))
-    sid = (skill.get("id") or "unknown").replace("/", "-").replace(" ", "-")
-
-    # Subject geometry — supernova sits left-of-centre.
-    cx, cy = 360, 290
-    core_r = 12
-
-    # Six radial filaments, one per star. Slight irregularity in length.
-    rays = []
-    ray_lens = [220, 200, 230, 210, 195, 215]
-    for i, length in enumerate(ray_lens):
-        angle = -math.pi / 2 + i * (math.pi * 2 / 6)
-        ex = cx + length * math.cos(angle)
-        ey = cy + length * math.sin(angle)
-        # Mild perpendicular curve so the rays read engraved, not laser-printed.
-        mx = (cx + ex) / 2 + 12 * math.cos(angle + math.pi / 2)
-        my = (cy + ey) / 2 + 12 * math.sin(angle + math.pi / 2)
-        rays.append(
-            f'<path d="M {cx} {cy} Q {mx:.1f} {my:.1f} {ex:.1f} {ey:.1f}" '
-            f'stroke="{APEX_GOLD}" stroke-opacity="0.78" stroke-width="1.5" '
-            f'stroke-linecap="round" fill="none"/>'
-        )
-    rays_svg = "\n  ".join(rays)
-
-    # Faint scatter of stellar-field dots around the supernova.
-    field_dots = []
-    for fx, fy, op in [
-        (180, 200, 0.5), (560, 240, 0.45), (210, 360, 0.5),
-        (520, 380, 0.55), (300, 130, 0.4), (470, 410, 0.4),
-    ]:
-        field_dots.append(
-            f'<circle cx="{fx}" cy="{fy}" r="1.4" fill="{CREAM_ENGRAVED}" fill-opacity="{op}"/>'
-        )
-    field_svg = "\n  ".join(field_dots)
-
-    # Slug + kicker — right of the supernova, vertically centered with the core.
-    slug_x = 660
-    slug_w = OG_W - slug_x - MARGIN
-    slug_size = autoscale_font(slug_raw, default_px=88, available_w=slug_w)
-    slug_y = 286
-    kicker_y = slug_y + 50
-
-    # Magnitude band — apex reads "★★★★★★ · α 6 OBS · YYYY".
-    stars_word = "★" * max(1, min(6, n_lvl))
-    designation = f"α 6 OBS · {year}"
-
-    magVal, gradeVal = resolveTrustData(skill, "6.0")
-
-    return f"""<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-  width="{OG_W}" height="{OG_H}" viewBox="0 0 {OG_W} {OG_H}"
-  class="plate plate--apex" data-plate="VI" data-branch="suite" data-level="{n_lvl}"
-  aria-label="{html.escape(og_rank_label(n_lvl, 'suite'))} — Apex plate">
-  <defs>
-    <radialGradient id="sn-core-{sid}" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#fff7d6" stop-opacity="1"/>
-      <stop offset="40%" stop-color="{APEX_GOLD}" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="{APEX_GOLD}" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-
-  {_shared_frame(og_rank_label(n_lvl, 'suite'))}
-
-  <!-- Diamond Seal (Apex only — atlas publisher's mark) -->
-  {_diamond_seal(MARGIN, MARGIN + 4, size=28)}
-
-  <!-- Stellar field scatter -->
-  {field_svg}
-
-  <!-- Six radial filaments -->
-  {rays_svg}
-
-  <!-- Hot core: blooming halo + bright disc -->
-  <circle cx="{cx}" cy="{cy}" r="58" fill="url(#sn-core-{sid})"/>
-  <circle cx="{cx}" cy="{cy}" r="{core_r}" fill="#fff7d6"/>
-
-  <!-- SN designation (catalogue prefix) -->
-  <text x="{slug_x}" y="{slug_y - 64}" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="{CREAM_ENGRAVED}" fill-opacity="0.7">SN</text>
-
-  <!-- Slash-skill slug (catalogue designation) -->
-  <text x="{slug_x}" y="{slug_y}" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="{slug_size}" fill="{CREAM_ENGRAVED}" dominant-baseline="middle">/{slug}</text>
-
-  <!-- Title kicker -->
-  <text x="{slug_x}" y="{kicker_y}" font-family="'EB Garamond',Georgia,serif" font-style="italic"
-    font-size="24" fill="{CREAM_ENGRAVED}" fill-opacity="0.6" dominant-baseline="middle">'{title}'</text>
-
-  <!-- Discoverer signature -->
-  {_catalog_signature(contributor, is_origin, year)}
-
-  <!-- Marginal magnitude band -->
-  {_magnitude_band(magVal, gradeVal, stars_word, designation)}
-</svg>
-"""
-
-
-# ─── Plate V · STELLAR ────────────────────────────────────────────────────────
-
-def build_stellar_plate(skill: dict) -> str:
-    """Plate V — main-sequence star with two concentric orbital tracks.
-
-    Composition: amber disc centred on the right two-thirds of the plate,
-    two cream hairline orbits, four cream companion dots placed on the
-    orbits (abstract for v1; semantic prereq mapping is a follow-up).
-    Slug uses Bayer convention: `α /sparc-methodology`.
-    """
-    contributor = skill.get("contributor", "")
-    title_text = skill.get("title") or skill.get("name") or ""
-    title = html.escape(truncate(title_text, 64))
-    slug_raw = slug_after_slash(skill)
-    slug = html.escape(slug_raw)
-    year = designation_year(skill)
-    is_origin = bool(skill.get("origin"))
-    n_lvl = level_num(skill.get("level", "5★"))
-    sid = (skill.get("id") or "unknown").replace("/", "-").replace(" ", "-")
-
-    # Star sits right-of-centre. Slug occupies the left third.
-    cx, cy = 880, 290
-    disc_r = 42
-
-    # Two concentric orbits (long-dash hairlines, like real chart plots).
-    r1, r2 = 90, 150
-    orbits = (
-        f'<circle cx="{cx}" cy="{cy}" r="{r1}" fill="none" stroke="{CREAM_ENGRAVED}" '
-        f'stroke-opacity="0.45" stroke-width="1" stroke-dasharray="6 4"/>'
-        f'<circle cx="{cx}" cy="{cy}" r="{r2}" fill="none" stroke="{CREAM_ENGRAVED}" '
-        f'stroke-opacity="0.32" stroke-width="1" stroke-dasharray="8 6"/>'
+def _gutter_rule(accent: str) -> str:
+    """Vertical fold rule separating the type column (left) from the subject
+    column (right). A cream hairline overlaid by a short accent-tinted segment
+    at the medallion's latitude — the atlas's central-fold convention."""
+    top = TICK_Y + 20
+    bot = RULE_Y - 8
+    seg_top = MEDALLION_CY - 70
+    seg_bot = MEDALLION_CY + 70
+    return (
+        f'<line x1="{COL_SPLIT_X}" y1="{top}" x2="{COL_SPLIT_X}" y2="{bot}" '
+        f'stroke="{CREAM_ENGRAVED}" stroke-opacity="0.16" stroke-width="1"/>'
+        f'<line x1="{COL_SPLIT_X}" y1="{seg_top}" x2="{COL_SPLIT_X}" y2="{seg_bot}" '
+        f'stroke="{accent}" stroke-opacity="0.55" stroke-width="1.6"/>'
     )
 
-    # Four companion dots — two per orbit, placed at canonical positions.
-    companion_specs = [
-        (r1, -math.pi / 6),
-        (r1,  math.pi - math.pi / 8),
-        (r2,  math.pi / 3),
-        (r2, -math.pi + math.pi / 7),
-    ]
-    dots = []
-    for r, ang in companion_specs:
-        dx = cx + r * math.cos(ang)
-        dy = cy + r * math.sin(ang)
-        dots.append(
-            f'<circle cx="{dx:.1f}" cy="{dy:.1f}" r="3" fill="{CREAM_ENGRAVED}" fill-opacity="0.85"/>'
-        )
-    dots_svg = "\n  ".join(dots)
 
-    # Slug — left third.
+def _plate_class_kicker(plate_class: str, accent: str) -> str:
+    """Subject-column eyebrow: the celestial classification of the medallion,
+    mono caps in the branch accent, sitting just above the medallion disc."""
+    y = MEDALLION_CY - MEDALLION_R - 22
+    return (
+        f'<text x="{MEDALLION_CX}" y="{y}" '
+        f'font-family="\'Departure Mono\',\'JetBrains Mono\',ui-monospace,monospace" '
+        f'font-size="15" letter-spacing="4.0" fill="{accent}" fill-opacity="0.92" '
+        f'text-anchor="middle" dominant-baseline="middle">{html.escape(plate_class)}</text>'
+    )
+
+
+def _medallion(branch: str, rank: int, sid: str, accent: str) -> str:
+    """Embed the skill's AOV4 `-hero` medallion as the subject art.
+
+    The 2048² hero art (ornate ring disc spanning ~77.7% of the frame, centred
+    at 1024,1024) is drawn at a width that maps that disc to a 2×MEDALLION_R
+    circle, positioned so the disc centre lands on (MEDALLION_CX, MEDALLION_CY),
+    and clipped to a circle so the black corners are cropped. A faint accent
+    halo + cream hairline ring seat the disc into the engraved ground.
+    """
+    href = aov_medallion_href(branch, rank)
+    img_w = 2 * MEDALLION_R / _AOV_DISC_FRAC
+    img_x = MEDALLION_CX - img_w / 2
+    img_y = MEDALLION_CY - img_w / 2
+    clip_id = f"med-clip-{sid}"
+    halo_id = f"med-halo-{sid}"
+    return (
+        f'<defs>'
+        f'<clipPath id="{clip_id}"><circle cx="{MEDALLION_CX}" cy="{MEDALLION_CY}" '
+        f'r="{MEDALLION_R}"/></clipPath>'
+        f'<radialGradient id="{halo_id}" cx="50%" cy="50%" r="50%">'
+        f'<stop offset="60%" stop-color="{accent}" stop-opacity="0"/>'
+        f'<stop offset="100%" stop-color="{accent}" stop-opacity="0.22"/>'
+        f'</radialGradient>'
+        f'</defs>'
+        # accent halo bloom behind the disc
+        f'<circle cx="{MEDALLION_CX}" cy="{MEDALLION_CY}" r="{MEDALLION_R + 26}" '
+        f'fill="url(#{halo_id})"/>'
+        # the medallion art, clipped to the disc
+        f'<image x="{img_x:.1f}" y="{img_y:.1f}" width="{img_w:.1f}" height="{img_w:.1f}" '
+        f'href="{href}" xlink:href="{href}" preserveAspectRatio="xMidYMid slice" '
+        f'clip-path="url(#{clip_id})"/>'
+        # cream hairline ring seating the disc into the plate
+        f'<circle cx="{MEDALLION_CX}" cy="{MEDALLION_CY}" r="{MEDALLION_R}" fill="none" '
+        f'stroke="{CREAM_ENGRAVED}" stroke-opacity="0.30" stroke-width="1"/>'
+        f'<circle cx="{MEDALLION_CX}" cy="{MEDALLION_CY}" r="{MEDALLION_R + 8}" fill="none" '
+        f'stroke="{accent}" stroke-opacity="0.35" stroke-width="1.2"/>'
+    )
+
+
+# ─── Unified atlas plate ──────────────────────────────────────────────────────
+
+def build_plate(skill: dict) -> str:
+    """Render one catalogue leaf for any branch + rank.
+
+    Composition (Ygg-II /impeccable reshape):
+      LEFT column  — plate-class rule (RA/Dec ticks), slash-slug, italic title
+                     kicker, gold discoverer's signature, marginal magnitude band.
+      RIGHT column — the skill's own AOV4 medallion (`build_plate` never draws
+                     procedural line-art; the stamp its rank earned IS the art),
+                     seated under a branch-classed kicker.
+
+    Everything — medallion asset, plate-class word, top-right rank label, gutter
+    tint — is keyed on the read-time BRANCH (computeBranch) + star rank, never a
+    stored type/tier field (E1). Every graded skill lands a proper plate: a 5★
+    suite reads "Ultimate · 5★" over its gold apex-family medallion; a 4★ unique
+    reads "Unique · 4★" over its violet singularity stamp.
+    """
+    contributor = skill.get("contributor", "")
+    title_text = skill.get("title") or skill.get("name") or ""
+    title = html.escape(truncate(title_text, 60))
+    slug_raw = slug_after_slash(skill)
+    slug = html.escape(slug_raw)
+    year = designation_year(skill)
+    is_origin = bool(skill.get("origin"))
+    n_lvl = level_num(skill.get("level", ""))
+    sid = (skill.get("id") or "unknown").replace("/", "-").replace(" ", "-")
+
+    branch = og_branch(skill)
+    accent = VIOLET_HALO if branch == "unique" else APEX_GOLD
+    rank_label = og_rank_label(n_lvl, branch)
+    plate_class = og_plate_class(n_lvl, branch)
+
+    # LEFT column type block. Slug is vertically centred with the medallion so
+    # the two columns balance; the title kicker sits just below it.
     slug_x = MARGIN + 12
-    slug_w = 560
-    slug_size = autoscale_font(slug_raw, default_px=80, available_w=slug_w)
-    slug_y = 268
+    slug_w = COL_SPLIT_X - slug_x - 40
+    # +1 char for the leading slash; 0.53 ratio matches EB Garamond 600 better
+    # than the 0.46 default (which let long slugs overrun into the medallion).
+    slug_size = autoscale_font("/" + slug_raw, default_px=82,
+                               available_w=slug_w, avg_glyph_ratio=0.53)
+    slug_y = MEDALLION_CY - 8
+    prefix_y = slug_y - slug_size * 0.62 - 18
+    kicker_y = slug_y + 50
 
-    # Bayer prefix sits ABOVE the slug.
-    bayer_y = slug_y - 56
-    kicker_y = slug_y + 48
+    # Catalogue prefix above the slug — a mono designation echoing the plate
+    # class (SN for supernova, α for stellar, BH for singularity, GAIA field).
+    prefix_map = {"SINGULARITY": "BH", "APEX · SUPERNOVA": "SN", "STELLAR": "α"}
+    prefix = prefix_map.get(plate_class, "GAIA")
 
-    # Magnitude band — Stellar reads "5.0 · CLASS A · ★★★★★ · α SLUG · YYYY".
-    stars_word = "★" * max(1, min(6, n_lvl))
-    designation = f"α {slug_raw[:18].upper()} · {year}"
+    # Marginal magnitude band. Suite/standard count stars; unique reads its
+    # branch-forked rank word (no stars — a singularity emits no light) — only
+    # the valid Unique ladder words, never a banned legacy rank word (E2).
+    if branch == "unique":
+        rank_word = _rank_word(f"{n_lvl}★", "unique").upper() if n_lvl >= 4 else "AWAITED"
+        stars_or_word = f"⊘ {rank_word}"
+        designation = f"BH {to_roman(max(1, n_lvl))} · {year}"
+        fallback_mag = "∞"
+    else:
+        stars_or_word = "★" * max(1, min(6, n_lvl))
+        if plate_class == "APEX · SUPERNOVA":
+            designation = f"α 6 OBS · {year}"
+        elif plate_class == "STELLAR":
+            designation = f"α {slug_raw[:16].upper()} · {year}"
+        else:
+            designation = f"GAIA · {year}"
+        fallback_mag = f"{n_lvl}.0" if n_lvl > 0 else "·"
 
-    magVal, gradeVal = resolveTrustData(skill, "5.0")
+    mag_val, grade_val = resolveTrustData(skill, fallback_mag)
+
+    # Apex earns the atlas publisher's Diamond Seal in the top-left corner.
+    seal = _diamond_seal(MARGIN, MARGIN + 4, size=28) if n_lvl >= 6 else ""
 
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="{OG_W}" height="{OG_H}" viewBox="0 0 {OG_W} {OG_H}"
-  class="plate plate--stellar" data-plate="V" data-branch="suite" data-level="{n_lvl}"
-  aria-label="{html.escape(og_rank_label(n_lvl, 'suite'))} — Stellar plate">
-  <defs>
-    <radialGradient id="st-core-{sid}" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#fde2a4" stop-opacity="1"/>
-      <stop offset="55%" stop-color="{AMBER_STAR}" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="{AMBER_STAR}" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
+  class="plate plate--{branch}" data-branch="{branch}" data-level="{n_lvl}"
+  data-plate-class="{html.escape(plate_class)}"
+  aria-label="{html.escape(rank_label)} — {html.escape(plate_class)} plate for /{slug}">
+  {_shared_frame(rank_label)}
+  {seal}
+  {_gutter_rule(accent)}
 
-  {_shared_frame(og_rank_label(n_lvl, 'suite'))}
+  <!-- SUBJECT column: the skill's own AOV4 medallion -->
+  {_plate_class_kicker(plate_class, accent)}
+  {_medallion(branch, n_lvl, sid, accent)}
 
-  <!-- Two concentric orbital tracks -->
-  {orbits}
+  <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
+  <text x="{slug_x}" y="{prefix_y:.1f}" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
+    font-size="26" letter-spacing="4.2" fill="{CREAM_ENGRAVED}" fill-opacity="0.65">{html.escape(prefix)}</text>
 
-  <!-- Companion dots on the orbits -->
-  {dots_svg}
-
-  <!-- Main-sequence disc -->
-  <circle cx="{cx}" cy="{cy}" r="{disc_r + 30}" fill="url(#st-core-{sid})"/>
-  <circle cx="{cx}" cy="{cy}" r="{disc_r}" fill="{AMBER_STAR}"/>
-
-  <!-- Bayer designation (catalogue prefix) -->
-  <text x="{slug_x}" y="{bayer_y}" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="{CREAM_ENGRAVED}" fill-opacity="0.7">α</text>
-
-  <!-- Slash-skill slug -->
   <text x="{slug_x}" y="{slug_y}" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="{slug_size}" fill="{CREAM_ENGRAVED}" dominant-baseline="middle">/{slug}</text>
 
-  <!-- Title kicker -->
   <text x="{slug_x}" y="{kicker_y}" font-family="'EB Garamond',Georgia,serif" font-style="italic"
     font-size="24" fill="{CREAM_ENGRAVED}" fill-opacity="0.6" dominant-baseline="middle">'{title}'</text>
 
@@ -525,209 +535,24 @@ def build_stellar_plate(skill: dict) -> str:
   {_catalog_signature(contributor, is_origin, year)}
 
   <!-- Marginal magnitude band -->
-  {_magnitude_band(magVal, gradeVal, stars_word, designation)}
-</svg>
-"""
-
-
-# ─── Plate IV · SINGULARITY ───────────────────────────────────────────────────
-
-def build_singularity_plate(skill: dict) -> str:
-    """Plate IV — black hole.
-
-    Composition: a slightly-darker disc (pure negative space) ringed by a
-    thin violet accretion hairline. Four stellar-field dots scattered
-    nearby; two of them displaced toward the void to render gravitational
-    lensing. The marginal magnitude band reads `MAG ∞` — a black hole
-    has mass but no luminosity. The star-count cell is replaced by a word
-    (`HARDENED`, `EVOLVED`, etc.) because there are no stars to count when
-    there's no light.
-    """
-    contributor = skill.get("contributor", "")
-    title_text = skill.get("title") or skill.get("name") or ""
-    title = html.escape(truncate(title_text, 64))
-    slug_raw = slug_after_slash(skill)
-    slug = html.escape(slug_raw)
-    year = designation_year(skill)
-    is_origin = bool(skill.get("origin"))
-    n_lvl = level_num(skill.get("level", "4★"))
-    sid = (skill.get("id") or "unknown").replace("/", "-").replace(" ", "-")
-
-    # Black hole sits left-of-centre. Slug right.
-    cx, cy = 360, 290
-    void_r = 80
-    ring_r_outer = 96
-    ring_r_inner = 90
-
-    # Lensing-displaced stellar field — 4 dots, 2 leaning toward the void.
-    # Original positions vs. lensed positions (the displacement IS the joke).
-    field_dots = []
-    lensed_pairs = [
-        # (x, y, displaced_x, displaced_y, opacity, is_lensed)
-        (180, 200, 195, 215, 0.55, True),    # leans toward void
-        (560, 200, 560, 200, 0.50, False),   # untouched, off to the right
-        (560, 380, 545, 365, 0.55, True),    # leans toward void
-        (180, 400, 180, 400, 0.45, False),   # untouched, lower-left
-        (300, 130, 300, 130, 0.40, False),
-    ]
-    for ox, oy, dx, dy, op, is_lensed in lensed_pairs:
-        field_dots.append(
-            f'<circle cx="{dx}" cy="{dy}" r="1.6" fill="{CREAM_ENGRAVED}" fill-opacity="{op}"/>'
-        )
-        if is_lensed:
-            # Faint streak from original to displaced position — reads as the
-            # lensing path. Cream at very low alpha so it doesn't shout.
-            field_dots.append(
-                f'<line x1="{ox}" y1="{oy}" x2="{dx}" y2="{dy}" stroke="{CREAM_ENGRAVED}" '
-                f'stroke-opacity="0.12" stroke-width="0.6"/>'
-            )
-    field_svg = "\n  ".join(field_dots)
-
-    # Slug — right side.
-    slug_x = 640
-    slug_w = OG_W - slug_x - MARGIN
-    slug_size = autoscale_font(slug_raw, default_px=84, available_w=slug_w)
-    slug_y = 286
-
-    bh_prefix_y = slug_y - 64
-    kicker_y = slug_y + 50
-
-    # Rank word (replaces the star-count cell on the magnitude band). The
-    # Singularity plate is the UNIQUE branch (4★+) — branch-forked words only,
-    # NEVER the banned Hardened/Transcendent (Ygg-II E2).
-    rank_word = _rank_word(f"{n_lvl}★", "unique").upper() if n_lvl >= 2 else "AWAITED"
-    designation = f"BH {to_roman(max(1, n_lvl))} · {year}"
-
-    magVal, gradeVal = resolveTrustData(skill, "∞")
-
-    return f"""<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-  width="{OG_W}" height="{OG_H}" viewBox="0 0 {OG_W} {OG_H}"
-  class="plate plate--singularity" data-plate="IV" data-branch="unique" data-level="{n_lvl}"
-  aria-label="{html.escape(og_rank_label(n_lvl, 'unique'))} — Singularity plate">
-  <defs>
-    <radialGradient id="bh-void-{sid}" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="85%" stop-color="#050410" stop-opacity="1"/>
-      <stop offset="100%" stop-color="{INK_NIGHT}" stop-opacity="1"/>
-    </radialGradient>
-  </defs>
-
-  {_shared_frame(og_rank_label(n_lvl, 'unique'))}
-
-  <!-- Lensing-displaced stellar field -->
-  {field_svg}
-
-  <!-- Accretion-disk hairline ring (thin violet) -->
-  <circle cx="{cx}" cy="{cy}" r="{ring_r_outer}" fill="none" stroke="{VIOLET_HALO}"
-    stroke-opacity="0.85" stroke-width="1.4"/>
-  <circle cx="{cx}" cy="{cy}" r="{(ring_r_outer + ring_r_inner) / 2}" fill="none"
-    stroke="{VIOLET_HALO}" stroke-opacity="0.35" stroke-width="0.6"/>
-
-  <!-- The void itself: same colour as the page, slightly darker, no glyph -->
-  <circle cx="{cx}" cy="{cy}" r="{void_r}" fill="url(#bh-void-{sid})"/>
-
-  <!-- BH designation (catalogue prefix) -->
-  <text x="{slug_x}" y="{bh_prefix_y}" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="28" letter-spacing="4.4" fill="{CREAM_ENGRAVED}" fill-opacity="0.7">BH-</text>
-
-  <!-- Slash-skill slug -->
-  <text x="{slug_x}" y="{slug_y}" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="{slug_size}" fill="{CREAM_ENGRAVED}" dominant-baseline="middle">/{slug}</text>
-
-  <!-- Title kicker -->
-  <text x="{slug_x}" y="{kicker_y}" font-family="'EB Garamond',Georgia,serif" font-style="italic"
-    font-size="24" fill="{CREAM_ENGRAVED}" fill-opacity="0.6" dominant-baseline="middle">'{title}'</text>
-
-  <!-- Discoverer signature -->
-  {_catalog_signature(contributor, is_origin, year)}
-
-  <!-- Marginal magnitude band — MAG ∞ -->
-  {_magnitude_band(magVal, gradeVal, f'⊘ {rank_word}', designation)}
-</svg>
-"""
-
-
-# ─── Default fallback (basic / extra) ─────────────────────────────────────────
-
-def build_default_plate(skill: dict) -> str:
-    """Minimal atlas plate for basic / extra skills.
-
-    These tiers are NOT promoted to the Atlas — the plate exists only to
-    satisfy the cron generator pipeline so it never crashes on a sub-4★
-    skill. Same atlas grammar; no celestial subject; just slug, kicker,
-    signature, and magnitude band. The marginal star count is `· · ·` — the
-    skill has not yet been catalogued as a celestial body.
-    """
-    contributor = skill.get("contributor", "")
-    title_text = skill.get("title") or skill.get("name") or ""
-    title = html.escape(truncate(title_text, 64))
-    slug_raw = slug_after_slash(skill)
-    slug = html.escape(slug_raw)
-    year = designation_year(skill)
-    is_origin = bool(skill.get("origin"))
-    n_lvl = level_num(skill.get("level", "2★"))
-    # Default plate serves the STANDARD branch (1-3★ shared ladder: Awakened /
-    # Named / Evolved). Dispatch (build_og_svg) routes 4★+ suite skills to the
-    # Stellar/Apex plates and unique skills to the Singularity plate, so this
-    # plate no longer keys on the dead `type == 'extra'` enum. The top-right
-    # label is the branch-forked rank word, not a flat "Basic Skill" (E1/E2).
-    branch = og_branch(skill)
-    plate_label = og_rank_label(n_lvl, branch)
-    plate_css_val = f"rank-{n_lvl}"
-
-    slug_x = MARGIN + 12
-    slug_w = OG_W - slug_x - MARGIN
-    slug_size = autoscale_font(slug_raw, default_px=72, available_w=slug_w)
-    slug_y = 290
-    kicker_y = slug_y + 46
-
-    stars = "★" * max(1, min(6, n_lvl))
-    designation = f"GAIA · {year}"
-    fallbackMag = f"{n_lvl}.0" if n_lvl > 0 else "·"
-    magVal, gradeVal = resolveTrustData(skill, fallbackMag)
-
-    return f"""<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-  width="{OG_W}" height="{OG_H}" viewBox="0 0 {OG_W} {OG_H}"
-  class="plate plate--default" data-plate="{plate_css_val}" data-branch="{branch}" data-level="{n_lvl}"
-  aria-label="{html.escape(plate_label)} plate">
-  {_shared_frame(plate_label)}
-
-  <!-- Slash-skill slug (no celestial subject for sub-4★ skills) -->
-  <text x="{slug_x}" y="{slug_y}" font-family="'EB Garamond',Georgia,serif" font-weight="600"
-    font-size="{slug_size}" fill="{CREAM_ENGRAVED}" dominant-baseline="middle">/{slug}</text>
-
-  <text x="{slug_x}" y="{kicker_y}" font-family="'EB Garamond',Georgia,serif" font-style="italic"
-    font-size="24" fill="{CREAM_ENGRAVED}" fill-opacity="0.6" dominant-baseline="middle">'{title}'</text>
-
-  {_catalog_signature(contributor, is_origin, year)}
-
-  {_magnitude_band(magVal, gradeVal, stars, designation)}
+  {_magnitude_band(mag_val, grade_val, stars_or_word, designation)}
 </svg>
 """
 
 
 # ─── Dispatcher ───────────────────────────────────────────────────────────────
 
+
 def build_og_svg(skill: dict) -> str:
-    """Pick the right Hall Plate based on read-time BRANCH + rank (Ygg-II E1).
+    """Render the Hall Plate for a skill via the unified branch+rank builder.
 
-    Dispatch keys on computeBranch(skill) + star rank — NEVER the dead
-    `type == 'ultimate'|'unique'|'extra'` enum. Under the old enum EVERY named
-    skill (type is only ever basic/fusion) fell through to the barren
-    "Basic Skill" default plate; branch dispatch gives all 6 ranks × 2 branches
-    a proper composition:
-
-    - unique branch (4★+)                → Singularity (Plate IV, violet) —
-      the standalone off-spectrum treatment; covers 4/5/6★.
-    - suite branch, 6★                   → Apex Supernova (Plate VI, gold)
-    - suite branch, 4-5★                 → Stellar (Plate V, amber star)
-    - standard branch (1-3★) / sub-4★    → default plate (not yet a celestial
-      body — correct, not a fallback dead-zone)
+    Read-time BRANCH (computeBranch) + star rank drive the whole composition
+    (Ygg-II E1) — never a stored type enum. That enum once sent every named
+    skill (type is only ever basic/fusion) to a barren fallback plate;
+    `build_plate` now classes the subject medallion, the plate-class word, the
+    rank label, and the gutter tint off that branch+rank instead.
     """
     level = skill.get("level", "")
-    n_lvl = level_num(level)
 
     # Defence-in-depth: pre-named/demoted skills get no OG card path at all
     # (the main loop skips them), but if a preview/sample ever renders one,
@@ -737,15 +562,8 @@ def build_og_svg(skill: dict) -> str:
         skill["contributor"] = REDACTED_HANDLE
         skill["origin"] = False
 
-    branch = og_branch(skill)
+    return build_plate(skill)
 
-    if branch == "unique":
-        return build_singularity_plate(skill)
-    if n_lvl >= 6:
-        return build_supernova_plate(skill)
-    if n_lvl >= 4:
-        return build_stellar_plate(skill)
-    return build_default_plate(skill)
 
 
 # ─── Raster fallback (optional cairosvg / wand pipeline) ──────────────────────


### PR DESCRIPTION
## Yggdrasil II · Wave 2 · N-8 — Share / OG card /impeccable reshape

Fixes the OG card's core dispatch bug + dead-zone art region. **Reviewer verdict: PASS (minor).**

### What shipped
1. **/impeccable composition** — the barren center-right dead zone is gone. Card is now a two-column 19th-c. natural-history atlas plate: LEFT = catalogue prefix + EB-Garamond slug + italic title + gold "Cataloged by @handle · ORIGIN · 2026" + Departure-Mono magnitude band; RIGHT = a framed AOV medallion in a brass plaque ring; vertical gutter fold rule separates them.
2. **AOV assets** — the medallion embeds the AOV V4 `-hero` webp by branch+rank (suite/standard→`aov4-c{1..6}`, unique→`aov4-d{4..6}`) via same-origin relative href, disc-clipped with cream+accent hairline rings.
3. **All-rank dispatch (the core bug)** — plate selection now keys on read-time `computeBranch` (imported from `gaia_cli.trustMagnitude`, reused) + star rank, NOT the dead type enum. Rank vocabulary via `gaia_cli.formatting.rank_word` (branch-forked). Baked-in HARDENED/TRANSCENDENT `<text>` gone; bare "Basic Skill" top-right label replaced by branch-forked rank label. Legacy per-type plate builders + AMBER_STAR deleted. Every named skill now renders a rich plate; the fallback dead-zone is eliminated.

### Verification
- 159 cards / 29 handles regenerated. 105 card-renderer tests pass. Share-modal path exercised end-to-end via Playwright (1280 + 390): gstack 5★-suite → STELLAR gold tree-orb medallion, "Ultimate · 5★"; impeccable 4★-unique → SINGULARITY violet, "Unique · 4★"; dspy 3★ → FIELD BODY, "Evolved · 3★".
- Authorship all `mbtiongson1`; diff 160 files (159 SVG + 1 script), zero Class-P leak, zero banned words, zero raw hex in output, zero dead-enum reads.

### Known minor (deferred to Wave 3 sweep)
- Unique-branch "SINGULARITY" kicker in violet #7c3aed = 3.36:1 on ink (below AA 4.5:1). Mitigated: the same classification is carried at full contrast elsewhere on the card ("Unique · N★" cream + "⊘ UNIQUE" magnitude band). Cosmetic polish, no info loss.

Part of EPIC #1002 · #998.
