### PR TITLE
design(ygg2-w2b): N-10 footer redesign + cross-brand Gaia Research CTA (Rimuru-Blue bridge)

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -36,6 +36,15 @@
   --honor-red-rgb: 239, 68, 68;
   --apex-gold: var(--rank-5);
   --apex-gold-rgb: 251, 191, 36;
+  /* Gaia Research sibling-brand bridge tokens. Rimuru-Blue is the EXACT
+     cross-brand match to --tier-basic (the natural bridge accent); Milim-Pink
+     is the Research counter-accent, already present as --cluster-5. Declared
+     once here as role tokens and only ever referenced via var() — no new hex. */
+  --research-blue: var(--tier-basic);
+  --research-blue-rgb: var(--tier-basic-rgb);
+  --research-pink: var(--cluster-5);
+  --research-pink-rgb: 236, 72, 153;
+  --font-research: 'Syne', 'Bricolage Grotesque', system-ui, sans-serif;
   --font-display: 'EB Garamond', Georgia, serif;
   --font-body: 'Bricolage Grotesque', Inter, system-ui, sans-serif;
   --font-mono: 'Departure Mono', 'JetBrains Mono', ui-monospace, monospace;
@@ -6436,6 +6445,130 @@ footer.footer-v2::before {
   margin: 0;
 }
 
