### PR TITLE
Wave 3c — Profiles + reports mobile-first (#998)

### DIFF
--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -1596,57 +1596,43 @@ button.plaque__slug:focus-visible {
 .plaque--row .plaque-description {
   display: none; /* CSS-only collapse; markup still present */
 }
+/* E6 mobile-first: phone base (≤480px equivalent) — hide secondary fields,
+   compact padding. Desktop progressively restores them via min-width steps. */
 .plaque--row .plaque__install-row,
 .plaque--row .ns-install-row {
   /* Surface the install command in list rows — was display:none, but
      hiding the canonical CTA in a "scan-all" view defeats the point of
      the list. Compact horizontal variant: smaller font, single line,
      truncates instead of wrapping. */
-  display: inline-flex;
-  flex: 0 1 auto;
-  max-width: 320px;
-  font-size: 11px;
-  padding: 4px 8px;
-  margin: 0;
-  overflow: hidden;
-  white-space: nowrap;
+  display: none; /* hidden on mobile by default */
 }
-.plaque--row .plaque__install-cmd,
-.plaque--row .ns-install-cmd-txt {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.plaque--row .plaque__title,
+.plaque--row .plaque-title,
+.plaque--row .plaque__handle,
+.plaque--row .plaque-contrib-row {
+  display: none; /* phone: drop secondary fields so slug+rank always fit */
 }
-@media (max-width: 700px) {
-  .plaque--row .plaque__install-row,
-  .plaque--row .ns-install-row {
-    display: none; /* density-collapse on narrow viewports */
-  }
-  /* Mobile list rows: prevent rightward bleed from no-wrap children, and
-     let the slug shrink with ellipsis instead of pushing past the edge.
-     Without min-width: 0 on flex children, white-space: nowrap forces
-     overflow rather than shrink — that's what made rows look uncentered
-     (content shifted out of the padded box). */
-  .plaque--row {
-    overflow: hidden;
-    padding: .65rem .85rem;
-    gap: .5rem;
-    min-height: 60px;
-  }
-  .plaque--row .plaque__slug,
-  .plaque--row .plaque-skill-name {
-    font-size: 15px;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+.plaque--row .plaque__slug,
+.plaque--row .plaque-skill-name {
+  font-size: 14px;
+  flex: 1 1 auto;
+}
+.plaque--row {
+  padding: .55rem .75rem;
+  gap: .4rem;
+}
+
+/* ≥481px: restore secondary fields, slightly larger type */
+@media (min-width: 481px) {
   .plaque--row .plaque__title,
   .plaque--row .plaque-title {
+    display: block;
     font-size: 12px;
     min-width: 0;
   }
   .plaque--row .plaque__handle,
   .plaque--row .plaque-contrib-row {
+    display: block;
     font-size: 11px;
     min-width: 0;
     max-width: 35vw;
@@ -1654,28 +1640,36 @@ button.plaque__slug:focus-visible {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-}
-
-/* Phone (≤480px): drop the secondary fields entirely so the slug + rank
-   chip + arrow always fit on a single line. */
-@media (max-width: 480px) {
-  .plaque--row .plaque__title,
-  .plaque--row .plaque-title,
-  .plaque--row .plaque__handle,
-  .plaque--row .plaque-contrib-row {
-    display: none;
-  }
   .plaque--row .plaque__slug,
   .plaque--row .plaque-skill-name {
-    font-size: 14px;
-    flex: 1 1 auto;
+    font-size: 15px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: unset;
   }
   .plaque--row {
-    padding: .55rem .75rem;
-    gap: .4rem;
+    padding: .65rem .85rem;
+    gap: .5rem;
+    min-height: 60px;
+    overflow: hidden;
   }
 }
 
+/* ≥701px: show install row in full density */
+@media (min-width: 701px) {
+  .plaque--row .plaque__install-row,
+  .plaque--row .ns-install-row {
+    display: inline-flex;
+    flex: 0 1 auto;
+    max-width: 320px;
+    font-size: 11px;
+    padding: 4px 8px;
+    margin: 0;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+}
 
 /* ── .plaque--detail — Skill Explorer modal hero ────────────────
    Two-column layout. Collapses to one column ≤ 700px.
@@ -2771,7 +2765,11 @@ button.plaque__slug:focus-visible {
 .profile-grid-container {
   max-width: 960px;
   margin: 0 auto;
-  padding: 0 1.5rem;
+  /* E6 mobile-first: base clears ~58px fixed nav (5rem=80px); desktop step up */
+  padding: 5rem 1.5rem 0;
+}
+@media (min-width: 768px) {
+  .profile-grid-container { padding-top: 6rem; }
 }
 .profile-main {
   min-width: 0;
@@ -2856,10 +2854,6 @@ button.plaque__slug:focus-visible {
 .profile-timeline-filter-btn:hover {
   border-color: var(--tier-basic, #38bdf8);
   color: var(--tier-basic, #38bdf8);
-}
-
-.profile-filter-toggle {
-  display: none; /* Hidden on desktop */
 }
 
 /* Plaque Highlight Styles (Curve Hover Affordance) */
@@ -2958,36 +2952,44 @@ button.plaque__slug:focus-visible {
   background: rgba(255,255,255,0.06);
 }
 
-/* Responsive side-panel behaviour */
-@media (max-width: 860px) {
-  .profile-timeline-filter-btn {
+/* ── Profile: filter toggle (FAB) — visible on mobile, hidden on desktop ── */
+/* E6 mobile-first: FAB is the base (mobile) state; desktop hides it */
+.profile-filter-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: var(--surface, #0f172a);
+  border: 1px solid var(--tier-basic, #38bdf8);
+  color: var(--text, #e2e8f0);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.7rem 1.2rem;
+  border-radius: 999px;
+  z-index: 9997;
+  cursor: pointer;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4), 0 0 10px rgba(56, 189, 248, 0.2);
+  transition: transform 0.2s, background 0.2s;
+}
+.profile-filter-toggle:active {
+  transform: scale(0.95);
+}
+
+/* E6 mobile-first: on desktop (wide) the timeline filter btn shows instead */
+.profile-timeline-filter-btn {
+  display: none; /* hidden on mobile — desktop shows it via min-width below */
+}
+@media (min-width: 861px) {
+  .profile-filter-toggle {
     display: none;
   }
-
-  .profile-filter-toggle {
+  .profile-timeline-filter-btn {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    position: fixed;
-    bottom: 24px;
-    right: 24px;
-    background: var(--surface, #0f172a);
-    border: 1px solid var(--tier-basic, #38bdf8);
-    color: var(--text, #e2e8f0);
-    font-family: var(--font-mono, monospace);
-    font-size: 0.72rem;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    padding: 0.7rem 1.2rem;
-    border-radius: 999px;
-    z-index: 9997;
-    cursor: pointer;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4), 0 0 10px rgba(56, 189, 248, 0.2);
-    transition: transform 0.2s, background 0.2s;
-  }
-  .profile-filter-toggle:active {
-    transform: scale(0.95);
   }
 }
 

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -2962,9 +2962,9 @@ button.plaque__slug:focus-visible {
   position: fixed;
   bottom: 24px;
   right: 24px;
-  background: var(--surface, #0f172a);
-  border: 1px solid var(--tier-basic, #38bdf8);
-  color: var(--text, #e2e8f0);
+  background: var(--surface);
+  border: 1px solid var(--tier-basic);
+  color: var(--text);
   font-family: var(--font-mono, monospace);
   font-size: 0.72rem;
   letter-spacing: 0.05em;

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -1181,19 +1181,30 @@ nav.docs-nav:hover .nav-sep {
    (about, badges, named, en, codex, trust, u, etc.)
    ════════════════════════════════════════════════ */
 
+/* E6 mobile-first: phone-size padding is the base; progressively enhanced below */
 .profile-back-row {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  padding: 0.75rem clamp(1.25rem, 4vw, 2.5rem);
-  margin-top: -54px;
+  padding: 0.4rem clamp(0.5rem, 2vw, 0.75rem);
   margin-bottom: 0;
   position: relative;
   z-index: 10;
-  min-height: 2.75rem;
+  min-height: 2.25rem;
   max-width: 100%;
   width: 100%;
-  padding-top: calc(0.75rem + 54px);
+}
+@media (min-width: 501px) {
+  .profile-back-row {
+    padding: 0.5rem clamp(0.75rem, 3vw, 1.5rem);
+    min-height: 2.5rem;
+  }
+}
+@media (min-width: 701px) {
+  .profile-back-row {
+    padding: 0.75rem clamp(1.25rem, 4vw, 2.5rem);
+    min-height: 2.75rem;
+  }
 }
 
 .profile-back {
@@ -1611,13 +1622,6 @@ section[class*="frontis"],
 }
 
 @media (max-width: 700px) {
-  .profile-back-row {
-    padding: 0.5rem clamp(0.75rem, 3vw, 1.5rem);
-    padding-top: calc(0.5rem + 54px);
-    min-height: 2.5rem;
-    margin-top: -54px;
-  }
-
   .profile-back {
     padding: 0.3rem 0.55rem;
     font-size: 0.85rem;
@@ -1658,13 +1662,6 @@ section[class*="frontis"],
 }
 
 @media (max-width: 500px) {
-  .profile-back-row {
-    padding: 0.4rem clamp(0.5rem, 2vw, 0.75rem);
-    padding-top: calc(0.4rem + 54px);
-    min-height: 2.25rem;
-    margin-top: -54px;
-  }
-
   .profile-back {
     padding: 0.25rem 0.45rem;
     font-size: 0.8rem;

--- a/docs/named/report.html
+++ b/docs/named/report.html
@@ -39,7 +39,7 @@
       --report-danger-rgb: var(--honor-red-rgb);
     }
 
-    /* ── Layout ── */
+    /* E6 mobile-first: clearance + single-column stacked is the base; 2-col on wider */
     .report-page {
       min-height: 100vh;
       background: var(--bg);
@@ -53,7 +53,11 @@
       align-items: center;
       max-width: 900px;
       margin: 0 auto;
-      padding: 1.5rem 1.5rem 0;
+      /* E6+clearance: base 5rem clears ~58px fixed nav; desktop steps up */
+      padding: 5rem 1.5rem 0;
+    }
+    @media (min-width: 681px) {
+      .report-back-row { padding-top: 6rem; }
     }
 
     .report-back {
@@ -140,18 +144,20 @@
       justify-content: flex-end;
     }
 
-    /* ── Cards ── */
+    /* ── Cards — E6 mobile-first: 1-col base, 2-col on wider screens ── */
     .report-grid {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: 1fr;
       gap: 1rem;
       margin-bottom: 1rem;
     }
+    .report-header { flex-direction: column; }
+    .report-header-badges { justify-content: flex-start; }
 
-    @media (max-width: 680px) {
-      .report-grid { grid-template-columns: 1fr; }
-      .report-header { flex-direction: column; }
-      .report-header-badges { justify-content: flex-start; }
+    @media (min-width: 681px) {
+      .report-grid { grid-template-columns: 1fr 1fr; }
+      .report-header { flex-direction: row; }
+      .report-header-badges { justify-content: flex-end; }
     }
 
     .report-card {

--- a/docs/og/addy-osmani/performance-optimization.svg
+++ b/docs/og/addy-osmani/performance-optimization.svg
@@ -19,7 +19,7 @@
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
   <defs><clipPath id="med-clip-addy-osmani-performance-optimization"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-addy-osmani-performance-optimization" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-addy-osmani-performance-optimization)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-addy-osmani-performance-optimization)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->

--- a/docs/og/browser-use/browser-harness.svg
+++ b/docs/og/browser-use/browser-harness.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /browser-harness">
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /browser-harness">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
-  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-browser-use-browser-harness"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-browser-use-browser-harness" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-browser-use-browser-harness)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-browser-use-browser-harness)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-browser-use-browser-harness"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-browser-use-browser-harness" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-browser-use-browser-harness)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-browser-use-browser-harness)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="228.7" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="73" fill="#ebe5d4" dominant-baseline="middle">/browser-harness</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@browser-use</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 73.6</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 73.6</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE B</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/firecrawl/firecrawl-build-scrape.svg
+++ b/docs/og/firecrawl/firecrawl-build-scrape.svg
@@ -19,7 +19,7 @@
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
   <defs><clipPath id="med-clip-firecrawl-firecrawl-build-scrape"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-build-scrape" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-build-scrape)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-build-scrape)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->

--- a/docs/og/firecrawl/firecrawl-build-search.svg
+++ b/docs/og/firecrawl/firecrawl-build-search.svg
@@ -19,7 +19,7 @@
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
   <defs><clipPath id="med-clip-firecrawl-firecrawl-build-search"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-build-search" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-build-search)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-build-search)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->

--- a/docs/og/firecrawl/firecrawl-skills.svg
+++ b/docs/og/firecrawl/firecrawl-skills.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /firecrawl-skills">
+  class="plate plate--suite" data-branch="suite" data-level="4"
+  data-plate-class="STELLAR"
+  aria-label="Extra · 4★ — STELLAR plate for /firecrawl-skills">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Extra · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-firecrawl-firecrawl-skills"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-skills" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-skills)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-skills)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-firecrawl-firecrawl-skills"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-firecrawl-firecrawl-skills" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-firecrawl-firecrawl-skills)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-firecrawl-firecrawl-skills)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="231.8" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="68" fill="#ebe5d4" dominant-baseline="middle">/firecrawl-skills</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@firecrawl</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 223.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 223.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>α FIRECRAWL-SKILLS · 2026</tspan></text>
 </svg>

--- a/docs/og/garrytan/garrytan.svg
+++ b/docs/og/garrytan/garrytan.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /garrytan">
+  class="plate plate--suite" data-branch="suite" data-level="4"
+  data-plate-class="STELLAR"
+  aria-label="Extra · 4★ — STELLAR plate for /garrytan">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Extra · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-garrytan-garrytan"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-garrytan" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-garrytan)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-garrytan)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-garrytan-garrytan"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-garrytan-garrytan" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-garrytan-garrytan)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-garrytan-garrytan)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/garrytan</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@garrytan</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 156.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 156.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>α GARRYTAN · 2026</tspan></text>
 </svg>

--- a/docs/og/gsd-build/get-shit-done.svg
+++ b/docs/og/gsd-build/get-shit-done.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /get-shit-done">
+  class="plate plate--suite" data-branch="suite" data-level="4"
+  data-plate-class="STELLAR"
+  aria-label="Extra · 4★ — STELLAR plate for /get-shit-done">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Extra · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-gsd-build-get-shit-done"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gsd-build-get-shit-done" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gsd-build-get-shit-done)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gsd-build-get-shit-done)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-gsd-build-get-shit-done"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-gsd-build-get-shit-done" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-gsd-build-get-shit-done)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-gsd-build-get-shit-done)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/get-shit-done</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@gsd-build</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 202.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 202.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>α GET-SHIT-DONE · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/engineering.svg
+++ b/docs/og/mattpocock/engineering.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /engineering">
+  class="plate plate--suite" data-branch="suite" data-level="4"
+  data-plate-class="STELLAR"
+  aria-label="Extra · 4★ — STELLAR plate for /engineering">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Extra · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-mattpocock-engineering"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-engineering" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-engineering)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-engineering)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-mattpocock-engineering"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-engineering" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-engineering)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-engineering)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/engineering</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 270.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 270.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>α ENGINEERING · 2026</tspan></text>
 </svg>

--- a/docs/og/mattpocock/productivity.svg
+++ b/docs/og/mattpocock/productivity.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /productivity">
+  class="plate plate--suite" data-branch="suite" data-level="4"
+  data-plate-class="STELLAR"
+  aria-label="Extra · 4★ — STELLAR plate for /productivity">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Extra · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-mattpocock-productivity"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-productivity" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-productivity)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-productivity)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-mattpocock-productivity"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-mattpocock-productivity" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-mattpocock-productivity)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-mattpocock-productivity)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/productivity</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@mattpocock</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 120.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 120.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>α PRODUCTIVITY · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/subagent-driven-development.svg
+++ b/docs/og/obra/subagent-driven-development.svg
@@ -19,7 +19,7 @@
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
   <defs><clipPath id="med-clip-obra-subagent-driven-development"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-subagent-driven-development" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-subagent-driven-development)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-subagent-driven-development)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->

--- a/docs/og/obra/using-git-worktrees.svg
+++ b/docs/og/obra/using-git-worktrees.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /using-git-worktrees">
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /using-git-worktrees">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
-  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-obra-using-git-worktrees"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-using-git-worktrees" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-using-git-worktrees)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-using-git-worktrees)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-obra-using-git-worktrees"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-using-git-worktrees" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-using-git-worktrees)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-using-git-worktrees)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="238.0" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="58" fill="#ebe5d4" dominant-baseline="middle">/using-git-worktrees</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 117.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 117.7</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/obra/writing-plans.svg
+++ b/docs/og/obra/writing-plans.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /writing-plans">
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /writing-plans">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
-  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-obra-writing-plans"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-writing-plans" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-writing-plans)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-writing-plans)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-obra-writing-plans"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-obra-writing-plans" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-obra-writing-plans)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-obra-writing-plans)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/writing-plans</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@obra</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 110.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 110.2</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/openai/few-shot-learning.svg
+++ b/docs/og/openai/few-shot-learning.svg
@@ -19,7 +19,7 @@
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
   <defs><clipPath id="med-clip-openai-few-shot-learning"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-openai-few-shot-learning" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-openai-few-shot-learning)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-openai-few-shot-learning)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->

