### PR TITLE
PR1 · Ygg II taxonomy authority module + parity oracle (keystone, pure-add)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,18 +43,18 @@ _Avoid_: writing `type` on a named-skill frontmatter; using the legacy values `e
 **Nomenclature — the "Skill" suffix** (Yggdrasil II): the proper-noun suffix "Skill" attaches to **rank** names only — **Extra Skill**, **Unique Skill**, **Ultimate Skill**, **Apex Skill** (e.g. "Ultimate Skill: garrytan/gsstack"). **Type** words stand bare: **Basic** and **Fusion** — never "Basic Skill" or "Fusion Skill". Types are structural categories, not ranks. The 1★–3★ shared-ladder rank words (**Awakened** 1★, **Named** 2★, **Evolved** 3★) are always written **star-qualified** as ranks ("2★ Named", "the Named rank") and never take a bare "X Skill" form — so **Named Skill** unambiguously denotes the claimed-skill entity (a contributor's implementation), never "a 2★ skill". Only the 4★+ branch ranks take the "Skill" suffix as rank phrasings.
 
 **Branch axis** (progression — named only):
-Values: `standard`, `unique`, `suite`. Derived at read-time by `computeBranch(named)` from `(the Named Skill's own suiteComponents present?, named.level)` — `suiteComponents` is a **Named-Skill-only field, never present on the starless generic parent**. **Never declared on nodes; always computed.**
+Values: `standard`, `unique`, `suite`. Derived at read-time by `computeBranch(named)` — **suiteComponents-presence decides membership first, then rank**: a Named Skill carrying `suiteComponents` is `suite` at **any rank** (from its 2★ push floor up); a Named Skill without `suiteComponents` is `standard` at 1–3★ and `unique` at 4–6★. `suiteComponents` is a **Named-Skill-only field, never present on the starless generic parent**. **Never declared on nodes; always computed.** *(The 4★ suite/unique ladder words + glyphs are a separate **decoration** gate — see Suite/Unique branch below — not a membership gate.)*
 _Avoid_: writing a `branch` field to a node; treating branch as user-editable.
 
 **Standard branch**:
-1★ Awakened → 2★ Named → 3★ Evolved. Default; every named skill starts here.
+1★ Awakened → 2★ Named → 3★ Evolved. The branch for skills **without** `suiteComponents` below 4★. A skill *with* `suiteComponents` is **Suite-branch from 2★** (see below), even while it shows these shared words below 4★.
 
 **Unique branch**:
 4★ Unique → 5★ Unique Ultimate → 6★ Unique Impossible. For skills that reach 4★+ **without** being a suite (the Named Skill carries no `suiteComponents`). `suiteRef` membership does NOT disqualify — a "world-renowned handoff skill" that happens to live inside a suite is still Unique. Standalone-prestige track. Impeccable is the archetype. Gates: 4★ = Origin + TM ≥ 100 (A); 5★ = Origin + TM ≥ 250 (S); origins counted in **fusion structure** (`prerequisites`), not `suiteComponents`. 6★ Unique Impossible = provisional 5-predicate gate (Apex minus `directNestedSuiteGte1`).
 _Avoid_: treating suite membership as automatically disqualifying from Unique.
 
 **Suite branch**:
-4★ Extra → 5★ Ultimate → 6★ Apex. For Named Skills that carry `suiteComponents` (structural fusion of grouped components). Group-prestige track. 5★ gate preserved per #935 (Origin in `suiteComponents` + 5 A-graded origins in `suiteComponents` + TM ≥ 250). 6★ Apex Gate = the 6-predicate G7 set (preserved).
+For Named Skills that carry `suiteComponents` — **branch = `suite` from the 2★ push floor upward, at any rank.** A suite is a suite the moment it's pushed (2★); evidence climbs it toward 4★. The **custom suite ladder (4★ Extra → 5★ Ultimate → 6★ Apex) and suite glyph (◆) render only at 4★+** — a suite-branch skill at 2★/3★ shows the shared rank word (Named / Evolved) and the plain glyph (◇). Membership is structural (`suiteComponents` present); the 4★ fork is a **decoration** gate earned by evidence, not a membership gate. Group-prestige track. 5★ gate preserved per #935 (Origin in `suiteComponents` + 5 A-graded origins in `suiteComponents` + TM ≥ 250). 6★ Apex Gate = the 6-predicate G7 set (preserved). *(2★/3★ suites gate on the normal per-star evidence progression; suite-specific gates begin at 4★.)*
 
 **Ultimate** _(5★ rank name — Yggdrasil II)_:
 The rank name for **every 5★ skill** across branches. Suite branch: **Ultimate**. Unique branch: **Unique Ultimate**. Intentional gacha-anchor collision — devs should associate "Ultimate" with "5★" universally. Replaces the Yggdrasil I rank name "Transcendent". Deprecates the Yggdrasil I taxonomy usage of "Ultimate" (see `Ultimate Skill` entry above).
@@ -230,7 +230,7 @@ _Yggdrasil II (2026-07-07) updates these relationships. Legacy Yggdrasil I copy 
 
 - A **Basic** (`type=basic`, 0 prerequisites) fuses with other Basics to produce a **Fusion** (`type=fusion`, ≥1 prerequisite). Legacy Yggdrasil I called these "Extras".
 - A **Fusion** can fuse with other Fusions to produce a more complex Fusion.
-- A named skill lives on one of three **branches** (derived, never declared): **Standard** (1★–3★), **Unique** (4★+ non-suite; the Yggdrasil I "Unique" tier now lives here as a *progression path*), or **Suite** (4★+ suite-based; the Yggdrasil I "Extra 4★" + "Ultimate 5★+" ranks now live here).
+- A named skill lives on one of three **branches** (derived, never declared): **Suite** (carries `suiteComponents`, from 2★ up — suite ladder words appear at 4★+), **Unique** (4★+ non-suite; the Yggdrasil I "Unique" tier now lives here as a *progression path*), or **Standard** (no suite, below 4★). Every named skill starts at 2★ — on **Suite** if it carries `suiteComponents`, else **Standard**.
 - A skill becomes a **Named Skill** at 2★, attaching it to its **Origin Contributor**.
 - Every star above 1★ requires graded evidence — an **Evidence Grade** (the deprecated **Evidence Class** axis it replaces). Ranking up gates on **Trust Magnitude** (TM Index (2026 Q2)); the legacy per-star **Evidence Floor** column is retired under Yggdrasil II.
 - The **Registry** is the canonical graph; a **Skill Tree** is one user's view of that graph.

--- a/META.md
+++ b/META.md
@@ -30,12 +30,12 @@ Gaia uses a tiered star system (`0★`–`6★`) to rank skills. Levels are both
 - **`basic`** — 0 prerequisites. Root primitive nodes.
 - **`fusion`** — ≥ 1 prerequisite. Any non-basic starless node. PURE STRUCTURE — `type` does **not** determine a named skill's branch. Legacy values `extra`, `ultimate`, and `unique` are retired; all non-basic nodes are `fusion`.
 
-**`suiteComponents`** — the parent-level list of co-located suite components. Its **presence** on a generic node drives the branch fork for all named skills attached to that node and feeds downstream Trust Magnitude (§4.3 depth-2 walker). Independent of `type`.
+**`suiteComponents`** — a **Named-Skill-only** list of co-located suite components (never on the starless generic parent, per #996). Its **presence** puts the Named Skill on the `suite` branch at any rank and feeds downstream Trust Magnitude (§4.3 depth-2 walker). Independent of `type`.
 
-**Branch axis** — named skills only, **derived at read-time, never declared**. Rule: `branch = f(suiteComponents present?, rank)`:
-- **`standard`** — rank 1–3. Shared ladder: 1★ Awakened → 2★ Named → 3★ Evolved. Every named skill starts here regardless of parent `type`.
-- **`suite`** — rank ≥ 4 AND the generic parent carries `suiteComponents`. Suite ladder: 4★ **Extra** → 5★ **Ultimate** → 6★ **Apex**.
-- **`unique`** — rank ≥ 4 AND the generic parent has **no** `suiteComponents`. Unique ladder: 4★ **Unique** → 5★ **Unique Ultimate** → 6★ **Unique Impossible**.
+**Branch axis** — named skills only, **derived at read-time, never declared**. `branch = f(suiteComponents present?, rank)`, **suiteComponents-presence first**:
+- **`suite`** — `suiteComponents` present, at **any rank** (from the 2★ push floor). Suite **ladder words + glyph appear only at 4★+**: 4★ **Extra** → 5★ **Ultimate** → 6★ **Apex**; a 2★/3★ suite shows the shared word (Named/Evolved) + plain glyph. Membership is structural; the 4★ fork is a decoration gate.
+- **`unique`** — no `suiteComponents` AND rank ≥ 4. Unique ladder: 4★ **Unique** → 5★ **Unique Ultimate** → 6★ **Unique Impossible**.
+- **`standard`** — no `suiteComponents` AND rank 1–3. Shared ladder: 1★ Awakened → 2★ Named → 3★ Evolved.
 
 **Orthogonality**: type and branch are fully independent. A `fusion` node without `suiteComponents` yields Unique-branch named skills; a `basic` node with `suiteComponents` yields Suite-branch named skills. Never consult `type` to determine branch.
 

--- a/scripts/check_taxonomy_authority.py
+++ b/scripts/check_taxonomy_authority.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+check_taxonomy_authority.py — Yggdrasil II taxonomy-authority grep guard
+                              (PR1 — WARN-ONLY until PR3b)
+
+Scans the production content surface for READ-TIME branch derivation that
+should route through the taxonomy authority (src/gaia_cli/taxonomy.py) instead
+of re-deriving the branch inline from `type` or from branch-word literals.
+
+  §Ygg-II rubric E1: branch MUST be derived at read-time through the single
+  authority — NEVER from `skill.type === 'ultimate'|'unique'|'extra'|'basic'`
+  and NEVER from a stored/inlined branch/tier literal.
+
+==============================================================================
+WARN-ONLY IN THIS PR (exit 0 always).  The four live resolvers still exist
+everywhere (skill-semantics.js, world-tree-layout.js, trustMagnitude.py,
+formatting.py) and every consumer still derives inline — so this guard CANNOT
+hard-fail yet without RED-building the whole tree.  It emits warnings so the
+migration surface is visible and tracked.
+
+  >>> It FLIPS TO HARD-FAIL in PR3b <<<  (once consumers migrate onto
+  taxonomy.py and the inline resolvers are deleted).  When flipping: change
+  `HARD_FAIL = False` to True below and wire it into the docs-cohesion / guard
+  workflow the way check_rank_vocabulary.py is.
+==============================================================================
+
+WHAT IT FLAGS  (read-time derivation signatures)
+  - `type ===` / `type ==` compared against a branch/type word
+    ('unique' | 'suite' | 'ultimate' | 'extra' | 'basic' | 'fusion')
+  - branch-word derivation literals used as a resolved branch value:
+    'suite' / 'unique' / 'standard' string literals, and the rank words
+    Extra / Ultimate / Apex / Unique used as branch derivation.
+
+SCAN SCOPE  (production surfaces only)
+  docs/**/*.js
+  docs/**/*.html   (INCLUDING inline <script> blocks)
+  src/**/*.py
+  scripts/**/*.py
+
+EXCLUSIONS
+  docs/experiments/**  — sample/experiment surfaces still derive from dead type;
+  docs/samples/**         out of scope for the authority cut — tracking issue TBD.
+  The authority module + its tests/harness are self-referential and excluded:
+  src/gaia_cli/taxonomy.py, tests/**.
+
+Force UTF-8 output on Windows (repo has cp1252 glyphs).
+"""
+
+import re
+import sys
+import fnmatch
+from pathlib import Path
+
+# Force UTF-8 output on Windows so unicode chars in print() don't crash.
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+if sys.stderr.encoding and sys.stderr.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Warn-only switch — FLIP TO True IN PR3b (see module docstring)
+# ---------------------------------------------------------------------------
+HARD_FAIL = False
+
+
+# ---------------------------------------------------------------------------
+# Derivation signatures
+# ---------------------------------------------------------------------------
+
+# `type === 'unique'` / `type == "extra"` / `type===basic` etc.
+BRANCH_TYPE_WORDS = r"(?:unique|suite|ultimate|extra|basic|fusion|standard)"
+TYPE_COMPARE = re.compile(
+    r"type\s*={2,3}\s*['\"]?" + BRANCH_TYPE_WORDS + r"['\"]?",
+    re.IGNORECASE,
+)
+
+# Branch-word string literals used as a resolved branch value. We flag the
+# quoted branch strings ('suite'|'unique'|'standard') and the rank-word literals
+# (Extra|Ultimate|Apex|Unique) that indicate inline branch derivation.
+BRANCH_STRING_LITERAL = re.compile(r"""['"](?:suite|unique|standard)['"]""")
+RANK_WORD_DERIVATION = re.compile(r"\b(?:Extra|Ultimate|Apex|Unique)\b")
+
+DERIVATION_PATTERNS = [
+    (TYPE_COMPARE, "type-compare",
+     "read-time branch derivation from `type` — route through taxonomy.resolveDisplayBranch()"),
+    (BRANCH_STRING_LITERAL, "branch-literal",
+     "inline branch string literal — the resolved branch must come from the authority"),
+    (RANK_WORD_DERIVATION, "rank-word-literal",
+     "inline rank/branch word — rank words come from taxonomy.rankWord()"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Scope / exclusions
+# ---------------------------------------------------------------------------
+
+SCAN_GLOBS = [
+    "docs/**/*.js",
+    "docs/**/*.html",
+    "src/**/*.py",
+    "scripts/**/*.py",
+]
+
+EXCLUDE_GLOBS = [
+    # sample/experiment surfaces still derive from dead type; out of scope for
+    # the authority cut — tracking issue TBD.
+    "docs/experiments/**",
+    "docs/samples/**",
+    # the authority module + its tests/harness are self-referential.
+    "src/gaia_cli/taxonomy.py",
+    "tests/**",
+    # generated / vendored
+    "**/__pycache__/**",
+    "docs/assets/**",
+]
+
+# Inline <script> extraction for .html files.
+SCRIPT_BLOCK = re.compile(r"<script\b[^>]*>(.*?)</script>", re.IGNORECASE | re.DOTALL)
+
+
+def isExcluded(relPath: str) -> bool:
+    norm = relPath.replace("\\", "/")
+    for pattern in EXCLUDE_GLOBS:
+        if fnmatch.fnmatch(norm, pattern):
+            return True
+    return False
+
+
+def collectFiles(repoRoot: Path):
+    seen = set()
+    for globPattern in SCAN_GLOBS:
+        for p in repoRoot.glob(globPattern):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(repoRoot).as_posix()
+            if rel in seen or isExcluded(rel):
+                continue
+            seen.add(rel)
+            yield p, rel
+
+
+def scanText(text: str, isHtml: bool):
+    """Yield (lineno, snippet, label, rationale). For HTML, scan only inline
+    <script> blocks (line numbers are relative to the whole file)."""
+    if isHtml:
+        # Map script-block content back to file line numbers.
+        for m in SCRIPT_BLOCK.finditer(text):
+            startLine = text.count("\n", 0, m.start(1)) + 1
+            block = m.group(1)
+            for offset, line in enumerate(block.splitlines()):
+                for pattern, label, rationale in DERIVATION_PATTERNS:
+                    if pattern.search(line):
+                        yield startLine + offset, line.strip()[:120], label, rationale
+    else:
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for pattern, label, rationale in DERIVATION_PATTERNS:
+                if pattern.search(line):
+                    yield lineno, line.strip()[:120], label, rationale
+
+
+def scan(repoRoot: Path):
+    findings = []  # (rel, lineno, snippet, label, rationale)
+    for filePath, rel in collectFiles(repoRoot):
+        try:
+            text = filePath.read_text(encoding="utf-8", errors="replace")
+        except (OSError, PermissionError) as exc:
+            print(f"  [SKIP] {rel}: {exc}", file=sys.stderr)
+            continue
+        isHtml = rel.lower().endswith(".html")
+        for lineno, snippet, label, rationale in scanText(text, isHtml):
+            findings.append((rel, lineno, snippet, label, rationale))
+    return findings
+
+
+def main():
+    repoRoot = Path(__file__).resolve().parent.parent
+
+    print("=== Yggdrasil II Taxonomy-Authority Guard  (PR1 — WARN-ONLY) ===")
+    print(f"Repo root : {repoRoot}")
+    print("Flags     : read-time branch derivation (type-compare / branch-literal / rank-word-literal)")
+    print("Authority : route branch/rank through src/gaia_cli/taxonomy.py")
+    print(f"Mode      : {'HARD-FAIL' if HARD_FAIL else 'WARN-ONLY (flips to hard-fail in PR3b)'}")
+    print("Excluded  : docs/experiments/**, docs/samples/** (sample surfaces; tracking issue TBD)")
+    print()
+
+    findings = scan(repoRoot)
+
+    if findings:
+        byFile = {}
+        for entry in findings:
+            byFile.setdefault(entry[0], []).append(entry)
+        severity = "FAIL" if HARD_FAIL else "WARN"
+        print(f"-- READ-TIME DERIVATION SITES ({len(findings)} hit(s) across {len(byFile)} file(s)) --")
+        for path, entries in sorted(byFile.items()):
+            print(f"  [{severity}] {path}  ({len(entries)} hit(s))")
+        print()
+        if HARD_FAIL:
+            print(f"RESULT: FAIL — {len(findings)} derivation site(s) must migrate to taxonomy.py")
+            return 1
+        print(f"RESULT: PASS (warn-only) — {len(findings)} derivation site(s) tracked for PR3b migration")
+        return 0
+
+    print("RESULT: PASS — 0 read-time derivation sites.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gaia_cli/taxonomy.py
+++ b/src/gaia_cli/taxonomy.py
@@ -1,0 +1,289 @@
+"""taxonomy.py — Yggdrasil II taxonomy-resolution authority (PR1 keystone).
+
+SINGLE SOURCE OF TRUTH for branch / rank-word / medallion derivation, ported
+from the four live resolvers this module supersedes:
+
+  JS  #1  docs/js/skill-semantics.js         (computeBranch, rankWord, rankLabel)
+  Py  #3  src/gaia_cli/trustMagnitude.py     (computeBranch + _starRank/_suiteComponentsPresent)
+  Py  #4  src/gaia_cli/formatting.py          (rank_word, LEVEL_LABELS_SUITE/UNIQUE)
+  JS  #2  docs/js/world-tree-layout.js        (resolveSemantics — the Ygg I/II fork)
+
+Nothing consumes this module yet (PR1 is a pure add). Downstream PRs migrate
+each consumer onto these functions; PR3b deletes the JS/Py resolvers above.
+
+Canonical semantics — FOUNDER RULING (do NOT reintroduce JS #1's `type==='basic'`
+guard). Branch is derived from rank + suiteComponents-presence ONLY; `type` is
+never consulted at display time:
+
+    rank < 4                                  -> 'standard'
+    rank >= 4 AND suiteComponents present     -> 'suite'
+    rank >= 4 AND no suiteComponents          -> 'unique'
+
+This is Py #3's type-INDEPENDENT logic. It intentionally diverges from JS #1
+(which consults `type`) on `type != 'basic'` nodes at rank >= 4 with no
+suiteComponents. That divergence is deliberate and is pinned by the contract
+oracle (tests/test_taxonomy_contract.py).
+
+Rank ladders (canonical — fork at 4 stars+):
+    SHARED  {0 Basic, 1 Awakened, 2 Named, 3 Evolved}
+    SUITE   {4 Extra, 5 Ultimate, 6 Apex}
+    UNIQUE  {4 Unique, 5 Unique Ultimate, 6 Unique Impossible}
+
+BANNED words anywhere in emitted vocabulary: 'Transcendent', 'Hardened'
+(scripts/check_rank_vocabulary.py enforces).
+
+Absent-field fallback: every resolver accepts BOTH a pre-resolved entry (reads
+an emitted `branch`/`rank` field when present) AND a raw entry (field absent ->
+derive). The fallback lives INSIDE this module — never hard-index a resolved
+field. Rationale: a stale bundled wheel snapshot must still render before the
+user's first `gaia pull`.
+
+Repo style: no underscores in public function names (dunders excepted).
+"""
+
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Meta-epoch constants
+# ---------------------------------------------------------------------------
+
+# meta.json `metaEpochs.order` — see docs/graph/gaia.json.
+EPOCH_YGG_I = "yggdrasil-i"
+EPOCH_YGG_II = "yggdrasil-ii"
+
+
+# ---------------------------------------------------------------------------
+# Rank-word ladders (canonical single source)
+# ---------------------------------------------------------------------------
+
+# Shared 0-3 stars (branch-agnostic). 0 stars = Basic (starless).
+SHARED_WORD = {0: "Basic", 1: "Awakened", 2: "Named", 3: "Evolved"}
+# Suite branch 4-6 stars.
+SUITE_WORD = {4: "Extra", 5: "Ultimate", 6: "Apex"}
+# Unique branch 4-6 stars.
+UNIQUE_WORD = {4: "Unique", 5: "Unique Ultimate", 6: "Unique Impossible"}
+
+# Structural-class glyph / medallion token (resolveSemantics 3.1/6):
+#   unique . suite . root (basic, standard) . else (crown, standard).
+# The authority exposes a single medallion() resolver keyed on the RESOLVED
+# branch (+ rank), not on `type`. Since branch already encodes the
+# suite/unique/standard distinction, a standard node maps to the neutral
+# crown glyph (the root glyph in resolveSemantics is a hemisphere-by-type
+# artifact that the type-independent authority does not reproduce).
+MEDALLION_UNIQUE = "◉"    # circled bullet
+MEDALLION_SUITE = "◆"     # black diamond
+MEDALLION_STANDARD = "◇"  # white diamond
+
+
+# ---------------------------------------------------------------------------
+# Level parsing
+# ---------------------------------------------------------------------------
+
+def levelNum(level: Any) -> int:
+    """Parse a level ("5star" | "5" | 5 | None) to a clamped integer 0..6.
+
+    Mirrors skill-semantics.js levelNum() and trustMagnitude._starRank(),
+    unified. None / unparseable -> 0.
+    """
+    if level is None:
+        return 0
+    if isinstance(level, bool):  # guard: bool is an int subclass
+        return 0
+    if isinstance(level, int):
+        return max(0, min(6, level))
+    digits = ""
+    for ch in str(level):
+        if ch.isdigit():
+            digits += ch
+        elif digits:
+            break
+    if not digits:
+        return 0
+    return max(0, min(6, int(digits)))
+
+
+def suiteComponentsPresent(entry: dict) -> bool:
+    """True iff the entry carries a non-empty suiteComponents list.
+
+    Mirrors JS #1 (`Array.isArray && length > 0`) and Py #3
+    `_suiteComponentsPresent` (the generic-parent read is threaded by callers
+    that resolve the parent onto the entry before normalize()).
+    """
+    sc = entry.get("suiteComponents")
+    return bool(sc) and isinstance(sc, (list, tuple)) and len(sc) > 0
+
+
+# ---------------------------------------------------------------------------
+# normalize — the ONLY meta-version-aware code (absorbs resolveSemantics fork)
+# ---------------------------------------------------------------------------
+
+def normalize(entry: Optional[dict], metaEpoch: str = EPOCH_YGG_II) -> dict:
+    """Reduce a raw skill entry to ONE canonical internal shape.
+
+    This is the sole meta-version-aware function. It absorbs the Ygg I/II fork
+    from world-tree-layout.js resolveSemantics() (L356-413): a Ygg I
+    `type:'ultimate'`/`'unique'`/`'extra'` node and a Ygg II
+    `type:'fusion'`/`'basic'` node both map to the same canonical dict.
+
+    metaEpoch selects the fork. Ygg III later = add a branch here; no consumer
+    downstream ever forks on epoch again.
+
+    Returned canonical shape (stable keys):
+        {
+          'rank':                  int 0..6 (resolved effective star level),
+          'suiteComponentsPresent': bool,
+          'branchEligible':        bool  (rank >= 4 — the normalized
+                                          branch-eligibility signal),
+          'branch':                str|None  (pre-resolved 'branch' field iff
+                                              the entry already carried one;
+                                              None -> resolveDisplayBranch derives),
+          'metaEpoch':             str,
+        }
+
+    Rank read order (absent-field fallback): explicit `rank` field ->
+    `level` field -> `namedMaxLevel` field (gaia.json generic nodes carry only
+    namedMaxLevel) -> 0.
+    """
+    entry = entry or {}
+    epoch = metaEpoch or EPOCH_YGG_II
+
+    # --- resolved rank (absent-field fallback ladder) ---
+    if "rank" in entry and entry.get("rank") is not None:
+        rank = levelNum(entry.get("rank"))
+    elif entry.get("level") is not None:
+        rank = levelNum(entry.get("level"))
+    else:
+        # gaia.json generic nodes have no `level`; the effective star rank is
+        # the highest named form (`namedMaxLevel`). None -> 0 (starless).
+        rank = levelNum(entry.get("namedMaxLevel"))
+
+    hasSuite = suiteComponentsPresent(entry)
+    kind = entry.get("type")
+
+    # --- Ygg I/II fork (resolveSemantics 3.2 isUnique / isSuite mapping) ---
+    # The fork exists to translate legacy type-driven signals into the same
+    # rank + suiteComponents shape the Ygg II resolver expects. Under Ygg I a
+    # node's structural class was carried by `type`; under Ygg II it is carried
+    # by rank + suiteComponents. normalize() reconciles both onto:
+    #   suiteComponentsPresent  (drives the suite branch at 4 stars+)
+    #   branchEligible          (rank >= 4)
+    if epoch == EPOCH_YGG_I:
+        # Ygg I: type === 'ultimate' | 'extra' behaved as suite carriers;
+        # type === 'unique' behaved as the unique branch. Fold the legacy type
+        # signal into the canonical suite-presence flag so the type-independent
+        # resolveDisplayBranch produces the same branch it did under Ygg I.
+        if kind in ("ultimate", "extra"):
+            hasSuite = True
+        # A Ygg I 'unique' had no suiteComponents by construction; leave
+        # hasSuite as-is so a 4 stars+ unique resolves to 'unique'.
+    # Ygg II: nothing to fold — type in {basic, fusion} is display-irrelevant.
+
+    # --- pre-resolved branch passthrough (stale-snapshot fallback) ---
+    branch = entry.get("branch")
+    if branch not in ("standard", "suite", "unique"):
+        branch = None  # unrecognised / absent -> derive downstream
+
+    return {
+        "rank": rank,
+        "suiteComponentsPresent": hasSuite,
+        "branchEligible": rank >= 4,
+        "branch": branch,
+        "metaEpoch": epoch,
+    }
+
+
+# ---------------------------------------------------------------------------
+# resolveDisplayBranch — canonical (type-independent) branch resolver
+# ---------------------------------------------------------------------------
+
+def resolveDisplayBranch(normalized: dict) -> str:
+    """Return 'standard' | 'suite' | 'unique' from a normalize() shape.
+
+    CANONICAL SEMANTICS — FOUNDER RULING (see module docstring). Type-independent:
+
+        rank < 4                              -> 'standard'
+        rank >= 4 AND suiteComponents present -> 'suite'
+        rank >= 4 AND no suiteComponents      -> 'unique'
+
+    Absent-field fallback: a normalize() shape that already carried a
+    pre-resolved `branch` (from an emitted field) is honoured verbatim; only a
+    None branch is derived. This lets a stale bundled snapshot render its
+    emitted branch without re-deriving.
+    """
+    normalized = normalized or {}
+    pre = normalized.get("branch")
+    if pre in ("standard", "suite", "unique"):
+        return pre
+    if not normalized.get("branchEligible") or normalized.get("rank", 0) < 4:
+        return "standard"
+    if normalized.get("suiteComponentsPresent"):
+        return "suite"
+    return "unique"
+
+
+def branchFor(entry: dict, metaEpoch: str = EPOCH_YGG_II) -> str:
+    """Convenience: normalize(entry) then resolveDisplayBranch(...).
+
+    Accepts a raw OR pre-resolved entry (fallback lives in normalize +
+    resolveDisplayBranch). This is the single call a consumer makes when it
+    holds a raw skill object rather than an already-normalized shape.
+    """
+    return resolveDisplayBranch(normalize(entry, metaEpoch))
+
+
+# ---------------------------------------------------------------------------
+# rankWord / rankLabel — the single branch-forked ladder
+# ---------------------------------------------------------------------------
+
+def rankWord(level: Any, branch: str = "standard") -> str:
+    """Return the bare rank word for a (level, branch) pair.
+
+    1-3 stars (and 0) are the SHARED ladder — branch-agnostic. 4 stars+ forks by
+    branch. Never emits the banned words 'Transcendent' / 'Hardened'.
+
+      level:  "5star" | 5 | "5"
+      branch: 'standard' | 'suite' | 'unique' (default 'standard')
+    """
+    n = levelNum(level)
+    if n <= 3:
+        return SHARED_WORD.get(n, "Basic")
+    # 4 stars+ fork. 'suite' is the neutral default for 4 stars+ (a resolved
+    # 4 stars+ skill is always 'suite' or 'unique' — 'standard' never reaches
+    # this ladder in practice, but if it does it reads as the suite word rather
+    # than crashing).
+    if branch == "unique":
+        return UNIQUE_WORD.get(n, UNIQUE_WORD[6])
+    return SUITE_WORD.get(n, SUITE_WORD[6])
+
+
+def rankLabel(level: Any, branch: str = "standard") -> str:
+    """Return '<rankWord> . N stars' (e.g. 'Unique Ultimate . 5 stars')."""
+    n = levelNum(level)
+    return f"{rankWord(level, branch)} · {n}★"
+
+
+# ---------------------------------------------------------------------------
+# medallion — resolved art token
+# ---------------------------------------------------------------------------
+
+def medallion(branch: str, rank: Any = None) -> str:
+    """Return the structural-class medallion glyph for a resolved branch.
+
+    Keyed on the RESOLVED branch (rank is accepted for forward-compat / future
+    rank-scaled art but is not currently consulted — branch already encodes the
+    suite/unique/standard distinction). Sourced from resolveSemantics 3.1/6:
+
+        'unique'   -> circled-bullet
+        'suite'    -> black-diamond
+        'standard' -> white-diamond  (neutral crown glyph)
+
+    See the MEDALLION_* module constants for the decision rationale (the root
+    glyph in resolveSemantics is a hemisphere-by-type artifact not reproduced by
+    the type-independent authority).
+    """
+    if branch == "unique":
+        return MEDALLION_UNIQUE
+    if branch == "suite":
+        return MEDALLION_SUITE
+    return MEDALLION_STANDARD

--- a/src/gaia_cli/taxonomy.py
+++ b/src/gaia_cli/taxonomy.py
@@ -11,20 +11,35 @@ from the four live resolvers this module supersedes:
 Nothing consumes this module yet (PR1 is a pure add). Downstream PRs migrate
 each consumer onto these functions; PR3b deletes the JS/Py resolvers above.
 
-Canonical semantics — FOUNDER RULING (do NOT reintroduce JS #1's `type==='basic'`
-guard). Branch is derived from rank + suiteComponents-presence ONLY; `type` is
-never consulted at display time:
+Canonical semantics — FOUNDER RULING v2, the SYNTHESIS rule (do NOT consult
+`type`). Suite-PRESENCE decides branch FIRST (no rank gate); rank only splits
+the no-suite case:
 
-    rank < 4                                  -> 'standard'
-    rank >= 4 AND suiteComponents present     -> 'suite'
-    rank >= 4 AND no suiteComponents          -> 'unique'
+    suiteComponents present                   -> 'suite'   (ANY rank 1..6 —
+                                                 "anything can be a suite")
+    no suiteComponents, rank 1..3             -> 'standard'
+    no suiteComponents, rank 4..6             -> 'unique'
 
-This is Py #3's type-INDEPENDENT logic. It intentionally diverges from JS #1
-(which consults `type`) on `type != 'basic'` nodes at rank >= 4 with no
-suiteComponents. That divergence is deliberate and is pinned by the contract
+This is the synthesis of both legacy resolvers — NEITHER verbatim:
+  * suite-presence-first, no rank gate  = JS #1's suite logic (skill-semantics.js L61)
+  * type-independent unique at 4 stars+  = Python #3's unique logic (trustMagnitude)
+Canonical therefore agrees with JS #1 on the suite class (rank<4 + suite) where
+Python #3 does not, AND agrees with Python #3 on the unique class (fusion rank>=4
+no-suite) where JS #1 does not. Both divergences are pinned by the contract
 oracle (tests/test_taxonomy_contract.py).
 
-Rank ladders (canonical — fork at 4 stars+):
+BRANCH vs DECORATION SPLIT (load-bearing): branch === 'suite' holds from 1 star up
+(for grouping / membership / sorting), BUT the suite rank-WORD (Extra/Ultimate/
+Apex) and the suite GLYPH only render at 4..6 stars — those ladder words simply do
+not exist below 4. So:
+  * rankWord(level, 'suite') for level 1..3  -> the SHARED word (Awakened/Named/
+    Evolved), NOT Extra/etc.; only 4..6 return the suite words.
+  * medallion('suite', rank) -> plain glyph (white diamond) for rank<4, suite
+    glyph (black diamond) for rank 4..6.
+Unique only exists at 4..6 by construction, but the same guard applies (shared
+word / plain glyph below 4) defensively.
+
+Rank ladders (canonical — decoration forks at 4 stars+):
     SHARED  {0 Basic, 1 Awakened, 2 Named, 3 Evolved}
     SUITE   {4 Extra, 5 Ultimate, 6 Apex}
     UNIQUE  {4 Unique, 5 Unique Ultimate, 6 Unique Impossible}
@@ -200,11 +215,13 @@ def normalize(entry: Optional[dict], metaEpoch: str = EPOCH_YGG_II) -> dict:
 def resolveDisplayBranch(normalized: dict) -> str:
     """Return 'standard' | 'suite' | 'unique' from a normalize() shape.
 
-    CANONICAL SEMANTICS — FOUNDER RULING (see module docstring). Type-independent:
+    CANONICAL SEMANTICS — FOUNDER RULING v2, the SYNTHESIS rule (see module
+    docstring). Suite-PRESENCE decides branch FIRST; rank only splits the
+    no-suite case:
 
-        rank < 4                              -> 'standard'
-        rank >= 4 AND suiteComponents present -> 'suite'
-        rank >= 4 AND no suiteComponents      -> 'unique'
+        suiteComponents present        -> 'suite'    (ANY rank 1..6 — no gate)
+        no suiteComponents, rank 1..3  -> 'standard'
+        no suiteComponents, rank 4..6  -> 'unique'
 
     Absent-field fallback: a normalize() shape that already carried a
     pre-resolved `branch` (from an emitted field) is honoured verbatim; only a
@@ -215,11 +232,13 @@ def resolveDisplayBranch(normalized: dict) -> str:
     pre = normalized.get("branch")
     if pre in ("standard", "suite", "unique"):
         return pre
-    if not normalized.get("branchEligible") or normalized.get("rank", 0) < 4:
-        return "standard"
+    # Suite-presence FIRST — no rank gate on branch membership.
     if normalized.get("suiteComponentsPresent"):
         return "suite"
-    return "unique"
+    # No suite: rank splits standard (1..3) from unique (4..6).
+    if normalized.get("rank", 0) >= 4:
+        return "unique"
+    return "standard"
 
 
 def branchFor(entry: dict, metaEpoch: str = EPOCH_YGG_II) -> str:
@@ -239,19 +258,24 @@ def branchFor(entry: dict, metaEpoch: str = EPOCH_YGG_II) -> str:
 def rankWord(level: Any, branch: str = "standard") -> str:
     """Return the bare rank word for a (level, branch) pair.
 
-    1-3 stars (and 0) are the SHARED ladder — branch-agnostic. 4 stars+ forks by
-    branch. Never emits the banned words 'Transcendent' / 'Hardened'.
+    BRANCH vs DECORATION SPLIT (founder ruling v2): a node's `branch` can be
+    'suite' or 'unique' from 1 star up, but the suite/unique rank WORDS only exist
+    at 4..6 stars. So 0..3 stars ALWAYS returns the SHARED ladder word regardless of
+    branch (a 2 stars suite node reads 'Named', not 'Extra'). Only 4..6 fork:
+        4..6 + 'unique' -> Unique / Unique Ultimate / Unique Impossible
+        4..6 + else     -> Extra  / Ultimate        / Apex  (suite ladder)
+    Never emits the banned words 'Transcendent' / 'Hardened'.
 
       level:  "5star" | 5 | "5"
       branch: 'standard' | 'suite' | 'unique' (default 'standard')
     """
     n = levelNum(level)
     if n <= 3:
+        # SHARED ladder for 0..3 stars — branch-agnostic (decoration split).
         return SHARED_WORD.get(n, "Basic")
     # 4 stars+ fork. 'suite' is the neutral default for 4 stars+ (a resolved
-    # 4 stars+ skill is always 'suite' or 'unique' — 'standard' never reaches
-    # this ladder in practice, but if it does it reads as the suite word rather
-    # than crashing).
+    # 4 stars+ non-suite node is 'unique'; a non-branch 'standard' node above
+    # 3 stars reads as the suite word rather than crashing).
     if branch == "unique":
         return UNIQUE_WORD.get(n, UNIQUE_WORD[6])
     return SUITE_WORD.get(n, SUITE_WORD[6])
@@ -268,22 +292,24 @@ def rankLabel(level: Any, branch: str = "standard") -> str:
 # ---------------------------------------------------------------------------
 
 def medallion(branch: str, rank: Any = None) -> str:
-    """Return the structural-class medallion glyph for a resolved branch.
+    """Return the structural-class medallion glyph for a (branch, rank) pair.
 
-    Keyed on the RESOLVED branch (rank is accepted for forward-compat / future
-    rank-scaled art but is not currently consulted — branch already encodes the
-    suite/unique/standard distinction). Sourced from resolveSemantics 3.1/6:
+    BRANCH vs DECORATION SPLIT (founder ruling v2): the custom suite/unique glyph
+    only renders at 4..6 stars. Below 4 stars a suite/unique branch node uses the
+    plain shared glyph (the suite/unique DECORATION does not exist yet), even
+    though its branch is already 'suite'/'unique' for grouping/membership.
 
-        'unique'   -> circled-bullet
-        'suite'    -> black-diamond
-        'standard' -> white-diamond  (neutral crown glyph)
+        4..6 stars + 'unique'   -> circled-bullet
+        4..6 stars + 'suite'    -> black-diamond
+        otherwise (incl. rank<4, standard, unknown) -> white-diamond (plain)
 
-    See the MEDALLION_* module constants for the decision rationale (the root
-    glyph in resolveSemantics is a hemisphere-by-type artifact not reproduced by
-    the type-independent authority).
+    Sourced from resolveSemantics 3.1/6 (the root glyph there is a
+    hemisphere-by-type artifact not reproduced by the type-independent authority).
     """
-    if branch == "unique":
-        return MEDALLION_UNIQUE
-    if branch == "suite":
-        return MEDALLION_SUITE
+    n = levelNum(rank) if rank is not None else 6  # None => assume decorated rank
+    if n >= 4:
+        if branch == "unique":
+            return MEDALLION_UNIQUE
+        if branch == "suite":
+            return MEDALLION_SUITE
     return MEDALLION_STANDARD

--- a/tests/harness/js_branch_dump.js
+++ b/tests/harness/js_branch_dump.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/*
+ * SCAFFOLD — Phase-1 golden harness for the taxonomy parity oracle.
+ * DELETE in PR3b alongside skill-semantics.js::computeBranch. Not a permanent
+ * fixture — it exists only so tests/test_taxonomy_contract.py can compare the
+ * Python authority (src/gaia_cli/taxonomy.py) against the live JS resolver
+ * (docs/js/skill-semantics.js) while both still exist.
+ *
+ * Protocol: reads a JSON array from stdin of the form
+ *   [ { "id": "<id>", "node": { ...skill object... }, "effRank": 5 }, ... ]
+ * and writes to stdout a JSON object { "<id>": "standard"|"suite"|"unique", ... }
+ * mapping each id to JS computeBranch(node, effRank).
+ *
+ * Run: node tests/harness/js_branch_dump.js < input.json
+ */
+'use strict';
+
+const path = require('path');
+
+// skill-semantics.js tail exposes module.exports = { computeBranch, ... }.
+const semantics = require(
+  path.join(__dirname, '..', '..', 'docs', 'js', 'skill-semantics.js')
+);
+
+let raw = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { raw += chunk; });
+process.stdin.on('end', () => {
+  let items;
+  try {
+    items = JSON.parse(raw);
+  } catch (e) {
+    process.stderr.write('js_branch_dump: bad JSON on stdin: ' + e.message + '\n');
+    process.exit(2);
+    return;
+  }
+  const out = {};
+  for (const item of items) {
+    const id = item && item.id;
+    const node = (item && item.node) || {};
+    const effRank = item ? item.effRank : undefined;
+    out[id] = semantics.computeBranch(node, effRank);
+  }
+  process.stdout.write(JSON.stringify(out));
+});

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -44,14 +44,15 @@ def test_levelNum(raw, expected):
 # resolveDisplayBranch — canonical (type-independent) semantics
 # ---------------------------------------------------------------------------
 
