### PR TITLE
design(ygg2-w2c): N-7 reports design system (docs/reports/ + named/report.html)

### DIFF
--- a/docs/named/report.html
+++ b/docs/named/report.html
@@ -18,30 +18,25 @@
   <link rel="stylesheet" href="../css/plaque.css?v=6.8.8">
   <script src="../js/icons.js?v=6.8.8"></script>
   <script src="../js/atlas-helpers.js?v=6.8.8"></script>
+  <script src="../js/skill-semantics.js?v=6.8.8"></script>
   <script src="../js/rank-badge.js?v=6.8.8"></script>
 
   <style>
-    /* ── Grade color tokens (mirrors GRADE_COLORS in src/gaia_cli/formatting.py) ── */
+    /* ── Report status tokens — semantic aliases over the shared palette.
+       Evidence-grade coloring (S/A/B/C) is owned globally by styles.css via
+       [data-grade] selectors, so no local grade tokens live here. These four
+       cover the pass / next-step / caution / fail states unique to this
+       report surface. All resolve to existing design tokens (rubric E7 —
+       token-only, no raw hex). ── */
     :root {
-      --grade-s: #e2e8f0;
-      --grade-s-bg: rgba(226, 232, 240, 0.12);
-      --grade-s-border: rgba(226, 232, 240, 0.35);
-      --grade-a: #fbbf24;
-      --grade-a-bg: rgba(251, 191, 36, 0.12);
-      --grade-a-border: rgba(251, 191, 36, 0.35);
-      --grade-b: #94a3b8;
-      --grade-b-bg: rgba(148, 163, 184, 0.12);
-      --grade-b-border: rgba(148, 163, 184, 0.35);
-      --grade-c: #b45309;
-      --grade-c-bg: rgba(180, 83, 9, 0.12);
-      --grade-c-border: rgba(180, 83, 9, 0.35);
-      --grade-none: #475569;
-      --grade-none-bg: rgba(71, 85, 105, 0.12);
-      --grade-none-border: rgba(71, 85, 105, 0.35);
-
-      --type-repo: #38bdf8;
-      --type-arxiv: #10b981;
-      --type-github-stars: #fbbf24;
+      --report-ok:        var(--cluster-2);         /* verified · rank-up · pass */
+      --report-ok-rgb:    16, 185, 129;
+      --report-next:      var(--apex-gold);         /* actionable next step */
+      --report-next-rgb:  var(--apex-gold-rgb);
+      --report-warn:      var(--tier-fusion);       /* stale · disputed */
+      --report-warn-rgb:  var(--tier-fusion-rgb);
+      --report-danger:    var(--honor-red);         /* fail · dead link · demote */
+      --report-danger-rgb: var(--honor-red-rgb);
     }
 
     /* ── Layout ── */
@@ -280,9 +275,9 @@
       color: var(--muted);
       vertical-align: middle;
     }
-    .ev-type[data-type="repo"] { color: var(--type-repo); border-color: rgba(56,189,248,.3); }
-    .ev-type[data-type="arxiv"] { color: var(--type-arxiv); border-color: rgba(16,185,129,.3); }
-    .ev-type[data-type="github-stars"] { color: var(--type-github-stars); border-color: rgba(251,191,36,.3); }
+    .ev-type[data-type="repo"] { color: var(--tier-basic); border-color: var(--tier-basic-border); }
+    .ev-type[data-type="arxiv"] { color: var(--report-ok); border-color: rgba(var(--report-ok-rgb),.3); }
+    .ev-type[data-type="github-stars"] { color: var(--apex-gold); border-color: rgba(var(--apex-gold-rgb),.3); }
 
     .ev-source-link {
       color: var(--muted);
@@ -341,9 +336,9 @@
       border-radius: 0.4rem;
     }
 
-    .gap-row--green { border-color: rgba(16,185,129,.3); }
-    .gap-row--amber { border-color: rgba(251,191,36,.3); }
-    .gap-row--red { border-color: rgba(239,68,68,.25); }
+    .gap-row--green { border-color: rgba(var(--report-ok-rgb),.3); }
+    .gap-row--amber { border-color: rgba(var(--report-next-rgb),.3); }
+    .gap-row--red { border-color: rgba(var(--report-danger-rgb),.25); }
 
     .gap-icon {
       width: 1.5rem;
@@ -356,8 +351,8 @@
       flex-shrink: 0;
       margin-top: 0.1rem;
     }