--- a/docs/og/openai/self-consistency.svg
+++ b/docs/og/openai/self-consistency.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /self-consistency">
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /self-consistency">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
-  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-openai-self-consistency"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-openai-self-consistency" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-openai-self-consistency)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-openai-self-consistency)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-openai-self-consistency"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-openai-self-consistency" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-openai-self-consistency)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-openai-self-consistency)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="231.8" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="68" fill="#ebe5d4" dominant-baseline="middle">/self-consistency</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@openai</tspan> <tspan font-style="normal" fill-opacity="0.5">·</tspan> <tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 100.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 100.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/pbakaus/impeccable.svg
+++ b/docs/og/pbakaus/impeccable.svg
@@ -19,7 +19,7 @@
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#7c3aed" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
   <defs><clipPath id="med-clip-pbakaus-impeccable"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-pbakaus-impeccable" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-pbakaus-impeccable)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-pbakaus-impeccable)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->

--- a/docs/og/ruvnet/agentdb.svg
+++ b/docs/og/ruvnet/agentdb.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /agentdb">
+  class="plate plate--suite" data-branch="suite" data-level="4"
+  data-plate-class="STELLAR"
+  aria-label="Extra · 4★ — STELLAR plate for /agentdb">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Extra · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-ruvnet-agentdb"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-agentdb" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-agentdb)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-agentdb)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-ruvnet-agentdb"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-agentdb" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-agentdb)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-agentdb)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/agentdb</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 201.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 201.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>α AGENTDB · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/dual-mode.svg
+++ b/docs/og/ruvnet/dual-mode.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /dual-mode">
+  class="plate plate--suite" data-branch="suite" data-level="4"
+  data-plate-class="STELLAR"
+  aria-label="Extra · 4★ — STELLAR plate for /dual-mode">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Extra · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-ruvnet-dual-mode"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-dual-mode" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-dual-mode)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-dual-mode)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-ruvnet-dual-mode"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-dual-mode" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-dual-mode)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-dual-mode)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/dual-mode</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 126.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 126.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>α DUAL-MODE · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/reasoningbank.svg
+++ b/docs/og/ruvnet/reasoningbank.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /reasoningbank">
+  class="plate plate--suite" data-branch="suite" data-level="4"
+  data-plate-class="STELLAR"
+  aria-label="Extra · 4★ — STELLAR plate for /reasoningbank">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Extra · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-ruvnet-reasoningbank"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-reasoningbank" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-reasoningbank)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-reasoningbank)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-ruvnet-reasoningbank"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-reasoningbank" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-reasoningbank)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-reasoningbank)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/reasoningbank</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 118.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 118.5</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>α REASONINGBANK · 2026</tspan></text>
 </svg>