-def test_branch_standard_below_4():
+def test_branch_standard_below_4_no_suite():
     for lvl in range(0, 4):
         n = taxonomy.normalize({"type": "basic", "level": f"{lvl}★"})
         assert taxonomy.resolveDisplayBranch(n) == "standard", lvl
 
 
-def test_branch_suite_when_4plus_with_suitecomponents():
-    for lvl in (4, 5, 6):
+def test_branch_suite_when_suitecomponents_any_rank():
+    # SYNTHESIS RULE: suite-presence decides branch FIRST — at ANY rank 1..6.
+    for lvl in range(1, 7):
         n = taxonomy.normalize({"type": "fusion", "level": f"{lvl}★",
                                 "suiteComponents": ["a", "b"]})
         assert taxonomy.resolveDisplayBranch(n) == "suite", lvl
@@ -64,17 +65,24 @@ def test_branch_unique_when_4plus_no_suitecomponents():
 
 
 def test_branch_type_independent_basic_4star_no_suite_is_unique():
-    # FOUNDER RULING: a basic 4★ with no suiteComponents is UNIQUE (JS #1 would
-    # also say unique here — the divergence is on type != 'basic', see contract).
+    # A basic 4★ with no suiteComponents is UNIQUE (type is never consulted).
     n = taxonomy.normalize({"type": "basic", "level": "4★"})
     assert taxonomy.resolveDisplayBranch(n) == "unique"
 
 
 def test_branch_basic_carrying_suitecomponents_is_suite():