+/* ── Gaia brand family: "one house, two rooms." ──────────────────────
+   The Atlas mark keeps its serif/gold language; the Gaia Research mark
+   is rendered in ITS OWN language (Syne + Rimuru-Blue) as a distinct-but
+   -sibling block, bound by connective copy naming the flagship relation.
+   Rimuru-Blue (--research-blue == --tier-basic) is the exact shared token,
+   so the two rooms visibly belong to one house without merging the two
+   design systems. */
+.footer-v2 .footer-family {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+/* Kinship connector: a short vertical rule graduating from Atlas gold to
+   Research blue, plus the connective copy. The gradient IS the bridge. */
+.footer-v2 .footer-kinship {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  margin-top: .35rem;
+}
+
+.footer-v2 .footer-kinship-line {
+  flex: 0 0 auto;
+  width: 2px;
+  height: 2.1rem;
+  border-radius: 2px;
+  background: linear-gradient(
+    180deg,
+    rgba(var(--apex-gold-rgb), .85) 0%,
+    rgba(var(--research-blue-rgb), .85) 100%
+  );
+}
+
+.footer-v2 .footer-kinship-copy {
+  margin: 0;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: .82rem;
+  line-height: 1.3;
+  color: var(--muted);
+  max-width: 15ch;
+}
+
+/* The Gaia Research lockup — sibling brand in its own visual language. */
+.footer-v2 .footer-research {
+  display: inline-flex;
+  align-items: center;
+  gap: .7rem;
+  padding: .7rem .9rem;
+  border: 1px solid rgba(var(--research-blue-rgb), .28);
+  border-radius: 10px;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(var(--research-blue-rgb), .1) 0%,
+      rgba(var(--research-pink-rgb), .07) 100%
+    );
+  text-decoration: none;
+  transition:
+    border-color .32s cubic-bezier(0.16, 1, 0.3, 1),
+    background .32s cubic-bezier(0.16, 1, 0.3, 1),
+    transform .32s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow .32s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.footer-v2 .footer-research:hover,
+.footer-v2 .footer-research:focus-visible {
+  border-color: rgba(var(--research-blue-rgb), .6);
+  background:
+    linear-gradient(
+      135deg,
+      rgba(var(--research-blue-rgb), .18) 0%,
+      rgba(var(--research-pink-rgb), .12) 100%
+    );
+  transform: translateY(-1px);
+  box-shadow:
+    0 0 0 1px rgba(var(--research-blue-rgb), .2),
+    0 8px 22px rgba(var(--research-blue-rgb), .18);
+  outline: none;
+}
+
+/* Hex-lens seal — the shared motif, rendered in Research blue not Atlas gold. */
+.footer-v2 .footer-research-lens {
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--research-blue);
+  filter: drop-shadow(0 0 6px rgba(var(--research-blue-rgb), .45));
+  transition: transform .5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.footer-v2 .footer-research:hover .footer-research-lens {
+  transform: rotate(30deg);
+}
+
+.footer-v2 .footer-research-mark {
+  display: flex;
+  flex-direction: column;
+  gap: .12rem;
+  line-height: 1.05;
+}
+
+/* Syne wordmark — Research's own display voice. */
+.footer-v2 .footer-research-name {
+  font-family: var(--font-research);
+  font-weight: 700;
+  font-size: .95rem;
+  letter-spacing: -.01em;
+  color: var(--text);
+}
+
+.footer-v2 .footer-research-cta {
+  font-family: var(--font-mono);
+  font-size: .68rem;
+  letter-spacing: .04em;
+  color: var(--research-blue);
+  transition: letter-spacing .32s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.footer-v2 .footer-research:hover .footer-research-cta {
+  letter-spacing: .09em;
+}
+
 /* Link columns grid */
 .footer-v2 .footer-cols {
   display: grid;
@@ -6655,12 +6788,38 @@ footer.footer-v2::before {
     grid-template-columns: repeat(2, 1fr);
     gap: 1.75rem 2.5rem;
   }
+  /* On the stacked layout let the brand family breathe full-width and the
+     Research lockup sit as a comfortable tap target. */
+  .footer-v2 .footer-research {
+    align-self: flex-start;
+  }
 }
 
 @media (max-width: 520px) {
   .footer-v2 .footer-cols {
     grid-template-columns: repeat(2, 1fr);
     gap: 1.5rem;
+  }
+  .footer-v2 .footer-research {
+    width: 100%;
+  }
+}
+
+/* Kinship gradient + lens rotation are decorative; honor reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  .footer-v2 .footer-research,
+  .footer-v2 .footer-research-lens,
+  .footer-v2 .footer-research-cta {
+    transition: none;
+  }
+  .footer-v2 .footer-research:hover {
+    transform: none;
+  }
+  .footer-v2 .footer-research:hover .footer-research-lens {
+    transform: none;
+  }
+  .footer-v2 .footer-research:hover .footer-research-cta {
+    letter-spacing: .04em;
   }
 }
 

--- a/docs/js/site-footer.js
+++ b/docs/js/site-footer.js
@@ -7,6 +7,19 @@
   const el = document.getElementById('site-footer-mount');
   if (!el) return;
 
+  // Load the Syne webfont for the Gaia Research sibling lockup. We load it
+  // ourselves (our own CSS/DOM) and never import gaia-research files — the
+  // cross-repo content rule allows hyperlinks + legible kinship, not merger.
+  // Injected once from the footer so it propagates on every page the footer
+  // mounts into, no per-page <head> edits.
+  if (!document.getElementById('gaia-research-font')) {
+    const rf = document.createElement('link');
+    rf.id = 'gaia-research-font';
+    rf.rel = 'stylesheet';
+    rf.href = 'https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&display=swap';
+    document.head.appendChild(rf);
+  }
+
   // Fallback mirrors docs/js/mounts.js — keep in lockstep. Every top-level
   // docs/ subdirectory that uses site-nav or site-footer must appear here so
   // path-depth math still resolves when mounts.js hasn't loaded yet.
@@ -27,13 +40,40 @@
     <footer class="footer-v2">
       <div class="footer-inner">
         <div class="footer-brand-col">
-          <div class="footer-brand-mark">
-            <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-              <use href="${r}assets/icons.svg#seal-diamond"/>
-            </svg>
-            <span class="footer-wordmark">Gaia</span>
+          <div class="footer-family" aria-label="Gaia brand family">
+
+            <div class="footer-brand-mark">
+              <svg class="ico footer-seal" aria-hidden="true" focusable="false">
+                <use href="${r}assets/icons.svg#seal-diamond"/>
+              </svg>
+              <span class="footer-wordmark">Gaia</span>
+            </div>
+            <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
+
+            <div class="footer-kinship">
+              <span class="footer-kinship-line" aria-hidden="true"></span>
+              <p class="footer-kinship-copy">
+                The flagship registry of
+              </p>
+            </div>
+
+            <a class="footer-research" href="https://research.gaiaskilltree.com"
+               target="_blank" rel="noopener"
+               aria-label="Gaia Research — visit research.gaiaskilltree.com">
+              <span class="footer-research-lens" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="22" height="22" fill="none">
+                  <path d="M12 2.5 20.5 7v10L12 21.5 3.5 17V7L12 2.5Z"
+                        stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
+                  <circle cx="12" cy="12" r="3.4" stroke="currentColor" stroke-width="1.4"/>
+                </svg>
+              </span>
+              <span class="footer-research-mark">
+                <span class="footer-research-name">Gaia Research</span>
+                <span class="footer-research-cta">Enter the lab <span aria-hidden="true">→</span></span>
+              </span>
+            </a>
+
           </div>
-          <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
         </div>
 
         <nav class="footer-cols" aria-label="Site navigation">


### PR DESCRIPTION
## Yggdrasil II · Wave 2 · N-10 — Footer redesign + cross-brand Gaia Research CTA

**Reviewer verdict: PASS (minor).** Single footer mount (`site-footer.js`) → propagates site-wide.

### What shipped
- **Gaia Research CTA** — a visible, user-facing link to research.gaiaskilltree.com expressing the parent→flagship relationship ("Gaia Skill Tree is the flagship registry of Gaia Research"). Previously the only on-site reference was invisible JSON-LD.
- **Cross-brand reconciliation ("one house, two rooms")** — the Atlas footer keeps its serif/gold language; the Gaia Research sibling block is rendered in ITS OWN language (Syne wordmark + Rimuru-Blue accent) as a distinct-but-sibling lockup. Bridge accent = `--tier-basic` (#38bdf8 == Rimuru-Blue, exact token match). No wholesale Cyber-Slime token import — legible kinship, not merger. Syne loaded via our own CSS (no cross-repo file import).

### Verification
- Screenshot-verified 1280 + 390 on homepage AND /named/. Authorship `mbtiongson1`; 2 files (site-footer.js + styles.css), zero raw hex, zero banned words, no layout regression.

### Known minor (deferred to Wave 3 sweep)
- `--research-pink-rgb` / Syne 4th font family are DESIGN.md-E5-sanctioned for the sibling block; `--research-pink-rgb` triplet could alias a future `--cluster-5-rgb` token (token-purity nit, passes hex guard). `.footer-kinship-copy` uses the pre-existing `--muted` token (4.23:1) — not introduced by this diff.

Part of EPIC #1002 · #998.