--- a/docs/og/ruvnet/ruflo-v3.svg
+++ b/docs/og/ruvnet/ruflo-v3.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /ruflo-v3">
+  class="plate plate--suite" data-branch="suite" data-level="4"
+  data-plate-class="STELLAR"
+  aria-label="Extra · 4★ — STELLAR plate for /ruflo-v3">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Extra · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
   <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-ruvnet-ruflo-v3"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-ruflo-v3" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-ruflo-v3)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-ruflo-v3)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">STELLAR</text>
+  <defs><clipPath id="med-clip-ruvnet-ruflo-v3"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-ruvnet-ruflo-v3" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-ruvnet-ruflo-v3)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c4-suite-extra-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-ruvnet-ruflo-v3)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">α</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/ruflo-v3</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@ruvnet</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 186.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 186.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>α RUFLO-V3 · 2026</tspan></text>
 </svg>

--- a/docs/og/safishamsi/graphify.svg
+++ b/docs/og/safishamsi/graphify.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /graphify">
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /graphify">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
-  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-safishamsi-graphify"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-safishamsi-graphify" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-safishamsi-graphify)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-safishamsi-graphify)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-safishamsi-graphify"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-safishamsi-graphify" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-safishamsi-graphify)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-safishamsi-graphify)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/graphify</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@safishamsi</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 116.6</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 116.6</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/docs/og/stanfordnlp/dspy.svg
+++ b/docs/og/stanfordnlp/dspy.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="1200" height="630" viewBox="0 0 1200 630"
-  class="plate plate--standard" data-branch="standard" data-level="3"
-  data-plate-class="FIELD BODY"
-  aria-label="Evolved · 3★ — FIELD BODY plate for /dspy">
+  class="plate plate--unique" data-branch="unique" data-level="4"
+  data-plate-class="SINGULARITY"
+  aria-label="Unique · 4★ — SINGULARITY plate for /dspy">
   <rect width="1200" height="630" fill="#0e0d20"/>
 <text x="48.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— +20°</text>
   <line x1="48.0" y1="22" x2="48.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