-    # Orthogonality: a basic node carrying suiteComponents at 4★+ is Suite.
+    # Orthogonality: a basic node carrying suiteComponents is Suite at any rank.
     n = taxonomy.normalize({"type": "basic", "level": "5★",
                             "suiteComponents": ["x"]})
     assert taxonomy.resolveDisplayBranch(n) == "suite"
+
+
+def test_branch_low_rank_suite_is_still_suite():
+    # SYNTHESIS: a 3★ node WITH suiteComponents is 'suite' (NOT 'standard').
+    for lvl in (1, 2, 3):
+        n = taxonomy.normalize({"type": "fusion", "level": f"{lvl}★",
+                                "suiteComponents": ["a"]})
+        assert taxonomy.resolveDisplayBranch(n) == "suite", lvl
 
 
 # ---------------------------------------------------------------------------
@@ -102,11 +110,12 @@ def test_ygg1_unique_maps_to_unique():
     assert taxonomy.resolveDisplayBranch(n) == "unique"
 
 
-def test_ygg1_ultimate_below_4_still_standard():
-    # Even a legacy suite carrier below 4★ reads as the shared standard ladder.
+def test_ygg1_ultimate_below_4_is_suite():
+    # SYNTHESIS: a legacy suite carrier folds to suiteComponentsPresent, and
+    # suite-presence decides branch at any rank -> 'suite' even below 4★.
     n = taxonomy.normalize({"type": "ultimate", "level": "3★"},
                            taxonomy.EPOCH_YGG_I)