-    .gap-icon--check { background: rgba(16,185,129,.15); color: #10b981; }
-    .gap-icon--next  { background: rgba(251,191,36,.15); color: #fbbf24; }
+    .gap-icon--check { background: rgba(var(--report-ok-rgb),.15); color: var(--report-ok); }
+    .gap-icon--next  { background: rgba(var(--report-next-rgb),.15); color: var(--report-next); }
     .gap-icon--lock  { background: rgba(148,163,184,.1); color: var(--muted); }
 
     .gap-body { flex: 1; min-width: 0; }
@@ -376,8 +371,8 @@
       border: 1px solid;
       margin-bottom: 0.85rem;
     }
-    .gate-status--pass { color: #10b981; background: rgba(16,185,129,.08); border-color: rgba(16,185,129,.3); }
-    .gate-status--fail { color: #ef4444; background: rgba(239,68,68,.07); border-color: rgba(239,68,68,.25); }
+    .gate-status--pass { color: var(--report-ok); background: rgba(var(--report-ok-rgb),.08); border-color: rgba(var(--report-ok-rgb),.3); }
+    .gate-status--fail { color: var(--report-danger); background: rgba(var(--report-danger-rgb),.07); border-color: rgba(var(--report-danger-rgb),.25); }
 
     .gate-reason {
       font-size: 0.85rem;
@@ -422,9 +417,9 @@
       margin-top: 0.05rem;
     }
 
-    .tl-dot--rank_up   { color: #10b981; border-color: rgba(16,185,129,.4); }
-    .tl-dot--evidence  { color: #fbbf24; border-color: rgba(251,191,36,.4); }
-    .tl-dot--demote    { color: #ef4444; border-color: rgba(239,68,68,.4); }
+    .tl-dot--rank_up   { color: var(--report-ok); border-color: rgba(var(--report-ok-rgb),.4); }
+    .tl-dot--evidence  { color: var(--report-next); border-color: rgba(var(--report-next-rgb),.4); }
+    .tl-dot--demote    { color: var(--report-danger); border-color: rgba(var(--report-danger-rgb),.4); }
 
     .tl-body { flex: 1; min-width: 0; }
     .tl-action { font-weight: 600; color: var(--text); margin-bottom: 0.1rem; text-transform: capitalize; }
@@ -456,10 +451,12 @@
     }
 
     /* ── Tier orb colors (mirrors typeColors in gaia.json) ── */
-    .report-header-orb[data-type="basic"]    { color: var(--tier-basic);    background: var(--tier-basic-bg);    border-color: var(--tier-basic-border); }
-    .report-header-orb[data-type="extra"]    { color: var(--tier-extra);    background: var(--tier-extra-bg);    border-color: var(--tier-extra-border); }
-    .report-header-orb[data-type="unique"]   { color: var(--tier-unique);   background: var(--tier-unique-bg);   border-color: var(--tier-unique-border); }
-    .report-header-orb[data-type="ultimate"] { color: var(--tier-ultimate); background: var(--tier-ultimate-bg); border-color: var(--tier-ultimate-border); }
+    /* ── Header orb — keyed on the read-time branch (rubric E1). Never on a
+       dead type enum. computeBranch returns 'standard' | 'suite' | 'unique';
+       standard borrows the basic tier color, suite the fusion color. ── */
+    .report-header-orb[data-branch="standard"] { color: var(--tier-basic);  background: var(--tier-basic-bg);  border-color: var(--tier-basic-border); }
+    .report-header-orb[data-branch="suite"]    { color: var(--tier-fusion); background: var(--tier-fusion-bg); border-color: var(--tier-fusion-border); }
+    .report-header-orb[data-branch="unique"]   { color: var(--tier-unique); background: var(--tier-unique-bg); border-color: var(--tier-unique-border); }
 
     /* ── Inherited evidence label ── */
     .ev-inherited-tag {
@@ -486,10 +483,10 @@
       vertical-align: middle;
       margin-left: 0.25rem;
     }
-    .ev-flag--stale  { color: #f59e0b; border-color: rgba(245,158,11,.4); background: rgba(245,158,11,.07); }
-    .ev-flag--dead   { color: #ef4444; border-color: rgba(239,68,68,.4);  background: rgba(239,68,68,.07); }
-    .ev-flag--verified   { color: #10b981; border-color: rgba(16,185,129,.4); background: rgba(16,185,129,.07); }
-    .ev-flag--disputed   { color: #f59e0b; border-color: rgba(245,158,11,.4); background: rgba(245,158,11,.07); }
+    .ev-flag--stale  { color: var(--report-warn); border-color: rgba(var(--report-warn-rgb),.4); background: rgba(var(--report-warn-rgb),.07); }
+    .ev-flag--dead   { color: var(--report-danger); border-color: rgba(var(--report-danger-rgb),.4);  background: rgba(var(--report-danger-rgb),.07); }
+    .ev-flag--verified   { color: var(--report-ok); border-color: rgba(var(--report-ok-rgb),.4); background: rgba(var(--report-ok-rgb),.07); }
+    .ev-flag--disputed   { color: var(--report-warn); border-color: rgba(var(--report-warn-rgb),.4); background: rgba(var(--report-warn-rgb),.07); }
 
     /* ── Links card ── */
     .links-list {
@@ -516,7 +513,7 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
-    .links-row a:hover { color: #38bdf8; }
+    .links-row a:hover { color: var(--tier-basic); }
     .links-kind {
       font-family: var(--font-mono);
       font-size: 0.7rem;
@@ -567,16 +564,16 @@
       transition: border-color 0.15s, color 0.15s;
     }
     .upgrade-chip:hover {
-      border-color: #38bdf8;
-      color: #38bdf8;
+      border-color: var(--tier-basic);
+      color: var(--tier-basic);
     }
     .upgrade-chip--current {
-      background: rgba(251,191,36,0.08);
-      border-color: rgba(251,191,36,0.4);
-      color: #fbbf24;
+      background: rgba(var(--apex-gold-rgb),0.08);
+      border-color: rgba(var(--apex-gold-rgb),0.4);
+      color: var(--apex-gold);
       cursor: default;
     }
-    .upgrade-chip--current:hover { color: #fbbf24; border-color: rgba(251,191,36,0.4); }
+    .upgrade-chip--current:hover { color: var(--apex-gold); border-color: rgba(var(--apex-gold-rgb),0.4); }
     .upgrade-empty {
       font-style: italic;
       color: var(--muted);
@@ -626,16 +623,30 @@
     var NAMED_INDEX_URL = '../graph/named/index.json';
     var GRAPH_URL = '../graph/gaia.json';
 
-    var LEVEL_LABELS = {
-      '0': 'Basic', '1': 'Awakened', '2': 'Named',
-      '3': 'Evolved', '4': 'Hardened', '5': 'Transcendent', '6': 'Apex'
-    };
-
-    var TYPE_SYMBOLS = { basic: '○', extra: '◇', unique: '◉', ultimate: '◆' };
+    /* Branch → header-orb glyph. Mirrors the tier symbol tokens in tokens.css
+       (basic '○', fusion '◆', unique '◉'). Keyed on the read-time branch,
+       never a stored type (rubric E1). */
+    var BRANCH_SYMBOL = { standard: '○', suite: '◆', unique: '◉' };
 
     var GRADE_LABELS = { S: 'Platinum', A: 'Gold', B: 'Silver', C: 'Bronze' };
 
     var GRADE_ORDER = ['S', 'A', 'B', 'C'];
+
+    /* ── Branch + rank vocabulary — delegated to the shared resolver
+       (docs/js/skill-semantics.js). NEVER branch off a stored type such as
+       'ultimate' / 'extra' / 'unique' (rubric E1); NEVER emit the two retired
+       4★/5★ rank words the resolver replaced (rubric E2). The resolver forks
+       rank words by branch at 4★+. ── */
+    function branchOf(skill) {
+      return (window.GaiaSemantics && window.GaiaSemantics.computeBranch)
+        ? window.GaiaSemantics.computeBranch(skill, skill && skill.level)
+        : 'standard';
+    }
+    function rankNameOf(skill) {
+      return (window.GaiaSemantics && window.GaiaSemantics.rankWord)
+        ? window.GaiaSemantics.rankWord(skill && skill.level, branchOf(skill))
+        : ((skill && skill.level) || '');
+    }
 
     /* ── helpers ── */
     function esc(v) {
@@ -733,7 +744,7 @@
 
       return {
         levelNum: levelNum,
-        rankName: LEVEL_LABELS[String(levelNum)] || level,
+        rankName: rankNameOf(skill),
         sinceIso: sinceIso,
         sinceDisplay: fmtDate(sinceIso),
         sinceAgo: daysAgo(sinceIso),
@@ -743,7 +754,10 @@
     /* ── Compute actionable gap ── */
     function computeGap(skill) {
       var grade = (skill.overallTrustGrade || '').trim();
-      var isUltimate = skill.type === 'ultimate';
+      // Suite gate applies to suite-branch skills — derived, never off a type
+      // enum (rubric E1). computeBranch returns 'suite' for skills carrying
+      // suiteComponents.
+      var isSuite = branchOf(skill) === 'suite';
       var evidence = Array.isArray(skill.evidence) ? skill.evidence : [];
       var gateStatus = skill.ultimateGateStatus || null;
 
@@ -789,8 +803,8 @@
         }
       }
 
-      // Suite gate gap (for ultimates)
-      if (isUltimate && gateStatus) {
+      // Suite gate gap (for suite-branch skills)
+      if (isSuite && gateStatus) {
         if (gateStatus.passes) {
           rows.push({
             kind: 'check',
@@ -812,13 +826,13 @@
         rows.push({
           kind: 'next',
           title: 'Rank gap: evidence outpaces current stars',
-          desc: 'Silver (B) evidence supports higher rank than ' + (LEVEL_LABELS[String(levelNum)] || skill.level) + '. Run <code>gaia scan</code> to generate promotion candidates, then <code>gaia promote</code> when eligible.'
+          desc: 'Silver (B) evidence supports higher rank than ' + (rankNameOf(skill) || skill.level) + '. Run <code>gaia scan</code> to generate promotion candidates, then <code>gaia promote</code> when eligible.'
         });
       } else if (levelNum < 4 && grade === 'A') {
         rows.push({
           kind: 'next',
           title: 'Rank gap: Gold evidence supports advancement',
-          desc: 'Gold (A) grade evidence can support progression beyond ' + (LEVEL_LABELS[String(levelNum)] || skill.level) + '. Run <code>gaia scan</code> to check promotion eligibility.'
+          desc: 'Gold (A) grade evidence can support progression beyond ' + (rankNameOf(skill) || skill.level) + '. Run <code>gaia scan</code> to check promotion eligibility.'
         });
       }
 
@@ -839,28 +853,29 @@
     }
 
     function renderHeader(skill) {
-      var type = skill.type || 'basic';
-      var sym = TYPE_SYMBOLS[type] || '○';
+      var branch = branchOf(skill);
+      var sym = BRANCH_SYMBOL[branch] || '○';
       var levelNum = parseLevel(skill.level);
       var rankBadgeHtml = (typeof window.rankBadge === 'function')
         ? window.rankBadge(levelNum, { variant: 'full', size: 'md' })
         : '<span>' + esc(skill.level || '') + '</span>';
 
-      var tierBadge = '<span style="font-family:var(--font-mono);font-size:0.72rem;padding:.2rem .5rem;border-radius:.25rem;background:rgba(255,255,255,.04);border:1px solid var(--border);color:var(--muted);text-transform:capitalize;">' + esc(type) + '</span>';
+      var branchWord = branch === 'unique' ? 'Unique' : (branch === 'suite' ? 'Suite' : 'Standard');
+      var tierBadge = '<span style="font-family:var(--font-mono);font-size:0.72rem;padding:.2rem .5rem;border-radius:.25rem;background:rgba(255,255,255,.04);border:1px solid var(--border);color:var(--muted);text-transform:capitalize;">' + esc(branchWord) + '</span>';
 
       document.title = esc(skill.name) + ' — Trust Report · Gaia';
       var titleEl = document.getElementById('pageTitle');
       if (titleEl) titleEl.textContent = skill.name + ' — Trust Report · Gaia';
 
       return '<div class="report-header">' +
-        '<div class="report-header-orb" data-type="' + esc(type) + '">' + esc(sym) + '</div>' +
+        '<div class="report-header-orb" data-branch="' + esc(branch) + '">' + esc(sym) + '</div>' +
         '<div class="report-header-meta">' +
           '<h1 class="report-skill-name">' + esc(skill.name) + '</h1>' +
           (skill.title ? '<div class="report-skill-title">' + esc(skill.title) + '</div>' : '') +
           '<div class="report-skill-contributor">' +
             '<span>by</span>' +
             '<span class="report-contributor-name">@' + esc(skill.contributor || '?') + '</span>' +
-            (skill.origin ? ' <span style="font-size:.7rem;color:#fbbf24;font-family:var(--font-mono);">★ origin</span>' : '') +
+            (skill.origin ? ' <span style="font-size:.7rem;color:var(--apex-gold);font-family:var(--font-mono);">★ origin</span>' : '') +
           '</div>' +
         '</div>' +
         '<div class="report-header-badges">' +
@@ -1057,7 +1072,9 @@
     }
 
     function renderGateCard(skill) {
-      if (skill.type !== 'ultimate') return '';
+      // Suite gate renders only for suite-branch skills — derived at read-time
+      // (rubric E1), never off a 'ultimate' type enum.
+      if (branchOf(skill) !== 'suite') return '';
       var gate = skill.ultimateGateStatus;
       if (!gate) return '';
 
@@ -1310,8 +1327,5 @@
   }());
   </script>
 
-<!-- impeccable-live-start -->
-<script src="http://localhost:8400/live.js"></script>
-<!-- impeccable-live-end -->
 </body>
 </html>

--- a/docs/reports/2026-28/index.html
+++ b/docs/reports/2026-28/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.1.1";</script>
+  <script>window.GAIA_VERSION = "6.0.1";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -17,59 +17,312 @@
   <meta property="og:url" content="https://gaiaskilltree.com/reports/2026-28/">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" type="image/svg+xml" href="../../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.1.1">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.1.1">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.0.1">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.0.1">
   <link rel="alternate" type="application/json" href="https://gaiaskilltree.com/api/v1/reports/2026-28.json">
 
   <style>
-    /* ── Deferred-surface WIP banner ──────────────────────────────────────
-       Discloses that this surface renders in its L3-mechanical bridge
-       state pending the Sprint F rendering-layer rewrite (issue #973).
-       Follows the deferred-surface convention in CLAUDE.md §Deferred
-       surface convention. Removed by the port. */
-    .wip-banner {
+    /* ─────────────────────────────────────────────────────────────
+       WEEKLY REPORT — one ISO week of registry movement, read as a
+       ledger. Shares the archive register (.reports-shell): EB Garamond
+       display, Bricolage body, JetBrains Mono for identifiers and
+       numerics. Evidence-grade chips reuse the global .ev-grade family
+       from styles.css ([data-grade] coloring). Body copy sits on
+       --text against --bg for 4.5:1+ contrast. Token-only (rubric E7);
+       mobile-first with min-width breakpoints (rubric E6).
+       ───────────────────────────────────────────────────────────── */
+
+    .report-shell {
       max-width: 62rem;
-      /* Clear the fixed nav (~58px). Matches the 5rem/6rem top-clearance
-         pattern used by .bench-shell and .reports-shell. */
-      margin: 5rem auto 0;
-      padding: 0.75rem 1.5rem;
-      display: flex;
-      align-items: baseline;
-      flex-wrap: wrap;
-      gap: 0.5rem 0.9rem;
-      font-family: var(--font-mono);
-      font-size: 0.78rem;
-      line-height: 1.55;
+      margin: 0 auto;
+      padding: 5rem 1.25rem 6rem;
       color: var(--text);
-      background: rgba(var(--evidence-gold-rgb), 0.06);
-      border: 1px solid rgba(var(--evidence-gold-rgb), 0.28);
-      border-radius: 6px;
-      letter-spacing: 0.02em;
+      font-family: var(--font-body);
     }
     @media (min-width: 768px) {
-      .wip-banner { margin-top: 6rem; }
+      .report-shell { padding: 8rem 2rem 7rem; }
     }
-    .wip-banner .wip-tag {
-      color: var(--evidence-gold);
-      font-weight: 500;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
+
+    /* ── Masthead: the report's metadata header ─────────────── */
+    .report-masthead {
+      margin: 0 0 3.5rem;
+      padding-bottom: 1.75rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .report-eyebrow {
+      font-family: var(--font-mono);
       font-size: 0.72rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin: 0 0 0.85rem;
     }
-    .wip-banner .wip-body { color: var(--text); opacity: 0.86; }
-    .wip-banner a {
+    .report-masthead h1 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: clamp(2.2rem, 6vw, 3.5rem);
+      line-height: 1.04;
+      letter-spacing: -0.02em;
+      margin: 0 0 1.25rem;
+      color: var(--text);
+      text-wrap: balance;
+    }
+    .report-masthead h1 em {
+      font-style: italic;
+      color: var(--apex-gold);
+      font-weight: 400;
+    }
+    .report-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      line-height: 1.6;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+    .report-meta .rm-item { white-space: nowrap; }
+    .report-meta .rm-item strong {
+      color: var(--text);
+      font-weight: 500;
+    }
+    .report-meta code {
+      font-family: var(--font-mono);
       color: var(--evidence-gold);
-      text-decoration: none;
-      border-bottom: 1px solid rgba(var(--evidence-gold-rgb), 0.45);
-      transition: border-color 160ms ease-out;
+      background: rgba(var(--evidence-gold-rgb), 0.08);
+      border: 1px solid rgba(var(--evidence-gold-rgb), 0.28);
+      padding: 0.05em 0.4em;
+      border-radius: 3px;
+      font-size: 0.9em;
     }
-    .wip-banner a:hover,
-    .wip-banner a:focus-visible {
-      border-bottom-color: var(--evidence-gold);
+    .report-navlinks {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1.5rem;
+      margin-top: 1.4rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      letter-spacing: 0.02em;
+    }
+    .report-navlinks a {
+      color: var(--muted);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+    }
+    .report-navlinks a:hover,
+    .report-navlinks a:focus-visible {
+      color: var(--text);
+      border-bottom-color: var(--border);
       outline: none;
     }
+
+    /* ── Section: a headed block, not a boxed card ──────────── */
+    .report-section { margin-bottom: 3.5rem; }
+    .report-section-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1rem;
+      padding-bottom: 1rem;
+      margin-bottom: 0.25rem;
+      border-bottom: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+    .report-section-head h2 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: clamp(1.4rem, 3vw, 1.9rem);
+      line-height: 1.15;
+      letter-spacing: -0.01em;
+      margin: 0;
+      color: var(--text);
+    }
+    .report-section-note {
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+
+    /* ── Data table ─────────────────────────────────────────── */
+    .report-table-wrap { overflow-x: auto; }
+    .report-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+      min-width: 34rem;
+    }
+    .report-table thead th {
+      text-align: left;
+      padding: 0.9rem 0.85rem 0.7rem 0;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+      white-space: nowrap;
+      font-weight: 500;
+    }
+    .report-table thead th.num { text-align: right; }
+    .report-table tbody td {
+      padding: 0.9rem 0.85rem 0.9rem 0;
+      vertical-align: baseline;
+      border-bottom: 1px solid rgba(var(--evidence-platinum-rgb), 0.06);
+      color: var(--text);
+    }
+    .report-table tbody tr:last-child td { border-bottom: none; }
+    .report-table td.num {
+      text-align: right;
+      font-family: var(--font-mono);
+      font-variant-numeric: tabular-nums;
+    }
+    .report-table td.rank {
+      font-family: var(--font-mono);
+      color: var(--muted);
+      font-size: 0.82rem;
+      width: 2.5rem;
+    }
+
+    .rt-skill {
+      color: var(--text);
+      text-decoration: none;
+      font-family: var(--font-display);
+      font-size: 1.05rem;
+      font-weight: 500;
+      letter-spacing: -0.005em;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+    }
+    .rt-skill:hover,
+    .rt-skill:focus-visible {
+      color: var(--apex-gold);
+      border-bottom-color: rgba(var(--apex-gold-rgb), 0.4);
+      outline: none;
+    }
+    .rt-contributor {
+      display: block;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      color: var(--muted);
+      margin-top: 0.2rem;
+      letter-spacing: 0.02em;
+    }
+    .rt-level {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      color: var(--text);
+      white-space: nowrap;
+    }
+    .rt-rankchange {
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      color: var(--text);
+      white-space: nowrap;
+    }
+    .rt-rankchange .rc-prev { color: var(--muted); }
+    .rt-rankchange .rc-arrow { color: var(--muted); margin: 0 0.25em; }
+    .rt-when {
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+
+    /* Grade chip — reuses the global .ev-grade family from styles.css. */
+    .ev-grade { margin-left: 0.4rem; }
+
+    /* Delta / new / origin markers */
+    .rt-tag {
+      display: inline-block;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      letter-spacing: 0.04em;
+      padding: 0.08rem 0.4rem;
+      border-radius: 0.25rem;
+      border: 1px solid;
+      vertical-align: middle;
+    }
+    .rt-tag--new {
+      color: var(--apex-gold);
+      border-color: rgba(var(--apex-gold-rgb), 0.4);
+      background: rgba(var(--apex-gold-rgb), 0.08);
+    }
+    .rt-tag--origin {
+      color: var(--apex-gold);
+      border-color: rgba(var(--apex-gold-rgb), 0.4);
+      background: rgba(var(--apex-gold-rgb), 0.08);
+    }
+    .rt-delta { color: var(--muted); font-family: var(--font-mono); }
+    .rt-muted { color: var(--muted); }
+
+    /* ── Contested space sub-block ──────────────────────────── */
+    .report-space { margin-bottom: 2.5rem; }
+    .report-space:last-child { margin-bottom: 0; }
+    .report-space-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
+      flex-wrap: wrap;
+    }
+    .report-space-ref {
+      font-family: var(--font-mono);
+      font-size: 0.92rem;
+      color: var(--text);
+      font-weight: 500;
+    }
+    .report-space-meta {
+      font-family: var(--font-mono);
+      font-size: 0.74rem;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+
+    /* ── Empty section ──────────────────────────────────────── */
+    .report-empty {
+      padding: 1.5rem 0;
+      color: var(--muted);
+      font-style: italic;
+      font-size: 0.9rem;
+    }
+
+    /* ── Footer caption ─────────────────────────────────────── */
+    .report-caption {
+      margin-top: 4rem;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      line-height: 1.7;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+    .report-caption a {
+      color: var(--muted);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+    }
+    .report-caption a:hover,
+    .report-caption a:focus-visible {
+      color: var(--text);
+      border-bottom-color: var(--border);
+      outline: none;
+    }
+
     @media (prefers-reduced-motion: reduce) {
-      .wip-banner a { transition: none; }
+      .report-navlinks a,
+      .rt-skill,
+      .report-caption a { transition: none; }
     }
   </style>
 <script type="application/ld+json" data-injector="gaia-json-ld">
@@ -84,99 +337,307 @@
     "url": "https://gaiaskilltree.com/"
   }
 }
-{
-  "@context": "https://schema.org",
-  "@type": "NewsArticle",
-  "headline": "Gaia Weekly Report — 2026-28",
-  "url": "https://gaiaskilltree.com/reports/2026-28/"
-}
 </script>
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.1.1"></script>
-  <script src="../../js/site-nav.js?v=6.1.1"></script>
+  <script src="../../js/mounts.js?v=6.0.1"></script>
+  <script src="../../js/site-nav.js?v=6.0.1"></script>
 
-  <aside class="wip-banner" role="note" aria-label="Interim rendering notice">
-    <span class="wip-tag">◇ Interim rendering</span>
-    <span class="wip-body">Tables render as source markdown in this bridge state. Leaderboard view lands in Sprint F (<a href="https://github.com/gaia-research/gaia-skill-tree/issues/973">#973</a>). The <a href="https://gaiaskilltree.com/api/v1/reports/2026-28.json">canonical JSON</a> is frozen and permanent.</span>
-  </aside>
+  <main class="report-shell">
 
-  <main class="report-body" style="max-width: 72rem; margin: 2rem auto; padding: 0 1.25rem; color: var(--text); font-family: 'EB Garamond', Georgia, serif; line-height: 1.6;">
-    <div style="font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; color: var(--muted); letter-spacing: .12em; text-transform: uppercase; margin-bottom: .5rem;">
-      Weekly Report · Salvage Layer L3
-    </div>
-    <pre class="report-markdown" style="white-space: pre-wrap; font-family: inherit; font-size: 1rem; background: transparent; padding: 0; margin: 0;"># Weekly Report · 2026-28
+    <header class="report-masthead">
+      <p class="report-eyebrow">Weekly Report · ISO 2026-W28</p>
+      <h1>What moved, <em>week 28</em>.</h1>
+      <div class="report-meta">
+        <span class="rm-item"><strong>Generated</strong> 2026-07-06</span>
+        <span class="rm-item"><strong>Salvage layer</strong> <code>L3</code></span>
+        <span class="rm-item"><strong>Generator</strong> gaia-content-engine v6.0.1</span>
+      </div>
+      <nav class="report-navlinks" aria-label="Report navigation">
+        <a href="https://gaiaskilltree.com/reports/2026-27/">← Previous week</a>
+        <a href="https://gaiaskilltree.com/reports/">Archive</a>
+        <a href="https://gaiaskilltree.com/api/v1/reports/2026-28.json">Canonical JSON</a>
+      </nav>
+    </header>
 
-> **Report ID:** `2026-28` · **ISO week:** 2026-W28
-> **Generated:** 2026-07-06T13:29:36Z · **Layer:** `L3` · **Generator:** gaia-content-engine v6.1.1
+    <section class="report-section" aria-labelledby="trendingHeading">
+      <div class="report-section-head">
+        <h2 id="trendingHeading">Trending this week</h2>
+        <span class="report-section-note">by Trust Magnitude</span>
+      </div>
+      <div class="report-table-wrap">
+        <table class="report-table">
+          <thead><tr>
+            <th>#</th><th>Skill</th><th>Level</th>
+            <th class="num">Trust Magnitude</th><th class="num">Δ TM</th>
+          </tr></thead>
+          <tbody>
+            <tr>
+              <td class="rank">1</td>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills">Agent Skills</a>
+                <span class="rt-contributor">@addy-osmani</span>
+              </td>
+              <td><span class="rt-level">5★</span></td>
+              <td class="num">293.1<span class="ev-grade" data-grade="S">S</span></td>
+              <td class="num"><span class="rt-tag rt-tag--new">new</span></td>
+            </tr>
+            <tr>
+              <td class="rank">2</td>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done">Get Shit Done</a>
+                <span class="rt-contributor">@gsd-build</span>
+              </td>
+              <td><span class="rt-level">4★</span></td>
+              <td class="num">202.2<span class="ev-grade" data-grade="A">A</span></td>
+              <td class="num"><span class="rt-tag rt-tag--new">new</span></td>
+            </tr>
+            <tr>
+              <td class="rank">3</td>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization">Performance Optimization</a>
+                <span class="rt-contributor">@addy-osmani</span>
+              </td>
+              <td><span class="rt-level">4★</span></td>
+              <td class="num">83.2<span class="ev-grade" data-grade="B">B</span></td>
+              <td class="num"><span class="rt-muted">—</span></td>
+            </tr>
+            <tr>
+              <td class="rank">4</td>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/addy-osmani/code-review-and-quality">Code Review and Quality</a>
+                <span class="rt-contributor">@addy-osmani</span>
+              </td>
+              <td><span class="rt-level">3★</span></td>
+              <td class="num">53.1<span class="ev-grade" data-grade="B">B</span></td>
+              <td class="num"><span class="rt-tag rt-tag--new">new</span></td>
+            </tr>
+            <tr>
+              <td class="rank">5</td>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/addy-osmani/code-simplification">Code Simplification</a>
+                <span class="rt-contributor">@addy-osmani</span>
+              </td>
+              <td><span class="rt-level">3★</span></td>
+              <td class="num">53.1<span class="ev-grade" data-grade="B">B</span></td>
+              <td class="num"><span class="rt-tag rt-tag--new">new</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-[← Previous week](https://gaiaskilltree.com/reports/2026-27/) · [Archive](https://gaiaskilltree.com/reports/) · [Canonical JSON](https://gaiaskilltree.com/api/v1/reports/2026-28.json)
+    <section class="report-section" aria-labelledby="ascendedHeading">
+      <div class="report-section-head">
+        <h2 id="ascendedHeading">Recently ascended</h2>
+        <span class="report-section-note">most recent rank-ups</span>
+      </div>
+      <div class="report-table-wrap">
+        <table class="report-table">
+          <thead><tr>
+            <th>Skill</th><th>Rank change</th>
+            <th class="num">Trust Magnitude</th><th>Ascended</th>
+          </tr></thead>
+          <tbody>
+            <tr>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization">Performance Optimization</a>
+                <span class="rt-contributor">@addy-osmani</span>
+              </td>
+              <td>
+                <span class="rt-rankchange">
+<span class="rc-prev">3★</span><span class="rc-arrow">→</span>4★
+                </span>
+              </td>
+              <td class="num">83.2<span class="ev-grade" data-grade="B">B</span></td>
+              <td><span class="rt-when">2026-07-03</span></td>
+            </tr>
+            <tr>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills">Agent Skills</a>
+                <span class="rt-contributor">@addy-osmani</span>
+              </td>
+              <td>
+                <span class="rt-rankchange">
+5★
+                </span>
+              </td>
+              <td class="num">293.1<span class="ev-grade" data-grade="S">S</span></td>
+              <td><span class="rt-when">2026-07-02</span></td>
+            </tr>
+            <tr>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done">Get Shit Done</a>
+                <span class="rt-contributor">@gsd-build</span>
+              </td>
+              <td>
+                <span class="rt-rankchange">
+<span class="rc-prev">2★</span><span class="rc-arrow">→</span>4★
+                </span>
+              </td>
+              <td class="num">202.2<span class="ev-grade" data-grade="A">A</span></td>
+              <td><span class="rt-when">2026-07-02</span></td>
+            </tr>
+            <tr>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/gsd-build/ship">GSD Ship</a>
+                <span class="rt-contributor">@gsd-build</span>
+              </td>
+              <td>
+                <span class="rt-rankchange">
+<span class="rc-prev">2★</span><span class="rc-arrow">→</span>3★
+                </span>
+              </td>
+              <td class="num">52.2<span class="ev-grade" data-grade="B">B</span></td>
+              <td><span class="rt-when">2026-07-02</span></td>
+            </tr>
+            <tr>
+              <td>
+                <a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/gsd-build/execute-phase">GSD Execute Phase</a>
+                <span class="rt-contributor">@gsd-build</span>
+              </td>
+              <td>
+                <span class="rt-rankchange">
+<span class="rc-prev">2★</span><span class="rc-arrow">→</span>3★
+                </span>
+              </td>
+              <td class="num">52.2<span class="ev-grade" data-grade="B">B</span></td>
+              <td><span class="rt-when">2026-07-02</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-## Trending this week
+    <section class="report-section" aria-labelledby="contestedHeading">
+      <div class="report-section-head">
+        <h2 id="contestedHeading">Most contested spaces</h2>
+        <span class="report-section-note">most-implemented generic skills</span>
+      </div>
+        <div class="report-space">
+          <div class="report-space-head">
+            <span class="report-space-ref">git-ship-done-pipeline</span>
+            <span class="report-space-meta">2 implementations · top TM 293.1</span>
+          </div>
+          <div class="report-table-wrap">
+            <table class="report-table">
+              <thead><tr>
+                <th>Skill</th><th>Level</th>
+                <th class="num">Trust Magnitude</th><th>Origin</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills">addy-osmani/agent-skills</a></td>
+                  <td><span class="rt-level">5★</span></td>
+                  <td class="num">293.1<span class="ev-grade" data-grade="S">S</span></td>
+                  <td><span class="rt-tag rt-tag--origin">origin</span></td>
+                </tr>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done">gsd-build/get-shit-done</a></td>
+                  <td><span class="rt-level">4★</span></td>
+                  <td class="num">202.2<span class="ev-grade" data-grade="A">A</span></td>
+                  <td><span class="rt-muted">—</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="report-space">
+          <div class="report-space-head">
+            <span class="report-space-ref">vertical-slice-planning</span>
+            <span class="report-space-meta">3 implementations · top TM 156.0</span>
+          </div>
+          <div class="report-table-wrap">
+            <table class="report-table">
+              <thead><tr>
+                <th>Skill</th><th>Level</th>
+                <th class="num">Trust Magnitude</th><th>Origin</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/garrytan/garrytan">garrytan/garrytan</a></td>
+                  <td><span class="rt-level">4★</span></td>
+                  <td class="num">156.0<span class="ev-grade" data-grade="A">A</span></td>
+                  <td><span class="rt-tag rt-tag--origin">origin</span></td>
+                </tr>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/mattpocock/to-issues">mattpocock/to-issues</a></td>
+                  <td><span class="rt-level">3★</span></td>
+                  <td class="num">90.4<span class="ev-grade" data-grade="B">B</span></td>
+                  <td><span class="rt-muted">—</span></td>
+                </tr>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/addy-osmani/planning-and-task-breakdown">addy-osmani/planning-and-task-breakdown</a></td>
+                  <td><span class="rt-level">3★</span></td>
+                  <td class="num">53.1<span class="ev-grade" data-grade="B">B</span></td>
+                  <td><span class="rt-muted">—</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="report-space">
+          <div class="report-space-head">
+            <span class="report-space-ref">ux-audit</span>
+            <span class="report-space-meta">6 implementations · top TM 122.8</span>
+          </div>
+          <div class="report-table-wrap">
+            <table class="report-table">
+              <thead><tr>
+                <th>Skill</th><th>Level</th>
+                <th class="num">Trust Magnitude</th><th>Origin</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/pbakaus/impeccable">pbakaus/impeccable</a></td>
+                  <td><span class="rt-level">4★</span></td>
+                  <td class="num">122.8<span class="ev-grade" data-grade="A">A</span></td>
+                  <td><span class="rt-tag rt-tag--origin">origin</span></td>
+                </tr>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/martin-stepanoski/nielsen-heuristics-audit">martin-stepanoski/nielsen-heuristics-audit</a></td>
+                  <td><span class="rt-level">3★</span></td>
+                  <td class="num">94.9<span class="ev-grade" data-grade="B">B</span></td>
+                  <td><span class="rt-muted">—</span></td>
+                </tr>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/garrytan/plan-design-review">garrytan/plan-design-review</a></td>
+                  <td><span class="rt-level">3★</span></td>
+                  <td class="num">63.7<span class="ev-grade" data-grade="B">B</span></td>
+                  <td><span class="rt-muted">—</span></td>
+                </tr>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/garrytan/plan-devex-review">garrytan/plan-devex-review</a></td>
+                  <td><span class="rt-level">3★</span></td>
+                  <td class="num">63.7<span class="ev-grade" data-grade="B">B</span></td>
+                  <td><span class="rt-muted">—</span></td>
+                </tr>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/garrytan/design-review">garrytan/design-review</a></td>
+                  <td><span class="rt-level">2★</span></td>
+                  <td class="num">36.0<span class="ev-grade" data-grade="C">C</span></td>
+                  <td><span class="rt-muted">—</span></td>
+                </tr>
+                <tr>
+                  <td><a class="rt-skill" href="https://gaiaskilltree.com/named/#explorer/garrytan/devex-review">garrytan/devex-review</a></td>
+                  <td><span class="rt-level">2★</span></td>
+                  <td class="num">36.0<span class="ev-grade" data-grade="C">C</span></td>
+                  <td><span class="rt-muted">—</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+    </section>
 
-| Rank | Skill | Contributor | Level | Trust Magnitude | Δ TM |
-| ---: | :--- | :--- | :---: | ---: | ---: |
-| 1 | [Agent Skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | addy-osmani | 5â˜… | 293.1 · S | new |
-| 2 | [Get Shit Done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | gsd-build | 4â˜… | 202.2 · A | new |
-| 3 | [Performance Optimization](https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization) | addy-osmani | 4â˜… | 83.2 · B | — |
-| 4 | [Code Review and Quality](https://gaiaskilltree.com/named/#explorer/addy-osmani/code-review-and-quality) | addy-osmani | 3â˜… | 53.1 · B | new |
-| 5 | [Code Simplification](https://gaiaskilltree.com/named/#explorer/addy-osmani/code-simplification) | addy-osmani | 3â˜… | 53.1 · B | new |
+    <footer class="report-caption">
+      Compiled mechanically by the <a href="https://github.com/gaia-research/gaia-skill-tree/tree/main/scripts/contentEngine">Gaia Content Engine</a> from <a href="/api/v1/trending/">/api/v1/trending/*.json</a>, recomputed daily. The <a href="https://gaiaskilltree.com/api/v1/reports/2026-28.json">canonical JSON</a> is frozen and permanent. Salvage layer: <code>L3</code>.
+    </footer>
 
-## Recently ascended
-
-| Skill | Contributor | Rank change | Trust Magnitude | Ascended at |
-| :--- | :--- | :---: | ---: | :--- |
-| [Performance Optimization](https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization) | addy-osmani | 3â˜… → 4â˜… | 83.2 · B | 2026-07-03T19:57:07Z |
-| [Agent Skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | addy-osmani | → 5â˜… | 293.1 · S | 2026-07-02T21:46:18Z |
-| [Get Shit Done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | gsd-build | 2â˜… → 4â˜… | 202.2 · A | 2026-07-02T21:34:10Z |
-| [GSD Ship](https://gaiaskilltree.com/named/#explorer/gsd-build/ship) | gsd-build | 2â˜… → 3â˜… | 52.2 · B | 2026-07-02T21:34:10Z |
-| [GSD Execute Phase](https://gaiaskilltree.com/named/#explorer/gsd-build/execute-phase) | gsd-build | 2â˜… → 3â˜… | 52.2 · B | 2026-07-02T21:34:09Z |
-
-## Most contested spaces
-
-### `git-ship-done-pipeline` — 2 implementations
-
-_Top TM in this space: **293.1**_
-
-| Skill | Level | Trust Magnitude | Grade | Origin? |
-| :--- | :---: | ---: | :---: | :---: |
-| [addy-osmani/agent-skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | 5â˜… | 293.1 | S | ✓ |
-| [gsd-build/get-shit-done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | 4â˜… | 202.2 | A | — |
-
-### `vertical-slice-planning` — 3 implementations
-
-_Top TM in this space: **156.0**_
-
-| Skill | Level | Trust Magnitude | Grade | Origin? |
-| :--- | :---: | ---: | :---: | :---: |
-| [garrytan/garrytan](https://gaiaskilltree.com/named/#explorer/garrytan/garrytan) | 4â˜… | 156.0 | A | ✓ |
-| [mattpocock/to-issues](https://gaiaskilltree.com/named/#explorer/mattpocock/to-issues) | 3â˜… | 90.4 | B | — |
-| [addy-osmani/planning-and-task-breakdown](https://gaiaskilltree.com/named/#explorer/addy-osmani/planning-and-task-breakdown) | 3â˜… | 53.1 | B | — |
-
-### `ux-audit` — 6 implementations
-
-_Top TM in this space: **122.8**_
-
-| Skill | Level | Trust Magnitude | Grade | Origin? |
-| :--- | :---: | ---: | :---: | :---: |
-| [pbakaus/impeccable](https://gaiaskilltree.com/named/#explorer/pbakaus/impeccable) | 4â˜… | 122.8 | A | ✓ |
-| [martin-stepanoski/nielsen-heuristics-audit](https://gaiaskilltree.com/named/#explorer/martin-stepanoski/nielsen-heuristics-audit) | 3â˜… | 94.9 | B | — |
-| [garrytan/plan-design-review](https://gaiaskilltree.com/named/#explorer/garrytan/plan-design-review) | 3â˜… | 63.7 | B | — |
-| [garrytan/plan-devex-review](https://gaiaskilltree.com/named/#explorer/garrytan/plan-devex-review) | 3â˜… | 63.7 | B | — |
-| [garrytan/design-review](https://gaiaskilltree.com/named/#explorer/garrytan/design-review) | 2â˜… | 36.0 | C | — |
-| [garrytan/devex-review](https://gaiaskilltree.com/named/#explorer/garrytan/devex-review) | 2â˜… | 36.0 | C | — |
-
-
----
-
-_Generated mechanically by the [Gaia Content Engine](https://github.com/gaia-research/gaia-skill-tree/tree/main/scripts/contentEngine). Data flows from `/api/v1/trending/*.json` — recomputed daily by `buildTrendingProjection.py`. Salvage layer: `L3`._
-</pre>
   </main>
 
-  <footer style="max-width: 72rem; margin: 3rem auto 2rem; padding: 1.5rem 1.25rem 0; color: var(--muted); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; border-top: 1px solid var(--border);">
-    <a href="https://gaiaskilltree.com/reports/" style="color: var(--muted); text-decoration: none;">← All reports</a>
-    · <a href="https://gaiaskilltree.com/api/v1/reports/2026-28.json" style="color: var(--muted); text-decoration: none;">Canonical JSON</a>
-  </footer>
+  <div id="site-footer-mount"></div>
+  <script src="../../js/site-footer.js?v=6.0.1"></script>
 </body>
 </html>

--- a/scripts/contentEngine/templates/report.html.j2
+++ b/scripts/contentEngine/templates/report.html.j2
@@ -17,82 +17,469 @@
   <meta property="og:url" content="{{ report.urls.canonical }}">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" type="image/svg+xml" href="../../assets/marks/diamond-seal.svg">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
   <link rel="stylesheet" href="../../css/tokens.css?v={{ report.generatorVersion }}">
   <link rel="stylesheet" href="../../css/styles.css?v={{ report.generatorVersion }}">
   <link rel="alternate" type="application/json" href="{{ report.urls.json }}">
 
   <style>
-    /* ── Deferred-surface WIP banner ──────────────────────────────────────
-       Discloses that this surface renders in its L3-mechanical bridge
-       state pending the Sprint F rendering-layer rewrite (issue #973).
-       Follows the deferred-surface convention in CLAUDE.md §Deferred
-       surface convention. Removed by the port. */
-    .wip-banner {
+    /* ─────────────────────────────────────────────────────────────
+       WEEKLY REPORT — one ISO week of registry movement, read as a
+       ledger. Shares the archive register (.reports-shell): EB Garamond
+       display, Bricolage body, JetBrains Mono for identifiers and
+       numerics. Evidence-grade chips reuse the global .ev-grade family
+       from styles.css ([data-grade] coloring). Body copy sits on
+       --text against --bg for 4.5:1+ contrast. Token-only (rubric E7);
+       mobile-first with min-width breakpoints (rubric E6).
+       ───────────────────────────────────────────────────────────── */
+
+    .report-shell {
       max-width: 62rem;
-      /* Clear the fixed nav (~58px). Matches the 5rem/6rem top-clearance
-         pattern used by .bench-shell and .reports-shell. */
-      margin: 5rem auto 0;
-      padding: 0.75rem 1.5rem;
-      display: flex;
-      align-items: baseline;
-      flex-wrap: wrap;
-      gap: 0.5rem 0.9rem;
-      font-family: var(--font-mono);
-      font-size: 0.78rem;
-      line-height: 1.55;
+      margin: 0 auto;
+      padding: 5rem 1.25rem 6rem;
       color: var(--text);
-      background: rgba(var(--evidence-gold-rgb), 0.06);
-      border: 1px solid rgba(var(--evidence-gold-rgb), 0.28);
-      border-radius: 6px;
-      letter-spacing: 0.02em;
+      font-family: var(--font-body);
     }
     @media (min-width: 768px) {
-      .wip-banner { margin-top: 6rem; }
+      .report-shell { padding: 8rem 2rem 7rem; }
     }
-    .wip-banner .wip-tag {
-      color: var(--evidence-gold);
-      font-weight: 500;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
+
+    /* ── Masthead: the report's metadata header ─────────────── */
+    .report-masthead {
+      margin: 0 0 3.5rem;
+      padding-bottom: 1.75rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .report-eyebrow {
+      font-family: var(--font-mono);
       font-size: 0.72rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin: 0 0 0.85rem;
     }
-    .wip-banner .wip-body { color: var(--text); opacity: 0.86; }
-    .wip-banner a {
+    .report-masthead h1 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: clamp(2.2rem, 6vw, 3.5rem);
+      line-height: 1.04;
+      letter-spacing: -0.02em;
+      margin: 0 0 1.25rem;
+      color: var(--text);
+      text-wrap: balance;
+    }
+    .report-masthead h1 em {
+      font-style: italic;
+      color: var(--apex-gold);
+      font-weight: 400;
+    }
+    .report-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      line-height: 1.6;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+    .report-meta .rm-item { white-space: nowrap; }
+    .report-meta .rm-item strong {
+      color: var(--text);
+      font-weight: 500;
+    }
+    .report-meta code {
+      font-family: var(--font-mono);
       color: var(--evidence-gold);
-      text-decoration: none;
-      border-bottom: 1px solid rgba(var(--evidence-gold-rgb), 0.45);
-      transition: border-color 160ms ease-out;
+      background: rgba(var(--evidence-gold-rgb), 0.08);
+      border: 1px solid rgba(var(--evidence-gold-rgb), 0.28);
+      padding: 0.05em 0.4em;
+      border-radius: 3px;
+      font-size: 0.9em;
     }
-    .wip-banner a:hover,
-    .wip-banner a:focus-visible {
-      border-bottom-color: var(--evidence-gold);
+    .report-navlinks {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1.5rem;
+      margin-top: 1.4rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      letter-spacing: 0.02em;
+    }
+    .report-navlinks a {
+      color: var(--muted);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+    }
+    .report-navlinks a:hover,
+    .report-navlinks a:focus-visible {
+      color: var(--text);
+      border-bottom-color: var(--border);
       outline: none;
     }
+
+    /* ── Section: a headed block, not a boxed card ──────────── */
+    .report-section { margin-bottom: 3.5rem; }
+    .report-section-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1rem;
+      padding-bottom: 1rem;
+      margin-bottom: 0.25rem;
+      border-bottom: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+    .report-section-head h2 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: clamp(1.4rem, 3vw, 1.9rem);
+      line-height: 1.15;
+      letter-spacing: -0.01em;
+      margin: 0;
+      color: var(--text);
+    }
+    .report-section-note {
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+
+    /* ── Data table ─────────────────────────────────────────── */
+    .report-table-wrap { overflow-x: auto; }
+    .report-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+      min-width: 34rem;
+    }
+    .report-table thead th {
+      text-align: left;
+      padding: 0.9rem 0.85rem 0.7rem 0;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+      white-space: nowrap;
+      font-weight: 500;
+    }
+    .report-table thead th.num { text-align: right; }
+    .report-table tbody td {
+      padding: 0.9rem 0.85rem 0.9rem 0;
+      vertical-align: baseline;
+      border-bottom: 1px solid rgba(var(--evidence-platinum-rgb), 0.06);
+      color: var(--text);
+    }
+    .report-table tbody tr:last-child td { border-bottom: none; }
+    .report-table td.num {
+      text-align: right;
+      font-family: var(--font-mono);
+      font-variant-numeric: tabular-nums;
+    }
+    .report-table td.rank {
+      font-family: var(--font-mono);
+      color: var(--muted);
+      font-size: 0.82rem;
+      width: 2.5rem;
+    }
+
+    .rt-skill {
+      color: var(--text);
+      text-decoration: none;
+      font-family: var(--font-display);
+      font-size: 1.05rem;
+      font-weight: 500;
+      letter-spacing: -0.005em;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+    }
+    .rt-skill:hover,
+    .rt-skill:focus-visible {
+      color: var(--apex-gold);
+      border-bottom-color: rgba(var(--apex-gold-rgb), 0.4);
+      outline: none;
+    }
+    .rt-contributor {
+      display: block;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      color: var(--muted);
+      margin-top: 0.2rem;
+      letter-spacing: 0.02em;
+    }
+    .rt-level {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      color: var(--text);
+      white-space: nowrap;
+    }
+    .rt-rankchange {
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      color: var(--text);
+      white-space: nowrap;
+    }
+    .rt-rankchange .rc-prev { color: var(--muted); }
+    .rt-rankchange .rc-arrow { color: var(--muted); margin: 0 0.25em; }
+    .rt-when {
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+
+    /* Grade chip — reuses the global .ev-grade family from styles.css. */
+    .ev-grade { margin-left: 0.4rem; }
+
+    /* Delta / new / origin markers */
+    .rt-tag {
+      display: inline-block;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      letter-spacing: 0.04em;
+      padding: 0.08rem 0.4rem;
+      border-radius: 0.25rem;
+      border: 1px solid;
+      vertical-align: middle;
+    }
+    .rt-tag--new {
+      color: var(--apex-gold);
+      border-color: rgba(var(--apex-gold-rgb), 0.4);
+      background: rgba(var(--apex-gold-rgb), 0.08);
+    }
+    .rt-tag--origin {
+      color: var(--apex-gold);
+      border-color: rgba(var(--apex-gold-rgb), 0.4);
+      background: rgba(var(--apex-gold-rgb), 0.08);
+    }
+    .rt-delta { color: var(--muted); font-family: var(--font-mono); }
+    .rt-muted { color: var(--muted); }
+
+    /* ── Contested space sub-block ──────────────────────────── */
+    .report-space { margin-bottom: 2.5rem; }
+    .report-space:last-child { margin-bottom: 0; }
+    .report-space-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
+      flex-wrap: wrap;
+    }
+    .report-space-ref {
+      font-family: var(--font-mono);
+      font-size: 0.92rem;
+      color: var(--text);
+      font-weight: 500;
+    }
+    .report-space-meta {
+      font-family: var(--font-mono);
+      font-size: 0.74rem;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+
+    /* ── Empty section ──────────────────────────────────────── */
+    .report-empty {
+      padding: 1.5rem 0;
+      color: var(--muted);
+      font-style: italic;
+      font-size: 0.9rem;
+    }
+
+    /* ── Footer caption ─────────────────────────────────────── */
+    .report-caption {
+      margin-top: 4rem;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      line-height: 1.7;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+    .report-caption a {
+      color: var(--muted);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+    }
+    .report-caption a:hover,
+    .report-caption a:focus-visible {
+      color: var(--text);
+      border-bottom-color: var(--border);
+      outline: none;
+    }
+
     @media (prefers-reduced-motion: reduce) {
-      .wip-banner a { transition: none; }
+      .report-navlinks a,
+      .rt-skill,
+      .report-caption a { transition: none; }
     }
   </style>
+<script type="application/ld+json" data-injector="gaia-json-ld">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Gaia Weekly Report — {{ report.reportId }}",
+  "url": "{{ report.urls.canonical }}",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Gaia Skill Tree",
+    "url": "https://gaiaskilltree.com/"
+  }
+}
+</script>
 </head>
 <body>
   <nav id="site-nav"></nav>
   <script src="../../js/mounts.js?v={{ report.generatorVersion }}"></script>
   <script src="../../js/site-nav.js?v={{ report.generatorVersion }}"></script>
 
-  <aside class="wip-banner" role="note" aria-label="Interim rendering notice">
-    <span class="wip-tag">◇ Interim rendering</span>
-    <span class="wip-body">Tables render as source markdown in this bridge state. Leaderboard view lands in Sprint F (<a href="https://github.com/gaia-research/gaia-skill-tree/issues/973">#973</a>). The <a href="{{ report.urls.json }}">canonical JSON</a> is frozen and permanent.</span>
-  </aside>
+  <main class="report-shell">
 
-  <main class="report-body" style="max-width: 72rem; margin: 2rem auto; padding: 0 1.25rem; color: var(--text); font-family: 'EB Garamond', Georgia, serif; line-height: 1.6;">
-    <div style="font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; color: var(--muted); letter-spacing: .12em; text-transform: uppercase; margin-bottom: .5rem;">
-      Weekly Report · Salvage Layer {{ report.salvageLayer }}
-    </div>
-    <pre class="report-markdown" style="white-space: pre-wrap; font-family: inherit; font-size: 1rem; background: transparent; padding: 0; margin: 0;">{{ markdownBody }}</pre>
+    <header class="report-masthead">
+      <p class="report-eyebrow">Weekly Report · ISO {{ report.isoYear }}-W{{ '%02d' | format(report.isoWeek) }}</p>
+      <h1>What moved, <em>week {{ report.isoWeek }}</em>.</h1>
+      <div class="report-meta">
+        <span class="rm-item"><strong>Generated</strong> {{ report.generatedAt[:10] }}</span>
+        <span class="rm-item"><strong>Salvage layer</strong> <code>{{ report.salvageLayer }}</code></span>
+        <span class="rm-item"><strong>Generator</strong> gaia-content-engine v{{ report.generatorVersion }}</span>
+      </div>
+      <nav class="report-navlinks" aria-label="Report navigation">
+        <a href="{{ report.urls.previous }}">← Previous week</a>
+        <a href="{{ report.urls.archive }}">Archive</a>
+        <a href="{{ report.urls.json }}">Canonical JSON</a>
+      </nav>
+    </header>
+
+    {# ── Trending ─────────────────────────────────────────── #}
+    {% set trending = report.sections.trending %}
+    <section class="report-section" aria-labelledby="trendingHeading">
+      <div class="report-section-head">
+        <h2 id="trendingHeading">{{ trending.title }}</h2>
+        <span class="report-section-note">by Trust Magnitude</span>
+      </div>
+      {% if trending.entries %}
+      <div class="report-table-wrap">
+        <table class="report-table">
+          <thead><tr>
+            <th>#</th><th>Skill</th><th>Level</th>
+            <th class="num">Trust Magnitude</th><th class="num">Δ TM</th>
+          </tr></thead>
+          <tbody>
+            {% for e in trending.entries %}
+            <tr>
+              <td class="rank">{{ loop.index }}</td>
+              <td>
+                <a class="rt-skill" href="{{ e.url }}">{{ e.name }}</a>
+                <span class="rt-contributor">@{{ e.contributor }}</span>
+              </td>
+              <td><span class="rt-level">{{ e.level }}</span></td>
+              <td class="num">{{ '%.1f' | format(e.trustMagnitude) }}{% if e.trustGrade %}<span class="ev-grade" data-grade="{{ e.trustGrade }}">{{ e.trustGrade }}</span>{% endif %}</td>
+              <td class="num">{% if e.isNew %}<span class="rt-tag rt-tag--new">new</span>{% elif e.tmDelta and e.tmDelta > 0 %}<span class="rt-delta">+{{ '%.1f' | format(e.tmDelta) }}</span>{% else %}<span class="rt-muted">—</span>{% endif %}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="report-empty">No trending skills this week.</p>
+      {% endif %}
+    </section>
+
+    {# ── Ascended ─────────────────────────────────────────── #}
+    {% set ascended = report.sections.ascended %}
+    <section class="report-section" aria-labelledby="ascendedHeading">
+      <div class="report-section-head">
+        <h2 id="ascendedHeading">{{ ascended.title }}</h2>
+        <span class="report-section-note">most recent rank-ups</span>
+      </div>
+      {% if ascended.entries %}
+      <div class="report-table-wrap">
+        <table class="report-table">
+          <thead><tr>
+            <th>Skill</th><th>Rank change</th>
+            <th class="num">Trust Magnitude</th><th>Ascended</th>
+          </tr></thead>
+          <tbody>
+            {% for e in ascended.entries %}
+            <tr>
+              <td>
+                <a class="rt-skill" href="{{ e.url }}">{{ e.name }}</a>
+                <span class="rt-contributor">@{{ e.contributor }}</span>
+              </td>
+              <td>
+                <span class="rt-rankchange">
+                  {% if e.previousLevel %}<span class="rc-prev">{{ e.previousLevel }}</span><span class="rc-arrow">→</span>{% endif %}{{ e.level }}
+                </span>
+              </td>
+              <td class="num">{{ '%.1f' | format(e.trustMagnitude) }}{% if e.trustGrade %}<span class="ev-grade" data-grade="{{ e.trustGrade }}">{{ e.trustGrade }}</span>{% endif %}</td>
+              <td><span class="rt-when">{{ e.ascendedAt[:10] }}</span></td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="report-empty">No rank-ups recorded this week.</p>
+      {% endif %}
+    </section>
+
+    {# ── Contested ────────────────────────────────────────── #}
+    {% set contested = report.sections.contested %}
+    <section class="report-section" aria-labelledby="contestedHeading">
+      <div class="report-section-head">
+        <h2 id="contestedHeading">{{ contested.title }}</h2>
+        <span class="report-section-note">most-implemented generic skills</span>
+      </div>
+      {% if contested.entries %}
+        {% for b in contested.entries %}
+        <div class="report-space">
+          <div class="report-space-head">
+            <span class="report-space-ref">{{ b.genericSkillRef }}</span>
+            <span class="report-space-meta">{{ b.implementations }} implementations · top TM {{ '%.1f' | format(b.topTM) }}</span>
+          </div>
+          <div class="report-table-wrap">
+            <table class="report-table">
+              <thead><tr>
+                <th>Skill</th><th>Level</th>
+                <th class="num">Trust Magnitude</th><th>Origin</th>
+              </tr></thead>
+              <tbody>
+                {% for s in b.skills %}
+                <tr>
+                  <td><a class="rt-skill" href="{{ s.url }}">{{ s.id }}</a></td>
+                  <td><span class="rt-level">{{ s.level }}</span></td>
+                  <td class="num">{{ '%.1f' | format(s.trustMagnitude) }}{% if s.trustGrade %}<span class="ev-grade" data-grade="{{ s.trustGrade }}">{{ s.trustGrade }}</span>{% endif %}</td>
+                  <td>{% if s.origin %}<span class="rt-tag rt-tag--origin">origin</span>{% else %}<span class="rt-muted">—</span>{% endif %}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+      <p class="report-empty">No contested spaces this week.</p>
+      {% endif %}
+    </section>
+
+    <footer class="report-caption">
+      Compiled mechanically by the <a href="https://github.com/gaia-research/gaia-skill-tree/tree/main/scripts/contentEngine">Gaia Content Engine</a> from <a href="/api/v1/trending/">/api/v1/trending/*.json</a>, recomputed daily. The <a href="{{ report.urls.json }}">canonical JSON</a> is frozen and permanent. Salvage layer: <code>{{ report.salvageLayer }}</code>.
+    </footer>
+
   </main>
 
-  <footer style="max-width: 72rem; margin: 3rem auto 2rem; padding: 1.5rem 1.25rem 0; color: var(--muted); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; border-top: 1px solid var(--border);">
-    <a href="{{ report.urls.archive }}" style="color: var(--muted); text-decoration: none;">← All reports</a>
-    · <a href="{{ report.urls.json }}" style="color: var(--muted); text-decoration: none;">Canonical JSON</a>
-  </footer>
+  <div id="site-footer-mount"></div>
+  <script src="../../js/site-footer.js?v={{ report.generatorVersion }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Yggdrasil II · Wave 2 · N-7 — Reports design system

**Reviewer verdict: PASS (minor).** One shared report design language across `docs/reports/` + `docs/named/report.html`. **`docs/meta/reports/` explicitly UNTOUCHED (verified).**

### What shipped
- Unified report design system (typography scale, metadata header, section treatment, evidence tables) applied to `docs/reports/2026-28/index.html`, the `named/report.html` template, and the shared `scripts/contentEngine/templates/report.html.j2` render target (so future dated reports inherit it).
- Mobile-first, contrast-verified, tokens-only.

### Verification
- Screenshot-verified 1280 + 390. Authorship `mbtiongson1`; 3 files, zero raw hex, zero banned words, zero dead-enum. `git diff` confirms `docs/meta/reports/` has zero changes.

### Known minor (deferred to Wave 3 sweep)
- `.report-back-row` fixed-nav clearance on `docs/named/report.html` is **pre-existing** (not a W2c regression) — the "Named Skills" back link sits under the fixed nav. Wave 3's clearance sweep will fix. `--report-ok-rgb` triplet aliases `--cluster-2` (token-purity nit, passes hex guard).

Part of EPIC #1002 · #998.