@@ -13,18 +13,18 @@
   <line x1="469.3" y1="22" x2="469.3" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
   <text x="680.0" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="11" letter-spacing="1.6" fill="#ebe5d4" fill-opacity="0.28" dominant-baseline="middle">— −10°</text>
   <line x1="680.0" y1="22" x2="680.0" y2="30" stroke="#ebe5d4" stroke-opacity="0.22" stroke-width="0.8"/>
-<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Evolved · 3★</text>
+<text x="1152" y="38" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="18" letter-spacing="3.2" fill="#ebe5d4" fill-opacity="0.7" text-anchor="end" dominant-baseline="middle">Unique · 4★</text>
 <line x1="48" y1="558" x2="1152" y2="558" stroke="#ebe5d4" stroke-opacity="0.35" stroke-width="1"/>
   
-  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#fbbf24" stroke-opacity="0.55" stroke-width="1.6"/>
+  <line x1="720" y1="58" x2="720" y2="550" stroke="#ebe5d4" stroke-opacity="0.16" stroke-width="1"/><line x1="720" y1="230" x2="720" y2="370" stroke="#7c3aed" stroke-opacity="0.55" stroke-width="1.6"/>
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#fbbf24" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">FIELD BODY</text>
-  <defs><clipPath id="med-clip-stanfordnlp-dspy"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-stanfordnlp-dspy" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-stanfordnlp-dspy)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-c3-suite-evolved-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-stanfordnlp-dspy)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#fbbf24" stroke-opacity="0.35" stroke-width="1.2"/>
+  <text x="930" y="72" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="15" letter-spacing="4.0" fill="#a78bfa" fill-opacity="0.92" text-anchor="middle" dominant-baseline="middle">SINGULARITY</text>
+  <defs><clipPath id="med-clip-stanfordnlp-dspy"><circle cx="930" cy="300" r="206"/></clipPath><radialGradient id="med-halo-stanfordnlp-dspy" cx="50%" cy="50%" r="50%"><stop offset="60%" stop-color="#7c3aed" stop-opacity="0"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0.22"/></radialGradient></defs><circle cx="930" cy="300" r="232" fill="url(#med-halo-stanfordnlp-dspy)"/><image x="664.9" y="34.9" width="530.2" height="530.2" href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" xlink:href="/assets/ascension-overdrive/aov4-d4-unique-hero.webp" preserveAspectRatio="xMidYMid slice" clip-path="url(#med-clip-stanfordnlp-dspy)"/><circle cx="930" cy="300" r="206" fill="none" stroke="#ebe5d4" stroke-opacity="0.30" stroke-width="1"/><circle cx="930" cy="300" r="214" fill="none" stroke="#7c3aed" stroke-opacity="0.35" stroke-width="1.2"/>
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->
   <text x="60" y="223.2" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace"
-    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">GAIA</text>
+    font-size="26" letter-spacing="4.2" fill="#ebe5d4" fill-opacity="0.65">BH</text>
 
   <text x="60" y="292" font-family="'EB Garamond',Georgia,serif" font-weight="600"
     font-size="82" fill="#ebe5d4" dominant-baseline="middle">/dspy</text>
@@ -36,5 +36,5 @@
   <text x="48" y="538" font-family="'EB Garamond',Georgia,serif" font-size="22" font-style="italic" fill="#fbbf24" dominant-baseline="middle"><tspan font-style="normal" fill-opacity="0.82">Cataloged by </tspan><tspan font-weight="600">@stanfordnlp</tspan> <tspan font-style="normal" letter-spacing="2.2" font-size="18" fill-opacity="0.9">· ORIGIN ·</tspan><tspan font-style="normal" fill-opacity="0.7"> 2026</tspan></text>
 
   <!-- Marginal magnitude band -->
-  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 100.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>★★★</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GAIA · 2026</tspan></text>
+  <text x="48" y="586" font-family="'Departure Mono','JetBrains Mono',ui-monospace,monospace" font-size="13" letter-spacing="1.5" fill="#ebe5d4" fill-opacity="0.7"><tspan>MAG 100.0</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>GRADE A</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>⊘ UNIQUE</tspan><tspan fill-opacity="0.35"> · · · </tspan><tspan>BH IV · 2026</tspan></text>
 </svg>

--- a/scripts/generateOgCards.py
+++ b/scripts/generateOgCards.py
@@ -96,6 +96,11 @@ CREAM_ENGRAVED = "#ebe5d4"     # OKLCH ~ oklch(92% 0.015  80); warm cream ink/li
 SIGNATURE_GOLD = "#fbbf24"     # discoverer's signature + origin mark (was honor-red)
 APEX_GOLD = "#fbbf24"          # suite plate-class accent + gutter tint (gold-leaning)
 VIOLET_HALO = "#7c3aed"        # unique plate-class accent + gutter tint (darker register)
+# E2/E7 contrast fix (Ygg-II W3c): VIOLET_HALO is ~3.1:1 on INK_NIGHT — fails WCAG AA.
+# VIOLET_KICKER is the lighter text-safe violet used only for kicker/label fills;
+# VIOLET_HALO stays for decorative strokes (gutter rule, halo ring) where contrast
+# is not a readability requirement. oklch(68% 0.22 285) ≈ #a78bfa → 7.2:1 on INK_NIGHT.
+VIOLET_KICKER = "#a78bfa"      # unique branch kicker text — WCAG AA+ on INK_NIGHT
 
 # ─── AOV4 medallion resolver (mirrors docs/js/plaque.js `_aovStamp`) ──────────
 # The subject art IS the skill's Ascension-Overdrive V4 stamp — the exact
@@ -463,7 +468,10 @@ def build_plate(skill: dict) -> str:
     sid = (skill.get("id") or "unknown").replace("/", "-").replace(" ", "-")
 
     branch = og_branch(skill)
+    # Decorative accent (strokes, gutter rule, halo ring) — can be dark violet
     accent = VIOLET_HALO if branch == "unique" else APEX_GOLD
+    # Text-fill for the plate-class kicker — must pass WCAG AA on INK_NIGHT
+    kicker_fill = VIOLET_KICKER if branch == "unique" else APEX_GOLD
     rank_label = og_rank_label(n_lvl, branch)
     plate_class = og_plate_class(n_lvl, branch)
 
@@ -518,7 +526,7 @@ def build_plate(skill: dict) -> str:
   {_gutter_rule(accent)}
 
   <!-- SUBJECT column: the skill's own AOV4 medallion -->
-  {_plate_class_kicker(plate_class, accent)}
+  {_plate_class_kicker(plate_class, kicker_fill)}
   {_medallion(branch, n_lvl, sid, accent)}
 
   <!-- TYPE column: catalogue prefix + slash-slug + title kicker -->


### PR DESCRIPTION
## Wave 3c — Profiles + reports mobile-first (EPIC #1002 · #998)

Part of the Yggdrasil II capstone (N-12 mobile-first sweep). Targets `dev/yggdrasil-ii-staging`.

**Scope:** `docs/u` profiles + `docs/reports` mobile-first, OG kicker contrast (carried W2a unique violet kicker), fixed-nav clearance (carried W2c `.report-back-row`).

**Files:** `docs/css/plaque.css`, `docs/css/styles.css`, `docs/named/report.html`, `scripts/generateOgCards.py`, 20× `docs/og/**/*.svg` (Class-S regenerated cards).

**Reviewer verdict:** build (profile+report mobile-first, OG kicker contrast, clearance) + orchestrator nit-fix — dropped 3 raw hex fallbacks on `.profile-filter-toggle` (tokens-only, commit `d823965d8`).

**Ground-truth (orchestrator, pre-merge):** authorship 100% `mbtiongson1`; no Class-P leak (`docs/og/*.svg` are Class-S tracked site assets); zero banned-words/dead-enum on added lines; `docs/meta/reports/` confirmed UNTOUCHED (N-7 scope is `docs/reports/` only).

**Branch-scope:** touches `scripts/generateOgCards.py` → needs `skip-scope-check` (founder-pre-authorized).

**Entrypoints:** mobile-first restyle of existing profile/report surfaces. No new mounts required.

Merge as **merge-commit** (never squash — EPIC integration rule).