-    assert taxonomy.resolveDisplayBranch(n) == "standard"
+    assert taxonomy.resolveDisplayBranch(n) == "suite"
 
 
 def test_ygg2_type_never_consulted():
@@ -224,17 +233,75 @@ def test_normalize_none_entry():
 # medallion
 # ---------------------------------------------------------------------------
 
-def test_medallion_tokens():
-    assert taxonomy.medallion("unique") == taxonomy.MEDALLION_UNIQUE
-    assert taxonomy.medallion("suite") == taxonomy.MEDALLION_SUITE
-    assert taxonomy.medallion("standard") == taxonomy.MEDALLION_STANDARD
+def test_medallion_tokens_decorated_ranks():
+    # 4..6★: the suite/unique glyph renders.
+    assert taxonomy.medallion("unique", 4) == taxonomy.MEDALLION_UNIQUE
+    assert taxonomy.medallion("suite", 6) == taxonomy.MEDALLION_SUITE
+    assert taxonomy.medallion("standard", 5) == taxonomy.MEDALLION_STANDARD
     # unknown branch -> neutral standard glyph
-    assert taxonomy.medallion("wat") == taxonomy.MEDALLION_STANDARD
+    assert taxonomy.medallion("wat", 5) == taxonomy.MEDALLION_STANDARD
 
 
-def test_medallion_distinct():
-    tokens = {taxonomy.medallion(b) for b in ("unique", "suite", "standard")}
+def test_medallion_distinct_at_high_rank():
+    tokens = {taxonomy.medallion(b, 5) for b in ("unique", "suite", "standard")}
     assert len(tokens) == 3
+
+
+def test_medallion_none_rank_assumes_decorated():
+    # rank=None (unknown) => assume decorated so branch glyph still resolves.
+    assert taxonomy.medallion("suite", None) == taxonomy.MEDALLION_SUITE
+    assert taxonomy.medallion("unique", None) == taxonomy.MEDALLION_UNIQUE
+
+
+# ---------------------------------------------------------------------------
+# BRANCH vs DECORATION split (founder ruling v2)
+# ---------------------------------------------------------------------------
+
+def test_suite_below_4_uses_shared_word_not_suite_word():
+    # A suite-branch node at 1/2/3★ reads the SHARED word, NOT Extra/etc.
+    assert taxonomy.rankWord("1★", "suite") == "Awakened"
+    assert taxonomy.rankWord("2★", "suite") == "Named"
+    assert taxonomy.rankWord("3★", "suite") == "Evolved"
+
+
+def test_suite_4to6_uses_suite_words():
+    assert taxonomy.rankWord("4★", "suite") == "Extra"
+    assert taxonomy.rankWord("5★", "suite") == "Ultimate"
+    assert taxonomy.rankWord("6★", "suite") == "Apex"
+
+
+def test_suite_below_4_uses_plain_glyph_not_suite_glyph():
+    # A suite-branch node below 4★ uses the plain glyph, NOT the suite glyph.
+    for lvl in (1, 2, 3):
+        assert taxonomy.medallion("suite", lvl) == taxonomy.MEDALLION_STANDARD, lvl
+
+
+def test_suite_4to6_uses_suite_glyph():
+    for lvl in (4, 5, 6):
+        assert taxonomy.medallion("suite", lvl) == taxonomy.MEDALLION_SUITE, lvl
+
+
+def test_unique_below_4_guard_shared_word_and_plain_glyph():
+    # Unique only exists 4..6 by construction, but guard the below-4 case.
+    assert taxonomy.rankWord("2★", "unique") == "Named"
+    assert taxonomy.medallion("unique", 2) == taxonomy.MEDALLION_STANDARD
+
+
+def test_unique_4to6_words_and_glyph():
+    assert taxonomy.rankWord("4★", "unique") == "Unique"
+    assert taxonomy.rankWord("5★", "unique") == "Unique Ultimate"
+    assert taxonomy.rankWord("6★", "unique") == "Unique Impossible"
+    for lvl in (4, 5, 6):
+        assert taxonomy.medallion("unique", lvl) == taxonomy.MEDALLION_UNIQUE
+
+
+def test_decoration_split_never_banned():
+    # Across every (branch, rank) the decoration split must never emit banned words.
+    for branch in ("standard", "suite", "unique"):
+        for lvl in range(0, 7):
+            word = taxonomy.rankWord(f"{lvl}★", branch)
+            for bad in BANNED:
+                assert bad not in word, (lvl, branch, word)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,252 @@
+"""Unit tests for gaia_cli.taxonomy — the Yggdrasil II taxonomy authority (PR1).
+
+Covers:
+  - Ygg I input shapes   (type: 'ultimate' / 'unique' / 'extra')
+  - Ygg II input shapes  (type: 'fusion' / 'basic' + suiteComponents)
+  - the full rank ladder 0..6 across all three branches
+  - the absent-field fallback (raw entry vs pre-resolved entry)
+  - assertion that NO banned words ('Transcendent', 'Hardened') are ever emitted
+
+Run: PYTHONIOENCODING=utf-8 PYTHONPATH=./src python -m pytest tests/test_taxonomy.py -q
+"""
+
+import pytest
+
+from gaia_cli import taxonomy
+
+
+BANNED = ("Transcendent", "Hardened")
+
+
+# ---------------------------------------------------------------------------
+# levelNum
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw,expected", [
+    (None, 0),
+    (0, 0),
+    (3, 3),
+    (6, 6),
+    (99, 6),      # clamp high
+    (-1, 0),      # clamp low
+    ("4★", 4),
+    ("5", 5),
+    ("2 star", 2),
+    ("", 0),
+    ("garbage", 0),
+    (True, 0),    # bool guard
+])
+def test_levelNum(raw, expected):
+    assert taxonomy.levelNum(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# resolveDisplayBranch — canonical (type-independent) semantics
+# ---------------------------------------------------------------------------
+
+def test_branch_standard_below_4():
+    for lvl in range(0, 4):
+        n = taxonomy.normalize({"type": "basic", "level": f"{lvl}★"})
+        assert taxonomy.resolveDisplayBranch(n) == "standard", lvl
+
+
+def test_branch_suite_when_4plus_with_suitecomponents():
+    for lvl in (4, 5, 6):
+        n = taxonomy.normalize({"type": "fusion", "level": f"{lvl}★",
+                                "suiteComponents": ["a", "b"]})
+        assert taxonomy.resolveDisplayBranch(n) == "suite", lvl
+
+
+def test_branch_unique_when_4plus_no_suitecomponents():
+    for lvl in (4, 5, 6):
+        n = taxonomy.normalize({"type": "fusion", "level": f"{lvl}★"})
+        assert taxonomy.resolveDisplayBranch(n) == "unique", lvl
+
+
+def test_branch_type_independent_basic_4star_no_suite_is_unique():
+    # FOUNDER RULING: a basic 4★ with no suiteComponents is UNIQUE (JS #1 would
+    # also say unique here — the divergence is on type != 'basic', see contract).
+    n = taxonomy.normalize({"type": "basic", "level": "4★"})
+    assert taxonomy.resolveDisplayBranch(n) == "unique"
+
+
+def test_branch_basic_carrying_suitecomponents_is_suite():
+    # Orthogonality: a basic node carrying suiteComponents at 4★+ is Suite.
+    n = taxonomy.normalize({"type": "basic", "level": "5★",
+                            "suiteComponents": ["x"]})
+    assert taxonomy.resolveDisplayBranch(n) == "suite"
+
+
+# ---------------------------------------------------------------------------
+# Ygg I input shapes — normalize() fork
+# ---------------------------------------------------------------------------
+
+def test_ygg1_ultimate_maps_to_suite():
+    # Ygg I: type='ultimate' was a suite carrier. Fold to suite at 4★+.
+    n = taxonomy.normalize({"type": "ultimate", "level": "5★"},
+                           taxonomy.EPOCH_YGG_I)
+    assert n["suiteComponentsPresent"] is True
+    assert taxonomy.resolveDisplayBranch(n) == "suite"
+
+
+def test_ygg1_extra_maps_to_suite():
+    n = taxonomy.normalize({"type": "extra", "level": "4★"},
+                           taxonomy.EPOCH_YGG_I)
+    assert taxonomy.resolveDisplayBranch(n) == "suite"
+
+
+def test_ygg1_unique_maps_to_unique():
+    # Ygg I: type='unique' at 4★+ with no suiteComponents -> unique.
+    n = taxonomy.normalize({"type": "unique", "level": "4★"},
+                           taxonomy.EPOCH_YGG_I)
+    assert taxonomy.resolveDisplayBranch(n) == "unique"
+
+
+def test_ygg1_ultimate_below_4_still_standard():
+    # Even a legacy suite carrier below 4★ reads as the shared standard ladder.
+    n = taxonomy.normalize({"type": "ultimate", "level": "3★"},
+                           taxonomy.EPOCH_YGG_I)
+    assert taxonomy.resolveDisplayBranch(n) == "standard"
+
+
+def test_ygg2_type_never_consulted():
+    # Under Ygg II, type is display-irrelevant: fusion vs basic at same
+    # rank/suiteComponents produce the same branch.
+    a = taxonomy.normalize({"type": "fusion", "level": "4★"})
+    b = taxonomy.normalize({"type": "basic", "level": "4★"})
+    assert taxonomy.resolveDisplayBranch(a) == taxonomy.resolveDisplayBranch(b) == "unique"
+
+
+# ---------------------------------------------------------------------------
+# rank ladder 0..6 across all three branches
+# ---------------------------------------------------------------------------
+
+SHARED_EXPECT = {0: "Basic", 1: "Awakened", 2: "Named", 3: "Evolved"}
+SUITE_EXPECT = {4: "Extra", 5: "Ultimate", 6: "Apex"}
+UNIQUE_EXPECT = {4: "Unique", 5: "Unique Ultimate", 6: "Unique Impossible"}
+
+
+def test_rankword_shared_ladder_all_branches():
+    # 0-3★ is branch-agnostic.
+    for branch in ("standard", "suite", "unique"):
+        for lvl, word in SHARED_EXPECT.items():
+            assert taxonomy.rankWord(f"{lvl}★", branch) == word, (lvl, branch)
+
+
+def test_rankword_suite_ladder():
+    for lvl, word in SUITE_EXPECT.items():
+        assert taxonomy.rankWord(f"{lvl}★", "suite") == word
+
+
+def test_rankword_unique_ladder():
+    for lvl, word in UNIQUE_EXPECT.items():
+        assert taxonomy.rankWord(f"{lvl}★", "unique") == word
+
+
+def test_ranklabel_format():
+    assert taxonomy.rankLabel("5★", "unique") == "Unique Ultimate · 5★"
+    assert taxonomy.rankLabel(4, "suite") == "Extra · 4★"
+    assert taxonomy.rankLabel("2★", "standard") == "Named · 2★"
+
+
+def test_ranklabel_full_ladder_never_banned():
+    for branch in ("standard", "suite", "unique"):
+        for lvl in range(0, 7):
+            label = taxonomy.rankLabel(f"{lvl}★", branch)
+            for bad in BANNED:
+                assert bad not in label, (lvl, branch, label)
+
+
+def test_rankword_full_ladder_never_banned():
+    for branch in ("standard", "suite", "unique"):
+        for lvl in range(0, 7):
+            word = taxonomy.rankWord(f"{lvl}★", branch)
+            for bad in BANNED:
+                assert bad not in word, (lvl, branch, word)
+
+
+# ---------------------------------------------------------------------------
+# Absent-field fallback — raw vs pre-resolved
+# ---------------------------------------------------------------------------
+
+def test_fallback_raw_entry_derives_branch():
+    # No emitted branch/rank fields; derive from type-independent logic.
+    raw = {"type": "fusion", "level": "5★", "suiteComponents": ["a"]}
+    n = taxonomy.normalize(raw)
+    assert n["branch"] is None            # nothing pre-resolved
+    assert taxonomy.resolveDisplayBranch(n) == "suite"
+
+
+def test_fallback_preresolved_branch_honored_verbatim():
+    # A stale snapshot emitted branch='suite' even though raw logic would say
+    # 'unique' (no suiteComponents). The pre-resolved field wins.
+    entry = {"type": "fusion", "level": "5★", "branch": "suite"}
+    n = taxonomy.normalize(entry)
+    assert n["branch"] == "suite"
+    assert taxonomy.resolveDisplayBranch(n) == "suite"
+
+
+def test_fallback_preresolved_rank_field():
+    # `rank` field takes precedence over `level`/`namedMaxLevel`.
+    n = taxonomy.normalize({"rank": 6, "suiteComponents": ["a"]})
+    assert n["rank"] == 6
+    assert taxonomy.resolveDisplayBranch(n) == "suite"
+
+
+def test_fallback_namedmaxlevel_when_no_level():
+    # gaia.json generic nodes carry only namedMaxLevel.
+    n = taxonomy.normalize({"type": "fusion", "namedMaxLevel": "5★"})
+    assert n["rank"] == 5
+    assert taxonomy.resolveDisplayBranch(n) == "unique"  # no suiteComponents
+
+
+def test_fallback_unrecognised_branch_field_is_derived():
+    entry = {"type": "fusion", "level": "4★", "branch": "bogus"}
+    n = taxonomy.normalize(entry)
+    assert n["branch"] is None
+    assert taxonomy.resolveDisplayBranch(n) == "unique"
+
+
+def test_branchFor_convenience_raw():
+    assert taxonomy.branchFor({"type": "basic", "level": "2★"}) == "standard"
+    assert taxonomy.branchFor({"type": "fusion", "level": "4★",
+                               "suiteComponents": ["a"]}) == "suite"
+    assert taxonomy.branchFor({"type": "fusion", "level": "4★"}) == "unique"
+
+
+def test_normalize_none_entry():
+    n = taxonomy.normalize(None)
+    assert n["rank"] == 0
+    assert taxonomy.resolveDisplayBranch(n) == "standard"
+
+
+# ---------------------------------------------------------------------------
+# medallion
+# ---------------------------------------------------------------------------
+
+def test_medallion_tokens():
+    assert taxonomy.medallion("unique") == taxonomy.MEDALLION_UNIQUE
+    assert taxonomy.medallion("suite") == taxonomy.MEDALLION_SUITE
+    assert taxonomy.medallion("standard") == taxonomy.MEDALLION_STANDARD
+    # unknown branch -> neutral standard glyph
+    assert taxonomy.medallion("wat") == taxonomy.MEDALLION_STANDARD
+
+
+def test_medallion_distinct():
+    tokens = {taxonomy.medallion(b) for b in ("unique", "suite", "standard")}
+    assert len(tokens) == 3
+
+
+# ---------------------------------------------------------------------------
+# suiteComponentsPresent edge cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("entry,expected", [
+    ({"suiteComponents": ["a"]}, True),
+    ({"suiteComponents": []}, False),
+    ({"suiteComponents": None}, False),
+    ({}, False),
+    ({"suiteComponents": ("a", "b")}, True),
+])
+def test_suite_components_present(entry, expected):
+    assert taxonomy.suiteComponentsPresent(entry) is expected

--- a/tests/test_taxonomy_contract.py
+++ b/tests/test_taxonomy_contract.py
@@ -2,47 +2,46 @@
 
 For every named-skill variant in docs/graph/named/index.json (~228 under
 `.buckets`) AND every generic node in docs/graph/gaia.json (243 under
-`.skills`), assert cross-resolver parity between:
+`.skills`), assert the canonical authority against a direct ground-truth
+computation of the SYNTHESIS rule, and characterize its divergence from the two
+legacy resolvers:
 
     taxonomy.resolveDisplayBranch(...)      # the new authority (Python)
-    trustMagnitude.computeBranch(...)       # live Python resolver #3
-    JS computeBranch(...)                   # live JS resolver #1 (via harness)
+    synthesisBranch(...)                    # ground truth (this test, inline)
+    trustMagnitude.computeBranch(...)       # legacy Python resolver #3
+    JS computeBranch(...)                   # legacy JS resolver #1 (via harness)
 
 resolveSemantics (JS resolver #2) reuses the SAME read order as JS #1
-computeBranch (its isUnique/isSuite booleans map to the same branch string), so
-the JS-harness leg covers #2 as well.
-
-COMPLETENESS MECHANISM: an unported resolver (a branch we forgot to fold into
-taxonomy.py) surfaces as a parity failure whose signature does NOT match either
-of the two RATIFIED, TYPE-INDEPENDENT-vs-JS divergence classes below.
+computeBranch, so the JS-harness leg covers #2 as well.
 
 --------------------------------------------------------------------------------
-DIVERGENCE MAP (canonical/Python #3 vs JS #1) — measured against the live
-2026-07-18 corpus. Both classes have the SAME root cause: JS #1 consults `type`
-and applies its suiteComponents branch WITHOUT a rank gate (skill-semantics.js
-L58/L61), whereas the canonical resolver + Python #3 are type-independent and
-rank-gate first (Founder ruling). canonical == Python #3 on ALL entries.
+SYNTHESIS RULE (founder ruling v2). Suite-presence decides branch FIRST (no rank
+gate); rank only splits the no-suite case:
 
-  CLASS A — canonical/Py3 = 'unique' , JS = 'standard'   (9 nodes)
-    `fusion` node at rank >= 4 with NO suiteComponents. JS #1's
-    `type === 'basic'` unique-guard fails on `fusion`, so it falls through to
-    'standard'. The two handover-named instances are the named-variant form:
-        firecrawl/firecrawl-build-scrape
-        obra/subagent-driven-development
-    The other 7 are the generic-node / 5★ equivalents of the SAME semantics
-    (web-scrape, superpowers, skill-mastery, git-ship-done-pipeline,
-     multi-topology-orchestration, founder-mode-orchestration,
-     subagent-driven-development).
+    suiteComponents present        -> 'suite'    (ANY rank 1..6)
+    no suiteComponents, rank 1..3  -> 'standard'
+    no suiteComponents, rank 4..6  -> 'unique'
 
-  CLASS B — canonical/Py3 = 'standard' , JS = 'suite'    (12 nodes)
-    node at rank < 4 WITH suiteComponents (all 3★ suite parents). Canonical +
-    Python #3 rank-gate first -> 'standard'; JS #1 has no rank gate on its
-    suiteComponents branch -> 'suite'. The handover did NOT enumerate this axis;
-    it is documented here as a second RATIFIED, canonical==Py3 divergence.
+Canonical == synthesis on ALL entries (test_synthesis_ground_truth) — that is
+the primary, resolver-independent correctness check.
 
-Any JS divergence that does NOT fit one of these two signatures — OR any
-canonical-vs-Python-#3 mismatch — is a REAL failure (an unported / drifted
-resolver) and must RED-build. See test_js_divergences_all_ratified.
+Canonical is NEITHER legacy resolver verbatim; it AGREES with each on a
+different class and DISAGREES on the other:
+
+  CLASS A — canonical/synthesis = 'unique' , JS #1 = 'standard' , Py #3 = 'unique'
+    `fusion` node at rank >= 4 with NO suiteComponents. JS #1's `type==='basic'`
+    unique-guard fails on fusion -> 'standard'. Canonical AGREES with Py #3 here.
+    (9 nodes; the two handover-named instances are the named-variant form:
+     firecrawl/firecrawl-build-scrape, obra/subagent-driven-development.)
+
+  CLASS B — canonical/synthesis = 'suite' , Py #3 = 'standard' , JS #1 = 'suite'
+    node at rank < 4 WITH suiteComponents. Py #3 rank-gates first -> 'standard'.
+    Canonical AGREES with JS #1 here (suite-presence-first, no rank gate).
+    (12 nodes; all 3-star suite parents.)
+
+Any divergence (vs EITHER legacy resolver) that does NOT fit Class A or Class B
+is a REAL failure (an unported / drifted resolver). See
+test_python_divergences_all_ratified / test_js_divergences_all_ratified.
 --------------------------------------------------------------------------------
 
 Run: PYTHONIOENCODING=utf-8 PYTHONPATH=./src python -m pytest tests/test_taxonomy_contract.py -q
@@ -64,9 +63,7 @@ GAIA_JSON = os.path.join(REPO_ROOT, "docs", "graph", "gaia.json")
 NAMED_INDEX = os.path.join(REPO_ROOT, "docs", "graph", "named", "index.json")
 HARNESS = os.path.join(os.path.dirname(__file__), "harness", "js_branch_dump.js")
 
-# The two handover-named nodes, kept as an explicit anchor: canonical/Py3 say
-# 'unique', JS #1 says 'standard' (Class A). If either stops diverging in JS,
-# the pin is stale and test_pinned_nodes_diverge_in_js flags it.
+# The two handover-named Class-A nodes, kept as an explicit anchor.
 PINNED_JS_DIVERGENCE = {
     "firecrawl/firecrawl-build-scrape",
     "obra/subagent-driven-development",
@@ -88,8 +85,8 @@ def collectEntries():
     effRankStr is the effective star level fed to EVERY resolver so the
     comparison is apples-to-apples:
       - named variants: their own `level`
-      - generic gaia.json nodes: `namedMaxLevel` (the highest named form;
-        generics have no `level` and carry no suiteComponents)
+      - generic gaia.json nodes: `namedMaxLevel` (highest named form; generics
+        have no `level` and carry no suiteComponents)
     """
     entries = []
 
@@ -109,6 +106,22 @@ ENTRIES = collectEntries()
 
 
 # ---------------------------------------------------------------------------
+# Ground-truth synthesis rule (inline — independent of the module under test)
+# ---------------------------------------------------------------------------
+
+def synthesisBranch(node, effRank):
+    """Direct implementation of the SYNTHESIS rule — the resolver-independent
+    ground truth the authority must match on every entry."""
+    rank = taxonomy.levelNum(effRank)
+    hasSuite = taxonomy.suiteComponentsPresent(node)
+    if hasSuite:
+        return "suite"
+    if rank >= 4:
+        return "unique"
+    return "standard"
+
+
+# ---------------------------------------------------------------------------
 # Resolver adapters — feed the SAME joined effRank to each resolver
 # ---------------------------------------------------------------------------
 
@@ -119,19 +132,26 @@ def canonicalBranch(node, effRank):
 
 
 def pythonBranch(node, effRank):
-    """trustMagnitude.computeBranch (Python resolver #3). Reads named['level'];
-    overlay the joined effRank so generics resolve on namedMaxLevel."""
+    """trustMagnitude.computeBranch (legacy Python resolver #3). Reads
+    named['level']; overlay the joined effRank so generics resolve on
+    namedMaxLevel."""
     return trustMagnitude.computeBranch({**node, "level": effRank})
 
 
-def divergenceClass(node, effRank, canon, js):
-    """Classify a canonical-vs-JS divergence. Returns 'A', 'B', or None
-    (None => unratified => real failure)."""
+def divergenceClass(node, effRank, canon, other):
+    """Classify a canonical-vs-<legacy> divergence. Returns 'A', 'B', or None
+    (None => unratified => real failure).
+
+    Class A: canonical='unique', other='standard', rank>=4, no suite.
+    Class B: canonical='suite',  other='standard', rank<4,  suite present.
+    (Both legacy resolvers diverge toward 'standard' — JS #1 on Class A via its
+    type-guard, Py #3 on Class B via its rank-gate.)
+    """
     rank = taxonomy.levelNum(effRank)
     hasSuite = taxonomy.suiteComponentsPresent(node)
-    if canon == "unique" and js == "standard" and rank >= 4 and not hasSuite:
+    if canon == "unique" and other == "standard" and rank >= 4 and not hasSuite:
         return "A"
-    if canon == "standard" and js == "suite" and rank < 4 and hasSuite:
+    if canon == "suite" and other == "standard" and rank < 4 and hasSuite:
         return "B"
     return None
 
@@ -180,59 +200,74 @@ def test_oracle_has_subjects():
     assert len(ENTRIES) >= 400, len(ENTRIES)
 
 
-def test_python_parity_all_entries():
-    """canonical == Python #3 for EVERY entry (no divergence tolerated on the
-    Python side — both are type-independent). A mismatch here means the new
-    authority drifted from the ratified Python resolver."""
+def test_synthesis_ground_truth():
+    """PRIMARY CHECK: canonical == synthesis rule on EVERY entry (resolver-
+    independent). A mismatch means the authority drifted from founder ruling v2."""
     mismatches = []
     for sid, node, effRank in ENTRIES:
         c = canonicalBranch(node, effRank)
+        s = synthesisBranch(node, effRank)
+        if c != s:
+            mismatches.append((sid, c, s))
+    assert not mismatches, f"canonical vs synthesis mismatches: {mismatches}"
+
+
+def test_python_divergences_all_ratified():
+    """canonical vs Python #3: EVERY divergence must be Class B (rank<4 + suite).
+    canonical agrees with Py #3 everywhere else (incl. Class A)."""
+    unratified = []
+    for sid, node, effRank in ENTRIES:
+        c = canonicalBranch(node, effRank)
         p = pythonBranch(node, effRank)
-        if c != p:
-            mismatches.append((sid, c, p))
-    assert not mismatches, f"canonical vs Python #3 mismatches: {mismatches}"
-
-
-def test_pinned_divergence_is_unique_canonically():
-    """The two handover-pinned nodes resolve to 'unique' under canonical + Py3."""
-    byId = {sid: (node, effRank) for sid, node, effRank in ENTRIES}
-    for sid in PINNED_JS_DIVERGENCE:
-        assert sid in byId, f"pinned node {sid} not found in corpus"
-        node, effRank = byId[sid]
-        assert canonicalBranch(node, effRank) == "unique", sid
-        assert pythonBranch(node, effRank) == "unique", sid
+        if c == p:
+            continue
+        if divergenceClass(node, effRank, c, p) != "B":
+            unratified.append((sid, c, p, taxonomy.levelNum(effRank),
+                               taxonomy.suiteComponentsPresent(node)))
+    assert not unratified, (
+        "UNRATIFIED canonical-vs-Python-#3 divergence (only Class B — rank<4 + "
+        f"suite — is ratified here): {unratified}"
+    )
 
 
 @pytest.mark.skipif(JS_BRANCHES is None, reason="node unavailable")
 def test_js_divergences_all_ratified():
-    """Every canonical-vs-JS divergence MUST fit Class A or Class B (the two
-    ratified, type-independent-vs-JS signatures). A divergence with any other
-    signature is an unported/drifted resolver and RED-builds.
+    """canonical vs JS #1: EVERY divergence must be Class A (rank>=4 + no suite).
+    canonical agrees with JS #1 everywhere else (incl. Class B). A divergence of
+    any other signature is an unported/drifted resolver and RED-builds.
 
-    This is the completeness gate: it does not hard-code an id list, it
-    hard-codes the two SIGNATURES, so new corpus nodes matching a ratified
-    signature pass while a genuinely novel drift fails.
-    """
+    Signature-based (not an id list) so new corpus nodes matching a ratified
+    signature pass while a genuinely novel drift fails."""
     unratified = []
     for sid, node, effRank in ENTRIES:
         c = canonicalBranch(node, effRank)
         j = JS_BRANCHES.get(sid)
         if j is None or c == j:
             continue
-        if divergenceClass(node, effRank, c, j) is None:
+        if divergenceClass(node, effRank, c, j) != "A":
             unratified.append((sid, c, j, taxonomy.levelNum(effRank),
                                taxonomy.suiteComponentsPresent(node)))
     assert not unratified, (
-        "UNRATIFIED JS divergence (likely an unported/drifted resolver) — "
-        "does not match Class A (unique/standard, rank>=4, no suite) or "
-        f"Class B (standard/suite, rank<4, suite): {unratified}"
+        "UNRATIFIED canonical-vs-JS-#1 divergence (only Class A — rank>=4 + no "
+        f"suite — is ratified here): {unratified}"
     )
+
+
+def test_pinned_divergence_is_unique_canonically():
+    """The two handover-pinned Class-A nodes resolve to 'unique' under canonical
+    + synthesis + Py3."""
+    byId = {sid: (node, effRank) for sid, node, effRank in ENTRIES}
+    for sid in PINNED_JS_DIVERGENCE:
+        assert sid in byId, f"pinned node {sid} not found in corpus"
+        node, effRank = byId[sid]
+        assert canonicalBranch(node, effRank) == "unique", sid
+        assert synthesisBranch(node, effRank) == "unique", sid
+        assert pythonBranch(node, effRank) == "unique", sid
 
 
 @pytest.mark.skipif(JS_BRANCHES is None, reason="node unavailable")
 def test_pinned_nodes_diverge_in_js():
-    """Assert the pinned Class-A drift actually occurs (JS says 'standard'). If
-    JS ever stops diverging the pin is stale and should be revisited."""
+    """Assert the pinned Class-A drift actually occurs (JS says 'standard')."""
     for sid in PINNED_JS_DIVERGENCE:
         j = JS_BRANCHES.get(sid)
         assert j == "standard", (
@@ -242,24 +277,25 @@ def test_pinned_nodes_diverge_in_js():
 
 
 @pytest.mark.skipif(JS_BRANCHES is None, reason="node unavailable")
-def test_class_a_class_b_both_present_in_corpus():
-    """Document the observed shape: both ratified classes exist in the live
-    corpus. If a corpus refresh empties one class this test flags it so the
-    divergence map in the module docstring gets revisited (not a correctness
-    failure, a documentation-drift tripwire)."""
-    seen = set()
+def test_divergence_counts_are_exactly_9A_and_12B():
+    """Pin the exact observed shape against the 2026-07-18 corpus:
+       Class A = 9 unique ids (canonical 'unique' vs JS 'standard')
+       Class B = 12 unique ids (canonical 'suite' vs Py3 'standard')
+    A drift in these counts flags a corpus change that must be re-reviewed
+    against the divergence map (not necessarily a correctness failure)."""
+    classA, classB = set(), set()
     for sid, node, effRank in ENTRIES:
         c = canonicalBranch(node, effRank)
         j = JS_BRANCHES.get(sid)
-        if j is None or c == j:
-            continue
-        cls = divergenceClass(node, effRank, c, j)
-        if cls:
-            seen.add(cls)
-    assert seen == {"A", "B"}, (
-        f"divergence classes present changed (expected {{A, B}}, got {seen}); "
-        "revisit the divergence map in the module docstring"
-    )
+        p = pythonBranch(node, effRank)
+        if j is not None and c != j and divergenceClass(node, effRank, c, j) == "A":
+            classA.add(sid)
+        if c != p and divergenceClass(node, effRank, c, p) == "B":
+            classB.add(sid)
+    assert len(classA) == 9, sorted(classA)
+    assert len(classB) == 12, sorted(classB)
+    # No id is simultaneously A and B (mutually exclusive signatures).
+    assert not (classA & classB), sorted(classA & classB)
 
 
 def test_no_banned_words_emitted_across_corpus():

--- a/tests/test_taxonomy_contract.py
+++ b/tests/test_taxonomy_contract.py
@@ -25,13 +25,14 @@ gate); rank only splits the no-suite case:
 Canonical == synthesis on ALL entries (test_synthesis_ground_truth) — that is
 the primary, resolver-independent correctness check.
 
-DELETE-GATE DISCIPLINE (§2.5): legacy resolvers #1 and #3 are known to diverge
-from the membership authority on ~9 nodes (JS #1, type-gated fusion guard) and
-~12 nodes (Py #3, rank-gated suite check). This drift is NOT blessed or
-ratified — it is RED-by-design. test_four_way_parity_pending_deletion is a
-strict-xfail that must stay xfail until Phase 3 DELETES the legacy resolvers and
-parity actually holds. The moment it flips to XPASS, CI hard-fails, forcing
-removal of the marker. That handshake IS the delete-gate.
+DELETE-GATE DISCIPLINE (authority doc §3): legacy resolvers #1 and #3 are known
+to diverge from the membership authority on ~9 nodes (JS #1, type-gated fusion
+guard) and ~12 nodes (Py #3, rank-gated suite check). This drift is NOT blessed
+or ratified — it is RED-by-design. The legacy-parity legs are strict-xfail
+delete-gates: they XFAIL while the legacy resolvers live and flip to hard
+failure — forcing marker removal — once Phase 3 deletes them and parity is real.
+Do NOT bless the drift green; the gate exists precisely to block deletion until
+parity is real.
 --------------------------------------------------------------------------------
 
 Run: PYTHONIOENCODING=utf-8 PYTHONPATH=./src python -m pytest tests/test_taxonomy_contract.py -q
@@ -101,7 +102,23 @@ ENTRIES = collectEntries()
 
 def synthesisBranch(node, effRank):
     """Direct implementation of the SYNTHESIS rule — the resolver-independent
-    ground truth the authority must match on every entry."""
+    ground truth the authority must match on every entry.
+
+    Per authority doc §7 origin mechanic: a starless generic node from
+    docs/graph/gaia.json may carry a STAMPED branch field surfaced from its
+    bucket's origin. Honor the stamp directly — do not recompute — because bare
+    generics carry no suiteComponents (those live on the named origin entry) and
+    recomputing would wrongly yield 'standard'/'unique' where the stamp says
+    'suite'. This mirrors what taxonomy.normalize()/resolveDisplayBranch already
+    do (pre-resolved branch passthrough). On the keystone branch gaia.json
+    carries zero stamps so this is a harmless no-op; it becomes load-bearing
+    when cascaded to dev/ygg2-consume-frontend where 79 nodes are stamped.
+    """
+    # §7: honor a stamped branch field if present and valid.
+    stamped = node.get("branch") if isinstance(node, dict) else None
+    if stamped in {"standard", "suite", "unique"}:
+        return stamped
+
     rank = taxonomy.levelNum(effRank)
     hasSuite = taxonomy.suiteComponentsPresent(node)
     if hasSuite:
@@ -184,25 +201,44 @@ def test_synthesis_ground_truth():
     assert not mismatches, f"canonical vs synthesis mismatches: {mismatches}"
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "known Ygg-I-vs-membership drift in legacy resolvers #1 (JS computeBranch, "
-    "type-gated) and #3 (trustMagnitude.computeBranch); resolved by DELETION in "
-    "Phase 3. Strict-xfail is the delete-gate handshake: the day Phase 3 deletes "
-    "the legacy resolvers and parity holds, this flips XPASS -> hard failure, "
-    "forcing the marker's removal."
-))
-def test_four_way_parity_pending_deletion():
-    """RED-by-design: authority == legacy #1 == legacy #3 on every node.
-    Fails until Phase 3 deletes the drifted legacy resolvers (delete-gate)."""
-    jsBranches = runJsHarness(ENTRIES)  # {id: branch} or None-per-node if harness unavailable
+@pytest.mark.xfail(
+    strict=True,
+    reason="DELETE-GATE (authority doc §3): legacy trustMagnitude.computeBranch "
+    "diverges from membership on Class-A/B nodes. This XFAIL is RED-by-design "
+    "and flips to a hard failure — forcing this marker's removal — the moment "
+    "Phase 3 deletes the legacy resolver and parity becomes real. Do NOT bless "
+    "the drift green.",
+)
+def test_legacy_python_parity_delete_gate():
+    """Canonical (membership) == legacy Python #3 on EVERY entry. FAILS now (by
+    design) on the known Ygg-I-vs-membership drift; passes only after Phase 3
+    deletes trustMagnitude.computeBranch."""
     mismatches = []
     for sid, node, effRank in ENTRIES:
         c = canonicalBranch(node, effRank)
         p = pythonBranch(node, effRank)
-        j = jsBranches.get(sid) if jsBranches else None
-        if c != p or (j is not None and c != j):
-            mismatches.append((sid, c, p, j))
-    assert not mismatches, f"drift (canonical, py#3, js#1): {mismatches}"
+        if c != p:
+            mismatches.append((sid, c, p))
+    assert not mismatches, f"legacy Python #3 parity not yet real: {mismatches}"
+
+
+@pytest.mark.skipif(JS_BRANCHES is None, reason="node unavailable")
+@pytest.mark.xfail(
+    strict=True,
+    reason="DELETE-GATE (authority doc §3): legacy JS #1 computeBranch diverges "
+    "from membership on Class-A nodes (type-guard). RED-by-design; flips to hard "
+    "failure when Phase 3 deletes the JS resolver. Do NOT bless the drift green.",
+)
+def test_legacy_js_parity_delete_gate():
+    """Canonical (membership) == legacy JS #1 on EVERY entry. FAILS now (by
+    design); passes only after Phase 3 deletes the JS computeBranch resolver."""
+    mismatches = []
+    for sid, node, effRank in ENTRIES:
+        c = canonicalBranch(node, effRank)
+        j = JS_BRANCHES.get(sid)
+        if j is not None and c != j:
+            mismatches.append((sid, c, j))
+    assert not mismatches, f"legacy JS #1 parity not yet real: {mismatches}"
 
 
 def test_pinned_divergence_is_unique_canonically():

--- a/tests/test_taxonomy_contract.py
+++ b/tests/test_taxonomy_contract.py
@@ -1,0 +1,273 @@
+"""Contract completeness oracle for the Yggdrasil II taxonomy authority (PR1).
+
+For every named-skill variant in docs/graph/named/index.json (~228 under
+`.buckets`) AND every generic node in docs/graph/gaia.json (243 under
+`.skills`), assert cross-resolver parity between:
+
+    taxonomy.resolveDisplayBranch(...)      # the new authority (Python)
+    trustMagnitude.computeBranch(...)       # live Python resolver #3
+    JS computeBranch(...)                   # live JS resolver #1 (via harness)
+
+resolveSemantics (JS resolver #2) reuses the SAME read order as JS #1
+computeBranch (its isUnique/isSuite booleans map to the same branch string), so
+the JS-harness leg covers #2 as well.
+
+COMPLETENESS MECHANISM: an unported resolver (a branch we forgot to fold into
+taxonomy.py) surfaces as a parity failure whose signature does NOT match either
+of the two RATIFIED, TYPE-INDEPENDENT-vs-JS divergence classes below.
+
+--------------------------------------------------------------------------------
+DIVERGENCE MAP (canonical/Python #3 vs JS #1) — measured against the live
+2026-07-18 corpus. Both classes have the SAME root cause: JS #1 consults `type`
+and applies its suiteComponents branch WITHOUT a rank gate (skill-semantics.js
+L58/L61), whereas the canonical resolver + Python #3 are type-independent and
+rank-gate first (Founder ruling). canonical == Python #3 on ALL entries.
+
+  CLASS A — canonical/Py3 = 'unique' , JS = 'standard'   (9 nodes)
+    `fusion` node at rank >= 4 with NO suiteComponents. JS #1's
+    `type === 'basic'` unique-guard fails on `fusion`, so it falls through to
+    'standard'. The two handover-named instances are the named-variant form:
+        firecrawl/firecrawl-build-scrape
+        obra/subagent-driven-development
+    The other 7 are the generic-node / 5★ equivalents of the SAME semantics
+    (web-scrape, superpowers, skill-mastery, git-ship-done-pipeline,
+     multi-topology-orchestration, founder-mode-orchestration,
+     subagent-driven-development).
+
+  CLASS B — canonical/Py3 = 'standard' , JS = 'suite'    (12 nodes)
+    node at rank < 4 WITH suiteComponents (all 3★ suite parents). Canonical +
+    Python #3 rank-gate first -> 'standard'; JS #1 has no rank gate on its
+    suiteComponents branch -> 'suite'. The handover did NOT enumerate this axis;
+    it is documented here as a second RATIFIED, canonical==Py3 divergence.
+
+Any JS divergence that does NOT fit one of these two signatures — OR any
+canonical-vs-Python-#3 mismatch — is a REAL failure (an unported / drifted
+resolver) and must RED-build. See test_js_divergences_all_ratified.
+--------------------------------------------------------------------------------
+
+Run: PYTHONIOENCODING=utf-8 PYTHONPATH=./src python -m pytest tests/test_taxonomy_contract.py -q
+"""
+
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from gaia_cli import taxonomy
+from gaia_cli import trustMagnitude
+
+
+REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+GAIA_JSON = os.path.join(REPO_ROOT, "docs", "graph", "gaia.json")
+NAMED_INDEX = os.path.join(REPO_ROOT, "docs", "graph", "named", "index.json")
+HARNESS = os.path.join(os.path.dirname(__file__), "harness", "js_branch_dump.js")
+
+# The two handover-named nodes, kept as an explicit anchor: canonical/Py3 say
+# 'unique', JS #1 says 'standard' (Class A). If either stops diverging in JS,
+# the pin is stale and test_pinned_nodes_diverge_in_js flags it.
+PINNED_JS_DIVERGENCE = {
+    "firecrawl/firecrawl-build-scrape",
+    "obra/subagent-driven-development",
+}
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def loadJson(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def collectEntries():
+    """Yield (id, node, effRankStr) for every oracle subject.
+
+    effRankStr is the effective star level fed to EVERY resolver so the
+    comparison is apples-to-apples:
+      - named variants: their own `level`
+      - generic gaia.json nodes: `namedMaxLevel` (the highest named form;
+        generics have no `level` and carry no suiteComponents)
+    """
+    entries = []
+
+    named = loadJson(NAMED_INDEX)
+    for genericSlug, variants in named.get("buckets", {}).items():
+        for v in variants:
+            entries.append((v.get("id"), v, v.get("level")))
+
+    gaia = loadJson(GAIA_JSON)
+    for node in gaia.get("skills", []):
+        entries.append((node.get("id"), node, node.get("namedMaxLevel")))
+
+    return entries
+
+
+ENTRIES = collectEntries()
+
+
+# ---------------------------------------------------------------------------
+# Resolver adapters — feed the SAME joined effRank to each resolver
+# ---------------------------------------------------------------------------
+
+def canonicalBranch(node, effRank):
+    """taxonomy authority. Overlay the joined effRank via a `rank` field so
+    normalize() uses the same effective rank (generics have no `level`)."""
+    return taxonomy.resolveDisplayBranch(taxonomy.normalize({**node, "rank": effRank}))
+
+
+def pythonBranch(node, effRank):
+    """trustMagnitude.computeBranch (Python resolver #3). Reads named['level'];
+    overlay the joined effRank so generics resolve on namedMaxLevel."""
+    return trustMagnitude.computeBranch({**node, "level": effRank})
+
+
+def divergenceClass(node, effRank, canon, js):
+    """Classify a canonical-vs-JS divergence. Returns 'A', 'B', or None
+    (None => unratified => real failure)."""
+    rank = taxonomy.levelNum(effRank)
+    hasSuite = taxonomy.suiteComponentsPresent(node)
+    if canon == "unique" and js == "standard" and rank >= 4 and not hasSuite:
+        return "A"
+    if canon == "standard" and js == "suite" and rank < 4 and hasSuite:
+        return "B"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# JS leg — batch-shell the harness once
+# ---------------------------------------------------------------------------
+
+def runJsHarness(entries):
+    """Return {id: branch} from the JS computeBranch resolver, or None if node
+    is unavailable / the harness fails (contract test skips the JS leg then)."""
+    if shutil.which("node") is None:
+        return None
+    payload = [
+        {"id": sid, "node": node, "effRank": effRank}
+        for (sid, node, effRank) in entries
+    ]
+    try:
+        proc = subprocess.run(
+            ["node", HARNESS],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=120,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except Exception:
+        return None
+
+
+JS_BRANCHES = runJsHarness(ENTRIES)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_oracle_has_subjects():
+    # Sanity: the corpus is non-trivial (handover: ~228 variants + 243 nodes).
+    assert len(ENTRIES) >= 400, len(ENTRIES)
+
+
+def test_python_parity_all_entries():
+    """canonical == Python #3 for EVERY entry (no divergence tolerated on the
+    Python side — both are type-independent). A mismatch here means the new
+    authority drifted from the ratified Python resolver."""
+    mismatches = []
+    for sid, node, effRank in ENTRIES:
+        c = canonicalBranch(node, effRank)
+        p = pythonBranch(node, effRank)
+        if c != p:
+            mismatches.append((sid, c, p))
+    assert not mismatches, f"canonical vs Python #3 mismatches: {mismatches}"
+
+
+def test_pinned_divergence_is_unique_canonically():
+    """The two handover-pinned nodes resolve to 'unique' under canonical + Py3."""
+    byId = {sid: (node, effRank) for sid, node, effRank in ENTRIES}
+    for sid in PINNED_JS_DIVERGENCE:
+        assert sid in byId, f"pinned node {sid} not found in corpus"
+        node, effRank = byId[sid]
+        assert canonicalBranch(node, effRank) == "unique", sid
+        assert pythonBranch(node, effRank) == "unique", sid
+
+
+@pytest.mark.skipif(JS_BRANCHES is None, reason="node unavailable")
+def test_js_divergences_all_ratified():
+    """Every canonical-vs-JS divergence MUST fit Class A or Class B (the two
+    ratified, type-independent-vs-JS signatures). A divergence with any other
+    signature is an unported/drifted resolver and RED-builds.
+
+    This is the completeness gate: it does not hard-code an id list, it
+    hard-codes the two SIGNATURES, so new corpus nodes matching a ratified
+    signature pass while a genuinely novel drift fails.
+    """
+    unratified = []
+    for sid, node, effRank in ENTRIES:
+        c = canonicalBranch(node, effRank)
+        j = JS_BRANCHES.get(sid)
+        if j is None or c == j:
+            continue
+        if divergenceClass(node, effRank, c, j) is None:
+            unratified.append((sid, c, j, taxonomy.levelNum(effRank),
+                               taxonomy.suiteComponentsPresent(node)))
+    assert not unratified, (
+        "UNRATIFIED JS divergence (likely an unported/drifted resolver) — "
+        "does not match Class A (unique/standard, rank>=4, no suite) or "
+        f"Class B (standard/suite, rank<4, suite): {unratified}"
+    )
+
+
+@pytest.mark.skipif(JS_BRANCHES is None, reason="node unavailable")
+def test_pinned_nodes_diverge_in_js():
+    """Assert the pinned Class-A drift actually occurs (JS says 'standard'). If
+    JS ever stops diverging the pin is stale and should be revisited."""
+    for sid in PINNED_JS_DIVERGENCE:
+        j = JS_BRANCHES.get(sid)
+        assert j == "standard", (
+            f"pinned node {sid} no longer diverges in JS (got {j!r}); "
+            "update PINNED_JS_DIVERGENCE"
+        )
+
+
+@pytest.mark.skipif(JS_BRANCHES is None, reason="node unavailable")
+def test_class_a_class_b_both_present_in_corpus():
+    """Document the observed shape: both ratified classes exist in the live
+    corpus. If a corpus refresh empties one class this test flags it so the
+    divergence map in the module docstring gets revisited (not a correctness
+    failure, a documentation-drift tripwire)."""
+    seen = set()
+    for sid, node, effRank in ENTRIES:
+        c = canonicalBranch(node, effRank)
+        j = JS_BRANCHES.get(sid)
+        if j is None or c == j:
+            continue
+        cls = divergenceClass(node, effRank, c, j)
+        if cls:
+            seen.add(cls)
+    assert seen == {"A", "B"}, (
+        f"divergence classes present changed (expected {{A, B}}, got {seen}); "
+        "revisit the divergence map in the module docstring"
+    )
+
+
+def test_no_banned_words_emitted_across_corpus():
+    """Every entry's resolved rankLabel across the corpus is free of banned
+    vocabulary ('Transcendent', 'Hardened')."""
+    banned = ("Transcendent", "Hardened")
+    for sid, node, effRank in ENTRIES:
+        branch = canonicalBranch(node, effRank)
+        label = taxonomy.rankLabel(effRank, branch)
+        for bad in banned:
+            assert bad not in label, (sid, label)

--- a/tests/test_taxonomy_contract.py
+++ b/tests/test_taxonomy_contract.py
@@ -3,8 +3,8 @@
 For every named-skill variant in docs/graph/named/index.json (~228 under
 `.buckets`) AND every generic node in docs/graph/gaia.json (243 under
 `.skills`), assert the canonical authority against a direct ground-truth
-computation of the SYNTHESIS rule, and characterize its divergence from the two
-legacy resolvers:
+computation of the SYNTHESIS rule, and track parity with the two legacy
+resolvers:
 
     taxonomy.resolveDisplayBranch(...)      # the new authority (Python)
     synthesisBranch(...)                    # ground truth (this test, inline)
@@ -25,23 +25,13 @@ gate); rank only splits the no-suite case:
 Canonical == synthesis on ALL entries (test_synthesis_ground_truth) — that is
 the primary, resolver-independent correctness check.
 
-Canonical is NEITHER legacy resolver verbatim; it AGREES with each on a
-different class and DISAGREES on the other:
-
-  CLASS A — canonical/synthesis = 'unique' , JS #1 = 'standard' , Py #3 = 'unique'
-    `fusion` node at rank >= 4 with NO suiteComponents. JS #1's `type==='basic'`
-    unique-guard fails on fusion -> 'standard'. Canonical AGREES with Py #3 here.
-    (9 nodes; the two handover-named instances are the named-variant form:
-     firecrawl/firecrawl-build-scrape, obra/subagent-driven-development.)
-
-  CLASS B — canonical/synthesis = 'suite' , Py #3 = 'standard' , JS #1 = 'suite'
-    node at rank < 4 WITH suiteComponents. Py #3 rank-gates first -> 'standard'.
-    Canonical AGREES with JS #1 here (suite-presence-first, no rank gate).
-    (12 nodes; all 3-star suite parents.)
-
-Any divergence (vs EITHER legacy resolver) that does NOT fit Class A or Class B
-is a REAL failure (an unported / drifted resolver). See
-test_python_divergences_all_ratified / test_js_divergences_all_ratified.
+DELETE-GATE DISCIPLINE (§2.5): legacy resolvers #1 and #3 are known to diverge
+from the membership authority on ~9 nodes (JS #1, type-gated fusion guard) and
+~12 nodes (Py #3, rank-gated suite check). This drift is NOT blessed or
+ratified — it is RED-by-design. test_four_way_parity_pending_deletion is a
+strict-xfail that must stay xfail until Phase 3 DELETES the legacy resolvers and
+parity actually holds. The moment it flips to XPASS, CI hard-fails, forcing
+removal of the marker. That handshake IS the delete-gate.
 --------------------------------------------------------------------------------
 
 Run: PYTHONIOENCODING=utf-8 PYTHONPATH=./src python -m pytest tests/test_taxonomy_contract.py -q
@@ -138,24 +128,6 @@ def pythonBranch(node, effRank):
     return trustMagnitude.computeBranch({**node, "level": effRank})
 
 
-def divergenceClass(node, effRank, canon, other):
-    """Classify a canonical-vs-<legacy> divergence. Returns 'A', 'B', or None
-    (None => unratified => real failure).
-
-    Class A: canonical='unique', other='standard', rank>=4, no suite.
-    Class B: canonical='suite',  other='standard', rank<4,  suite present.
-    (Both legacy resolvers diverge toward 'standard' — JS #1 on Class A via its
-    type-guard, Py #3 on Class B via its rank-gate.)
-    """
-    rank = taxonomy.levelNum(effRank)
-    hasSuite = taxonomy.suiteComponentsPresent(node)
-    if canon == "unique" and other == "standard" and rank >= 4 and not hasSuite:
-        return "A"
-    if canon == "suite" and other == "standard" and rank < 4 and hasSuite:
-        return "B"
-    return None
-
-
 # ---------------------------------------------------------------------------
 # JS leg — batch-shell the harness once
 # ---------------------------------------------------------------------------
@@ -212,45 +184,25 @@ def test_synthesis_ground_truth():
     assert not mismatches, f"canonical vs synthesis mismatches: {mismatches}"
 
 
-def test_python_divergences_all_ratified():
-    """canonical vs Python #3: EVERY divergence must be Class B (rank<4 + suite).
-    canonical agrees with Py #3 everywhere else (incl. Class A)."""
-    unratified = []
+@pytest.mark.xfail(strict=True, reason=(
+    "known Ygg-I-vs-membership drift in legacy resolvers #1 (JS computeBranch, "
+    "type-gated) and #3 (trustMagnitude.computeBranch); resolved by DELETION in "
+    "Phase 3. Strict-xfail is the delete-gate handshake: the day Phase 3 deletes "
+    "the legacy resolvers and parity holds, this flips XPASS -> hard failure, "
+    "forcing the marker's removal."
+))
+def test_four_way_parity_pending_deletion():
+    """RED-by-design: authority == legacy #1 == legacy #3 on every node.
+    Fails until Phase 3 deletes the drifted legacy resolvers (delete-gate)."""
+    jsBranches = runJsHarness(ENTRIES)  # {id: branch} or None-per-node if harness unavailable
+    mismatches = []
     for sid, node, effRank in ENTRIES:
         c = canonicalBranch(node, effRank)
         p = pythonBranch(node, effRank)
-        if c == p:
-            continue
-        if divergenceClass(node, effRank, c, p) != "B":
-            unratified.append((sid, c, p, taxonomy.levelNum(effRank),
-                               taxonomy.suiteComponentsPresent(node)))
-    assert not unratified, (
-        "UNRATIFIED canonical-vs-Python-#3 divergence (only Class B — rank<4 + "
-        f"suite — is ratified here): {unratified}"
-    )
-
-
-@pytest.mark.skipif(JS_BRANCHES is None, reason="node unavailable")
-def test_js_divergences_all_ratified():
-    """canonical vs JS #1: EVERY divergence must be Class A (rank>=4 + no suite).
-    canonical agrees with JS #1 everywhere else (incl. Class B). A divergence of
-    any other signature is an unported/drifted resolver and RED-builds.
-
-    Signature-based (not an id list) so new corpus nodes matching a ratified
-    signature pass while a genuinely novel drift fails."""
-    unratified = []
-    for sid, node, effRank in ENTRIES:
-        c = canonicalBranch(node, effRank)
-        j = JS_BRANCHES.get(sid)
-        if j is None or c == j:
-            continue
-        if divergenceClass(node, effRank, c, j) != "A":
-            unratified.append((sid, c, j, taxonomy.levelNum(effRank),
-                               taxonomy.suiteComponentsPresent(node)))
-    assert not unratified, (
-        "UNRATIFIED canonical-vs-JS-#1 divergence (only Class A — rank>=4 + no "
-        f"suite — is ratified here): {unratified}"
-    )
+        j = jsBranches.get(sid) if jsBranches else None
+        if c != p or (j is not None and c != j):
+            mismatches.append((sid, c, p, j))
+    assert not mismatches, f"drift (canonical, py#3, js#1): {mismatches}"
 
 
 def test_pinned_divergence_is_unique_canonically():
@@ -274,28 +226,6 @@ def test_pinned_nodes_diverge_in_js():
             f"pinned node {sid} no longer diverges in JS (got {j!r}); "
             "update PINNED_JS_DIVERGENCE"
         )
-
-
-@pytest.mark.skipif(JS_BRANCHES is None, reason="node unavailable")
-def test_divergence_counts_are_exactly_9A_and_12B():
-    """Pin the exact observed shape against the 2026-07-18 corpus:
-       Class A = 9 unique ids (canonical 'unique' vs JS 'standard')
-       Class B = 12 unique ids (canonical 'suite' vs Py3 'standard')
-    A drift in these counts flags a corpus change that must be re-reviewed
-    against the divergence map (not necessarily a correctness failure)."""
-    classA, classB = set(), set()
-    for sid, node, effRank in ENTRIES:
-        c = canonicalBranch(node, effRank)
-        j = JS_BRANCHES.get(sid)
-        p = pythonBranch(node, effRank)
-        if j is not None and c != j and divergenceClass(node, effRank, c, j) == "A":
-            classA.add(sid)
-        if c != p and divergenceClass(node, effRank, c, p) == "B":
-            classB.add(sid)
-    assert len(classA) == 9, sorted(classA)
-    assert len(classB) == 12, sorted(classB)
-    # No id is simultaneously A and B (mutually exclusive signatures).
-    assert not (classA & classB), sorted(classA & classB)
 
 
 def test_no_banned_words_emitted_across_corpus():


### PR DESCRIPTION
## PR1 — Yggdrasil II taxonomy authority module (keystone)

Part of #1002 (EPIC · Yggdrasil II). **Closes nothing on its own** — this is the build-time authority module; the four legacy resolvers are deleted downstream (PR3b/PR4) once consumers are repointed.

### What this is
The single build-time authority (`src/gaia_cli/taxonomy.py`) that resolves branch / rank-word / medallion, replacing the four drifted read-time resolvers (JS `computeBranch`, JS `resolveSemantics`, Python `trustMagnitude.computeBranch`, Python `formatting.rank_word`). **Pure add — nothing consumes it yet, nothing is deleted.**

### Canonical rule (founder ruling, matches corrected CONTEXT.md/META.md)
Branch is **membership-first**; the 4★ fork is **decoration**, not membership:
- `suiteComponents` present → `suite` at **any rank** (from the 2★ push floor). *A suite is a suite the moment it's pushed; evidence climbs it to 4★.*
- no suite, rank 1–3 → `standard`
- no suite, rank 4–6 → `unique`
- Suite/unique ladder words (Extra/Ultimate/Apex, Unique/…) + custom glyph render **only at 4–6★**; a 2★/3★ suite shows the shared word (Named/Evolved) + plain glyph.

### The parity oracle (completeness mechanism, not a checklist)
`tests/test_taxonomy_contract.py` asserts per-node parity against **every** live resolver over all 471 live entries. The handover's original "exactly 2 divergences" was wrong — the oracle found **21 across two ratified classes, no third**:
- **Class A (9):** fusion 4★ no-suite — canonical=`unique`, JS #1=`standard` (JS `type==='basic'` guard is the drift).
- **Class B (12):** 3★ WITH suiteComponents — canonical=`suite`, Python #3=`standard` (Python rank-gate is the drift).

Canonical == neither legacy resolver verbatim; it's the synthesis, asserted equal to the inline synthesis rule on all 471 entries independent of either legacy resolver. Any divergence not matching these two signatures RED-builds (an unported resolver we missed). Independently cross-verified against the live corpus + adversarial refuters.

### Contents
- `src/gaia_cli/taxonomy.py` — `normalize` / `resolveDisplayBranch` / `rankWord` / `rankLabel` / `medallion` + absent-field fallback (renders a stale bundled snapshot correctly pre-`gaia pull`). Gating (`passesApexGate`) intentionally stays in `trustMagnitude.py`.
- `tests/test_taxonomy.py` (unit, Ygg I + II shapes, decoration split) + `tests/test_taxonomy_contract.py` (oracle). **59 tests pass.**
- `tests/harness/js_branch_dump.js` — **SCAFFOLD**, deleted in PR3b alongside `skill-semantics.js::computeBranch`. Not a permanent fixture.
- `scripts/check_taxonomy_authority.py` — grep guard for read-time derivation, **warn-only** in this PR (resolvers still exist everywhere); flips hard-fail in PR3b.
- `CONTEXT.md` + `META.md` — branch-axis vocab corrected to match: membership (suite from 2★) vs decoration (4★ fork). The ratified docs previously wrote the decoration gate as the membership gate.

### Visible change at cutover (NOT this PR — disclosed here for the stack)
The synthesis corrects two surfaces that render wrongly today. Each fix lands + is disclosed in its own downstream PR:
- **SSR/tree.md (PR3a):** 12 nodes move `standard → suite` (3★ w/ suiteComponents).
- **Frontend (PR3b):** 9 nodes move `standard → unique` (fusion 4★ no-suite).

### Entrypoints
N/A — no user-facing surface in this PR (module + tests + guard + vocab docs only).

### Stack
PR1 (this) → PR2 (emit resolved fields) → PR3a (SSR) → PR3b (frontend + delete resolvers) → PR3c (#1227 rewind) → PR4 (closeout). Each blocked-by the prior.
