### PR TITLE
docs(en): routine 017 — v6.8.16 bump, MCP namespace sync & AGENTS.md intake

### DIFF
--- a/docs/en/DOCS.md
+++ b/docs/en/DOCS.md
@@ -19,15 +19,15 @@ Secondary: Open-source contributors wanting to claim a Named Skill.
 | # | File | Title | Status | Routine |
 |---|------|--------|--------|---------|
 | 1 | `index.html` | Docs Home | ✅ Done (updated 017) | 001, 017 |
-| 2 | `getting-started.html` | Getting Started | ✅ Done (updated 012) | 001 |
-| 3 | `cli-reference.html` | CLI Reference | ✅ Done (updated 012) | 002 |
+| 2 | `getting-started.html` | Getting Started | ✅ Done (updated 017) | 001, 017 |
+| 3 | `cli-reference.html` | CLI Reference | ✅ Done (updated 017) | 002, 017 |
 | 4 | `skill-hierarchy.html` | Skill Hierarchy | ✅ Done | 002 |
 | 5 | `contributing.html` | Contributing | ✅ Done (updated 017) | 003, 017 |
-| 6 | `named-skills.html` | Named Skills & Origin | ✅ Done | 003 |
+| 6 | `named-skills.html` | Named Skills & Origin | ✅ Done (updated 017) | 003, 017 |
 | 7 | `evidence-classes.html` | Evidence & Trust | ✅ Done | 004 |
-| 8 | `fusion.html` | Skill Fusion | ✅ Done | 004 |
+| 8 | `fusion.html` | Skill Fusion | ✅ Done (updated 017) | 004, 017 |
 | 9 | `mcp-server.html` | MCP Server | ✅ Done (updated 017) | 005, 017 |
-| 10 | `faq.html` | FAQ | ✅ Done | 005 |
+| 10 | `faq.html` | FAQ | ✅ Done (updated 017) | 005, 017 |
 | 11 | `share-bundles.html` | Share Bundles | ✅ Done | 006 |
 | 12 | `timeline-audit.html` | Timeline Audit & Repair | ✅ Done | 008 |
 
@@ -84,8 +84,8 @@ Interactive & Copy UI:
 - Stars axis: 0★ → 6★. Never call it "rank" or "level" alone.
 - Rank names: Unawakened, Awakened, Named, Evolved, Hardened, Transcendent, Transcendent ★
 - Fusion: combining skills. Never "merge", "combine", "compose".
-- Named Skill: a skill claimed by a real contributor with Class C evidence or better.
-- Evidence Class: C (first sighting), B (reproducible), A (battle-tested, peer-reviewed).
+- Named Skill: a skill claimed by a real contributor with Grade C (Bronze) evidence or better.
+- Evidence Grade (current, S/A/B/C → Platinum/Gold/Silver/Bronze): the quality axis. Evidence Type (arxiv, repo-own, github-stars-own, etc.): the provenance axis. Evidence Class (deprecated, letters A/B/C): the legacy single axis these two replaced — never conflate Class A/B with Grade A/B.
 - Do NOT mention rarity (deprecated axis).
 
 ---

--- a/docs/en/DOCS.md
+++ b/docs/en/DOCS.md
@@ -18,15 +18,15 @@ Secondary: Open-source contributors wanting to claim a Named Skill.
 
 | # | File | Title | Status | Routine |
 |---|------|--------|--------|---------|
-| 1 | `index.html` | Docs Home | ✅ Done | 001 |
+| 1 | `index.html` | Docs Home | ✅ Done (updated 017) | 001, 017 |
 | 2 | `getting-started.html` | Getting Started | ✅ Done (updated 012) | 001 |
 | 3 | `cli-reference.html` | CLI Reference | ✅ Done (updated 012) | 002 |
 | 4 | `skill-hierarchy.html` | Skill Hierarchy | ✅ Done | 002 |
-| 5 | `contributing.html` | Contributing | ✅ Done | 003 |
+| 5 | `contributing.html` | Contributing | ✅ Done (updated 017) | 003, 017 |
 | 6 | `named-skills.html` | Named Skills & Origin | ✅ Done | 003 |
 | 7 | `evidence-classes.html` | Evidence & Trust | ✅ Done | 004 |
 | 8 | `fusion.html` | Skill Fusion | ✅ Done | 004 |
-| 9 | `mcp-server.html` | MCP Server | ✅ Done (updated 013) | 005 |
+| 9 | `mcp-server.html` | MCP Server | ✅ Done (updated 017) | 005, 017 |
 | 10 | `faq.html` | FAQ | ✅ Done | 005 |
 | 11 | `share-bundles.html` | Share Bundles | ✅ Done | 006 |
 | 12 | `timeline-audit.html` | Timeline Audit & Repair | ✅ Done | 008 |

--- a/docs/en/DOCS.md
+++ b/docs/en/DOCS.md
@@ -24,7 +24,7 @@ Secondary: Open-source contributors wanting to claim a Named Skill.
 | 4 | `skill-hierarchy.html` | Skill Hierarchy | ✅ Done | 002 |
 | 5 | `contributing.html` | Contributing | ✅ Done (updated 017) | 003, 017 |
 | 6 | `named-skills.html` | Named Skills & Origin | ✅ Done (updated 017) | 003, 017 |
-| 7 | `evidence-classes.html` | Evidence & Trust | ✅ Done | 004 |
+| 7 | `evidence-classes.html` | Evidence & Trust | ✅ Done (updated 017) | 004, 017 |
 | 8 | `fusion.html` | Skill Fusion | ✅ Done (updated 017) | 004, 017 |
 | 9 | `mcp-server.html` | MCP Server | ✅ Done (updated 017) | 005, 017 |
 | 10 | `faq.html` | FAQ | ✅ Done (updated 017) | 005, 017 |

--- a/docs/en/MEMORY.md
+++ b/docs/en/MEMORY.md
@@ -2,6 +2,92 @@
 
 ---
 
+## 2026-07-23 — Routine 017 (continued, PR #1249 still open)
+
+**Branch:** `docs/routines/017`
+**Task chosen:** Task 5 (edit outdated literature) — closed out issue #1254, filed by this same
+routine yesterday, and found the same drift had spread further than the issue described.
+
+### Trigger
+PR #1249 (`docs/routines/017`) was still open/unmerged when this session started, so per branch
+discipline this continues on the same branch rather than cutting `018`. Checked open `documentation`-
+labeled issues for the next task; issue #1254 (filed 2026-07-22, end of yesterday's session) was the
+clear next step — it's this routine's own flagged remainder, not someone else's backlog item.
+
+### What I did
+1. **Fixed `evidence-classes.html` Trust Number thresholds** — trust meter, grade table, and the
+   pitfalls-table Grade S row all said `S≥90/A≥80/B≥60/C≥40`. Real thresholds from
+   `registry/schema/meta.json` → `evidence.gradeThresholds` (confirmed against the CLI's own
+   `--trust` help text in `impl.py`) are `S≥250/A≥100/B≥50/C≥20`. Fixed all instances.
+2. **Rewrote the Evidence Type table** — was 3 rows (`arxiv`, `repo`, `github-stars`), two of which
+   used IDs that don't exist. Replaced with all 10 real IDs from `evidence.types`
+   (`repo-own`, `github-stars-own`, `arxiv`, `peer-review`, `verifier-attestation`,
+   `benchmark-result`, `fusion-recipe`, `proxy-containment`, `social-signal`, `self-attestation`),
+   each with what it represents and its real CLI flags, sourced from the `impl.py` `dev_evidence`
+   argparse block and each type's `meta.json` description/magnitude formula.
+3. **Fixed the `gaia dev evidence` CLI examples** — `--grade` is not a real flag (Grade is
+   auto-derived from `--trust`; confirmed no such argument in `impl.py`); `--dry-run` does not
+   exist for this subcommand either. Rewrote both example blocks to `--type` + `--trust`, with
+   `--commits`/`--contributors`/`--citations` on the relevant rows.
+4. **Found and fixed a CLI-shape error beyond the filed issue, in the same section**: the page's
+   "verify"/"dispute" examples showed them as flags on `gaia dev evidence` — they're actually a
+   separate subcommand, `gaia dev verify <skill_id> --index N [--dispute]` (confirmed in
+   `impl.py`, `dev_verify` parser). Fixed both examples; this wasn't in issue #1254 but is the
+   same accuracy problem in the same paragraph I was already rewriting, not separate scope.
+5. **Migration guide + pitfalls sections**: updated `repo`/`github-stars` type-pills to
+   `repo-own`/`github-stars-own`, and the Grade S callout's `≥ 90` to `≥ 250`. Replaced the
+   "Skipping `--dry-run`" pitfall (wrong — no such flag) with "Passing `--grade` instead of
+   `--trust`", the actually-real mistake.
+6. **Checked whether the same drift had spread to other pages** — issue #1254 only flagged
+   `evidence-classes.html`, but grepping `docs/en/` for the same numbers found it had:
+   - `faq.html` — Class-vs-Grade comparison item used `≥90/≥80/≥60/≥40` and `--grade S|A|B|C`
+     (nonexistent flag), plus `repo`/`github-stars` as example type IDs. Fixed all three.
+   - `named-skills.html` — Evidence Grade table had the same stale thresholds (type IDs there
+     were already correct from routine 017's earlier continuation). Also found and fixed
+     `gaia dev verify skill-id 0` missing the required `--index` flag (bare positional isn't
+     valid argparse for that subcommand). Fixed all four.
+7. Verified no HTML structural breakage: tag-balance check (table/tr/td/th/tbody/thead/div/ul/h2/h3)
+   and `html.parser` parse-error check on all three touched files — clean. Rendered
+   `evidence-classes.html` locally via Playwright/Chromium and screenshotted the Evidence Type
+   table, Trust Number meter/grade table, and CLI code block to confirm the new content displays
+   correctly with no layout breakage.
+8. Updated `DOCS.md` page map: `evidence-classes.html`, `named-skills.html`, `faq.html` rows all
+   now note "updated 017" with 017 added to their routine list (still the same open branch/PR,
+   not a new routine number).
+
+### Design decisions
+- Kept the Evidence Type table's "URL format / flags" column terse — full magnitude formulas
+  live in `meta.json` and don't belong on a docs page; the callout below the table points there
+  instead of duplicating it.
+- Fixed the `gaia dev verify` shape bug inline rather than filing a new issue for it — it's the
+  same CLI-accuracy sweep on the same page section already being rewritten for #1254, not
+  distinct scope. Filing a follow-up for something already open in the editor would just be
+  spreading the same fix across two PRs for no reason.
+- Did not touch the legacy `--class` example (`gaia dev evidence ... --class B`) — that flag is
+  real and still accepted for back-compat, confirmed in `impl.py`; only the *new*-form examples
+  needed fixing.
+
+### Issues informed
+- Closes #1254 (evidence-classes.html Trust Number / Evidence Type / CLI-flag drift) — all three
+  points in the issue fixed, plus the `gaia dev verify` shape bug found while doing so.
+
+### Files created / modified
+- `docs/en/DOCS.md` (modified)
+- `docs/en/MEMORY.md` (modified)
+- `docs/en/evidence-classes.html` (modified)
+- `docs/en/faq.html` (modified)
+- `docs/en/named-skills.html` (modified)
+
+### Planned next
+- Audit `mcp-server.html` and `cli-reference.html` for the same class of drift (flags/thresholds
+  documented from memory rather than re-derived from `impl.py`/`meta.json`) — this routine found
+  three pages with the same failure mode in one afternoon; worth a systematic pass rather than
+  waiting for the next issue report.
+- Once PR #1249 merges: next routine can move to a genuinely new page/feature rather than more
+  accuracy cleanup — the Class→Grade wording and numbers should now be consistent repo-wide.
+
+---
+
 ## 2026-07-22 — Routine 017
 
 **Branch:** `docs/routines/017`

--- a/docs/en/MEMORY.md
+++ b/docs/en/MEMORY.md
@@ -2,6 +2,34 @@
 
 ---
 
+## 2026-07-24 — Routine 017 (continued, PR #1249 still open)
+
+**Branch:** `docs/routines/017`
+**Task chosen:** Rotate least-recently-touched page — `cli-reference.html` — for ongoing audit and sync with new CLI features.
+
+### Trigger
+PR #1249 (`docs/routines/017`) still open/unmerged; per branch discipline, continue on the same routine branch. DOCS.md page map shows `cli-reference.html` last touched in routine 012; the planned next from routine 017's 2026-07-23 session flagged this page as needing systematic audit for CLI-shape drift.
+
+### What I did
+1. **Added `gaia scan --dir` flag documentation** — CLI feature from commit `3cee7a4cc` (feat(scan): add repeatable --dir flag for nonstandard skill roots #1159) was live but not yet documented. Updated `cli-reference.html` scan command card: updated signature to `[--quiet] [--auto-promote] [--json] [--dir DIR]...`; added table row for `--dir DIR` with description "Scan an extra skill root beyond configured paths (repeatable). Accepts home-relative, absolute, or relative paths. Equivalent to adding to .gaia/config.toml skillDirs=[...]"; added a new example demonstrating repeatable `--dir ~/my-skills --dir ./local-agents`.
+
+### Design decisions
+- Kept the `--dir` description terse, avoiding implementation details (path normalization, realpath-dedup, warning on missing paths) — users needing those specifics can read `src/gaia_cli/scanner.py` docstring or the reference in `CLAUDE.md`. The docs page level stays at "what it does, when to use it."
+- Description matches the phrasing in `src/gaia_cli/commands/scan.py` (line 24) which calls it "Sticky equivalent" to `.gaia/config.toml skillDirs=[...]" — both docs and code reference the same affordance.
+
+### Issues informed
+- Closes no filed issues; this is preventive: documented a live feature before the gap was reported.
+
+### Files created / modified
+- `docs/en/MEMORY.md` (modified)
+- `docs/en/cli-reference.html` (modified)
+
+### Planned next (Routine 018 or continuation)
+- Continue systematic audit of `cli-reference.html` for other undocumented recent flags (scan has more, other commands may too).
+- Audit `mcp-server.html` for package/version drift (similar to the class→grade migration already done).
+
+---
+
 ## 2026-07-23 — Routine 017 (continued, PR #1249 still open)
 
 **Branch:** `docs/routines/017`

--- a/docs/en/MEMORY.md
+++ b/docs/en/MEMORY.md
@@ -2,6 +2,34 @@
 
 ---
 
+## 2026-07-25 — Routine 017 — Editor pass (ship gate, PR #1249)
+
+**Role:** Weekly editor. Reviewed the week's accreted commits on `docs/routines/017`, verified claims against the actual product, fixed what didn't hold up, and shipped.
+
+### What I verified and fixed
+1. **`gaia scan` flag table had a fictional flag.** The 2026-07-24 session added `--dir` correctly but left `--auto-promote` in the signature/table/example — that flag does not exist on `gaia scan` (confirmed via `python -m gaia_cli.main scan --help` and `commands/scan.py`). The real, undocumented flag was `--all` ("scan globally installed skills in addition to the local repository"). Replaced `--auto-promote` with `--all` in `cli-reference.html` (signature, table row, example).
+2. **MCP server package name was wrong across two pages.** The 2026-07-22 session changed `mcp-server.html` and `index.html` to `@gaia-research/mcp@0.1.0`, citing `AGENTS.md` and commit `6ed72921d`. That commit itself was bad — `packages/mcp/package.json` (and its own README, and the root README's install table) has always published as `@gaia-registry/mcp-server`. Reverted both pages to the real package name and dropped the stale `-y`/version-pin flourishes to match the canonical README's install commands exactly.
+3. **Self-contradiction in `faq.html`.** This week's own `evidence-classes.html` fix added an explicit "do not call it 'trust score'" pitfall — but `faq.html` still said "trust score tier" two lines away in spirit. Changed to "quality tier."
+4. **Verified the big one held up.** The Trust Number threshold rewrite (S≥250/A≥100/B≥50/C≥20, replacing stale S≥90/A≥80/B≥60/C≥40) and the 10-row Evidence Type table were checked against `registry/schema/meta.json` and live `--help` output for `gaia dev evidence` / `gaia dev verify` — all accurate. Good work, kept as-is.
+5. **Two small pre-existing vocabulary nits caught in the same files while verifying:** "feed the same review queue" → "feed the same intake" (`contributing.html`; CONTEXT.md: Intake, avoid "queue"), and a TOC entry "Combine skills" → "Fuse skills" (`cli-reference.html`; CONTEXT.md: Fusion, avoid "combine"). Left the rest of the site's vocabulary alone — didn't do a full 12-page nomenclature sweep this round.
+
+### What I checked and left alone
+- Hex colors added this week (`#34d399` checkmarks, `#f59e0b` deprecated tag, `var(--muted, #64748b)` fallbacks) all match long-established, pervasive site-wide convention (same raw values already used in `styles.css` and sibling pages) — not new drift, not touched.
+- Version chips: all 12 pages consistently at `v6.8.16`, matching the latest tag and `pyproject.toml`. No stragglers.
+- Links/anchors added this week (`evidence-classes.html#pitfalls`, etc.) all resolve.
+- Rendered all 5 touched pages via Playwright — no console errors, nav clearance and TOC intact.
+
+### Verification
+`git status` scoped to `docs/en/**` only. HTML tag-balance check clean on all touched files. CI on PR #1249 all green (CodeQL, branch-scope, commit-attribution, design-system lint, docs-cohesion) before this pass; re-verified after.
+
+### Files modified this pass
+`docs/en/cli-reference.html`, `docs/en/contributing.html`, `docs/en/faq.html`, `docs/en/index.html`, `docs/en/mcp-server.html`.
+
+### Shipped
+Squash-merged PR #1249 into `main`. `docs/routines/017` closes; `docs/routines/018` opens next.
+
+---
+
 ## 2026-07-24 — Routine 017 (continued, PR #1249 still open)
 
 **Branch:** `docs/routines/017`

--- a/docs/en/MEMORY.md
+++ b/docs/en/MEMORY.md
@@ -22,7 +22,7 @@ Routine documentation agent triggered; observed repository version bump to `6.8.
 
 ### Issues informed
 - Resolves #1124 (Add `AGENTS.md` discovery reference to documentation)
-- Resolves #917 (Deprecated Evidence Classes audit and package alignment)
+- Partially addressed #917 (Deprecated Evidence Classes) — see continuation below, which actually closes it out.
 
 ### Files created / modified
 - `docs/en/MEMORY.md` (modified)
@@ -40,7 +40,76 @@ Routine documentation agent triggered; observed repository version bump to `6.8.
 - `docs/en/skill-hierarchy.html` (modified)
 - `docs/en/timeline-audit.html` (modified)
 
+### Continued (same day) — Evidence Class residue cleanup, PR #1249 still open
+
+**Task chosen:** Task 5 (edit outdated literature). PR #1249 (`docs/routines/017`) was still open/unmerged
+when this session started, so per branch discipline this continues on the same branch rather than opening 018.
+
+**Trigger:** Checked issue #917 (marked "Resolves" above, prematurely) — its own triage comment
+(nova-gaia, 2026-07-09) flagged a residual "Class C evidence" wording at what was then L880 of
+`skill-hierarchy.html`, asking for a reword to Trust Magnitude / Evidence Grade terms. That specific
+file was already clean (an earlier routine had fixed it), but grepping `docs/en/` for `Class [ABC]`
+turned up the same deprecated phrasing still live in six other places.
+
+**What I did:**
+1. Reworded every residual `Class A/B/C evidence` reference to the current `Grade A/B/C (Gold/Silver/Bronze)`
+   terminology, matching the migration already established in `evidence-classes.html`:
+   `named-skills.html` (7 spots: definition, compare panel, lifecycle steps 3–5, "what you need" list,
+   evidence-types paragraph, CLI example, commit message example), `getting-started.html`,
+   `fusion.html`, `faq.html` (star-tier table, 3 rows), `cli-reference.html` (`gaia propose` description),
+   `contributing.html` (PR title example).
+2. **Found a deeper, separate gap while doing so**: `cli-reference.html`'s `gaia dev evidence` card
+   documented ONLY the deprecated `--class A|B|C` flag — it had never been migrated to the CLI's actual
+   canonical interface (`--type` + `--trust`, confirmed against `src/gaia_cli/impl.py` argparse
+   definitions). Rewrote the whole command card: new flag table rows for `--type`, `--trust`,
+   `--stars/--commits/--contributors`, `--no-build`; kept `--class` documented but marked
+   `[DEPRECATED]`; added a warning callout cross-linking to the Evidence & Trust pitfalls section;
+   updated both shell examples to `--type repo-own --trust 20` / `--type arxiv --trust 100`.
+3. Updated `named-skills.html`'s evidence-types paragraph and CLI walkthrough example to use real
+   type IDs (`repo-own`, `github-stars-own`) instead of the shortened/incorrect `repo`, `github-stars`.
+4. Verified with `grep -rn "Class [ABC]" docs/en/` — zero unintentional matches remain; the two
+   surviving hits are the deliberate Class-vs-Grade contrast sentence in `faq.html` and my own
+   vocabulary note in `DOCS.md`.
+5. Updated `DOCS.md` vocabulary rules (Named Skill definition, evidence axis note) and page map
+   (routine 017 now also touches `getting-started.html`, `cli-reference.html`, `named-skills.html`,
+   `fusion.html`, `faq.html`).
+
+**Design decisions:**
+- Trust numbers used in rewritten CLI examples (20, 50, 100) are chosen to land exactly on the
+  Grade C/B/A boundaries per the real `meta.json` `evidence.gradeThresholds` (S≥250, A≥100, B≥50,
+  C≥20) — confirmed by reading `registry/schema/meta.json` directly, not assumed from the page's
+  own (as it turns out, wrong) numbers.
+- Kept `--class` in the flag table rather than deleting it — the CLI itself still accepts it for
+  back-compat, so hiding it would leave readers of old PRs confused about a flag they'll still see.
+
+**New gap discovered, deliberately NOT fixed here (separate, larger issue filed):**
+`evidence-classes.html` — the canonical Evidence & Trust page — has its own accuracy problems
+unrelated to the Class-wording residue: (a) its Trust Number thresholds table says S≥90/A≥80/B≥60/C≥40,
+but the real `registry/schema/meta.json` → `evidence.gradeThresholds` is S≥250/A≥100/B≥50/C≥20;
+(b) its Evidence Type examples use `repo`/`github-stars`, but the real `evidence.types` list in the
+same schema file is `fusion-recipe`, `github-stars-own`, `proxy-containment`, `verifier-attestation`,
+`benchmark-result`, `arxiv`, `peer-review`, `repo-own`, `self-attestation`, `social-signal` — five
+types aren't mentioned on the page at all; (c) one CLI example uses `--grade A` and `--dry-run`,
+neither of which exist as `gaia dev evidence` flags in `impl.py`. Fixing this properly means
+re-deriving every number and type reference against the schema across a 700+ line file — a distinct,
+larger task from tonight's wording cleanup, so it's filed as its own issue rather than rushed here.
+
+### Issues informed (continuation)
+- Closes #917 (deprecated Evidence Classes) — the residual wording it flagged is gone repo-wide in `docs/en/`.
+- Filed a new issue for the `evidence-classes.html` Trust Number / Evidence Type / CLI-flag accuracy gap (see PR/issue links).
+
+### Files created / modified (continuation)
+- `docs/en/DOCS.md` (modified)
+- `docs/en/MEMORY.md` (modified)
+- `docs/en/named-skills.html` (modified)
+- `docs/en/getting-started.html` (modified)
+- `docs/en/fusion.html` (modified)
+- `docs/en/faq.html` (modified)
+- `docs/en/cli-reference.html` (modified)
+- `docs/en/contributing.html` (modified)
+
 ### Planned next (Routine 018)
+- Fix the `evidence-classes.html` Trust Number threshold / Evidence Type / CLI-flag drift filed above.
 - Audit upcoming CLI commands for `v6.9.0` release features.
 - Maintain and sync documentation for newly curated named skills.
 

--- a/docs/en/MEMORY.md
+++ b/docs/en/MEMORY.md
@@ -2,6 +2,50 @@
 
 ---
 
+## 2026-07-22 — Routine 017
+
+**Branch:** `docs/routines/017`
+**Task chosen:** Version bump to v6.8.16, sync MCP server package name to `@gaia-research/mcp@0.1.0`, document root `AGENTS.md` intake surface, and perform full docs suite synchronization.
+
+### Trigger
+Routine documentation agent triggered; observed repository version bump to `6.8.16` / `v6.8.16` from `origin/main` (via `git describe --tags`).
+
+### What I did
+1. **Synchronized version numbers**: Updated all 12 English documentation HTML files under `docs/en/` from `v6.4.12` to `v6.8.16`. Mapped navigation tags, version chips, footer scripts (`?v=6.8.16`), and version labels across all files.
+2. **Updated MCP server package namespace**: Updated all occurrences in `mcp-server.html` and `index.html` to reference `@gaia-research/mcp@0.1.0` (with `-y` flag in npx commands), aligning with `AGENTS.md` and commit `6ed72921d`.
+3. **Documented root `AGENTS.md` discovery surface**: Added agent intake references in `contributing.html` and `index.html` pointing to `AGENTS.md` as the canonical entry point for visiting AI agents.
+4. **Updated page map in `DOCS.md`**: Updated Routine 017 entries in `DOCS.md` page map table.
+
+### Design decisions
+- Replaced outdated `@gaia-registry/mcp-server` references with the authoritative `@gaia-research/mcp@0.1.0` package identifier and explicit `-y` flags for zero-prompt npx execution.
+- Kept all HTML changes strictly within `docs/en/` adhering to `docs-en-shell.css` layout boundaries.
+
+### Issues informed
+- Resolves #1124 (Add `AGENTS.md` discovery reference to documentation)
+- Resolves #917 (Deprecated Evidence Classes audit and package alignment)
+
+### Files created / modified
+- `docs/en/MEMORY.md` (modified)
+- `docs/en/DOCS.md` (modified)
+- `docs/en/index.html` (modified)
+- `docs/en/mcp-server.html` (modified)
+- `docs/en/contributing.html` (modified)
+- `docs/en/cli-reference.html` (modified)
+- `docs/en/evidence-classes.html` (modified)
+- `docs/en/faq.html` (modified)
+- `docs/en/fusion.html` (modified)
+- `docs/en/getting-started.html` (modified)
+- `docs/en/named-skills.html` (modified)
+- `docs/en/share-bundles.html` (modified)
+- `docs/en/skill-hierarchy.html` (modified)
+- `docs/en/timeline-audit.html` (modified)
+
+### Planned next (Routine 018)
+- Audit upcoming CLI commands for `v6.9.0` release features.
+- Maintain and sync documentation for newly curated named skills.
+
+---
+
 ## 2026-07-11 — Routine 016
 
 **Branch:** `docs/routines/016`

--- a/docs/en/cli-reference.html
+++ b/docs/en/cli-reference.html
@@ -811,9 +811,9 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
@@ -825,7 +825,7 @@
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">CLI Reference</span>
     <div class="nav-spacer"></div>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <div class="page-layout">
@@ -2444,7 +2444,7 @@
 
   <!-- footer -->
   <footer class="docs-footer">
-    <span class="docs-footer-left">Gaia Registry v6.4.12 — open, evidence-backed skill graph for AI agents.</span>
+    <span class="docs-footer-left">Gaia Registry v6.8.16 — open, evidence-backed skill graph for AI agents.</span>
     <div class="docs-footer-right">
       <a href="index.html" style="color:var(--muted,#64748b);">Docs</a>
       <a href="../index.html" style="color:var(--muted,#64748b);">Atlas</a>

--- a/docs/en/cli-reference.html
+++ b/docs/en/cli-reference.html
@@ -1617,7 +1617,7 @@
           <div class="cmd-body">
             <ul class="cmd-desc">
               <li>Submits a proposal to claim an unclaimed canonical skill.</li>
-              <li>Requires Class C evidence or better to propose.</li>
+              <li>Requires Grade C (Bronze) evidence or better to propose.</li>
               <li>Attaches your name as the official Origin Contributor on approval.</li>
             </ul>
             <table class="flag-table">
@@ -2042,16 +2042,22 @@
         <div class="cmd-card" id="dev-evidence">
           <div class="cmd-card-header">
             <span class="cmd-name">gaia dev evidence</span>
-            <span class="cmd-signature">&lt;skill_id&gt; &lt;url&gt; [--class A|B|C] [--evaluator &lt;handle&gt;]
-              [--notes &lt;text&gt;]</span>
+            <span class="cmd-signature">&lt;skill_id&gt; &lt;url&gt; [--type &lt;type&gt;] [--trust &lt;number&gt;]
+              [--evaluator &lt;handle&gt;] [--notes &lt;text&gt;]</span>
             <span class="gate-badge verifier">◇ verifier</span>
           </div>
           <div class="cmd-body">
             <ul class="cmd-desc">
               <li>Attaches evaluation URLs to specific skill nodes.</li>
-              <li>Categorizes evidence into levels A (high), B (medium), or C (low).</li>
+              <li>Records an Evidence Type (provenance) and a Trust Magnitude number; the Evidence Grade (S/A/B/C — Platinum/Gold/Silver/Bronze) is auto-derived from the number, never set directly.</li>
               <li>Influences the speed of skill star upgrades.</li>
             </ul>
+            <div class="callout warn" style="margin-bottom:0.85rem;">
+              <strong>⚠️ --class is deprecated.</strong> The legacy <code>--class A|B|C</code> flag still
+              works for backward compatibility, but new evidence should always use <code>--type</code> +
+              <code>--trust</code>. Class letters and Grade letters are <em>not</em> equivalent — see
+              <a href="evidence-classes.html#pitfalls">Evidence &amp; Trust — common pitfalls</a>.
+            </div>
             <table class="flag-table">
               <thead>
                 <tr>
@@ -2062,9 +2068,24 @@
               </thead>
               <tbody>
                 <tr>
+                  <td>--type &lt;type&gt;</td>
+                  <td>Evidence Type — provenance of the demonstration. Validated against <code>meta.json</code> <code>evidence.types</code> (e.g. <code>repo-own</code>, <code>github-stars-own</code>, <code>arxiv</code>, <code>peer-review</code>, <code>benchmark-result</code>, <code>self-attestation</code>, <code>social-signal</code>).</td>
+                  <td>—</td>
+                </tr>
+                <tr>
+                  <td>--trust &lt;number&gt;</td>
+                  <td>Trust Magnitude value. Evidence Grade is auto-derived: S ≥ 250, A ≥ 100, B ≥ 50, C ≥ 20; below 20 is ungraded.</td>
+                  <td>—</td>
+                </tr>
+                <tr>
                   <td>--class A|B|C</td>
-                  <td>Evidence quality class.</td>
-                  <td>C</td>
+                  <td><span style="color:#f59e0b;">[DEPRECATED]</span> Legacy evidence quality class. Prefer <code>--trust</code>.</td>
+                  <td>—</td>
+                </tr>
+                <tr>
+                  <td>--stars / --commits / --contributors &lt;N&gt;</td>
+                  <td>Type-specific metrics (e.g. star count for <code>github-stars-own</code>, commit/contributor counts for <code>repo-own</code>) used by the Trust Magnitude formula for that type.</td>
+                  <td>—</td>
                 </tr>
                 <tr>
                   <td>--evaluator &lt;handle&gt;</td>
@@ -2081,18 +2102,23 @@
                   <td>Context note attached to this evidence entry.</td>
                   <td>—</td>
                 </tr>
+                <tr>
+                  <td>--no-build</td>
+                  <td>Skip rebuilding docs and graph assets after adding evidence.</td>
+                  <td>false</td>
+                </tr>
               </tbody>
             </table>
             <div class="example-block">
               <div class="example-label">examples</div>
-              <pre><span class="c"># Add Class B evidence (reproducible repo link)</span>
+              <pre><span class="c"># Add repo-own evidence (Trust 20 → Grade C / Bronze)</span>
 <span class="kw">GAIA_OPERATOR_OVERRIDE=1</span> <span class="cmd">gaia dev evidence</span> \
-  <span class="arg">web-search https://github.com/anthropics/cookbook --class B</span>
+  <span class="arg">web-search https://github.com/anthropics/cookbook --type repo-own --trust 20</span>
 
-<span class="c"># Add Class A evidence with an evaluator note</span>
+<span class="c"># Add arXiv evidence with an evaluator note (Trust 100 → Grade A / Gold)</span>
 <span class="kw">GAIA_OPERATOR_OVERRIDE=1</span> <span class="cmd">gaia dev evidence</span> \
   <span class="arg">autonomous-research-agent https://arxiv.org/abs/2401.00000 \
-  --class A --evaluator alice --notes "Peer-reviewed benchmark, 2024"</span></pre>
+  --type arxiv --trust 100 --evaluator alice --notes "Peer-reviewed benchmark, 2024"</span></pre>
             </div>
           </div>
         </div>

--- a/docs/en/cli-reference.html
+++ b/docs/en/cli-reference.html
@@ -931,7 +931,7 @@
             <li><a href="#init"><code>init</code> — Initialize config</a></li>
             <li><a href="#scan"><code>scan</code> — Scan for evidence</a></li>
             <li><a href="#promote"><code>promote</code> — Rank up skill</a></li>
-            <li><a href="#fuse"><code>fuse</code> — Combine skills</a></li>
+            <li><a href="#fuse"><code>fuse</code> — Fuse skills</a></li>
             <li><a href="#tree"><code>tree</code> — Render skill tree</a></li>
             <li><a href="#push"><code>push</code> — Submit intake batch</a></li>
           </ul>
@@ -1076,7 +1076,7 @@
         <div class="cmd-card" id="scan">
           <div class="cmd-card-header">
             <span class="cmd-name">gaia scan</span>
-            <span class="cmd-signature">[--quiet] [--auto-promote] [--json] [--dir DIR]...</span>
+            <span class="cmd-signature">[--quiet] [--all] [--json] [--dir DIR]...</span>
             <span class="gate-badge open">● open</span>
           </div>
           <div class="cmd-body">
@@ -1100,8 +1100,8 @@
                   <td>false</td>
                 </tr>
                 <tr>
-                  <td>--auto-promote</td>
-                  <td>Automatically promote every scan candidate without prompting.</td>
+                  <td>--all</td>
+                  <td>Scan globally installed skills in addition to the local repository.</td>
                   <td>false</td>
                 </tr>
                 <tr>
@@ -1124,8 +1124,8 @@
 <span class="c"># Quiet scan, then inspect candidates in JSON</span>
 <span class="cmd">gaia scan</span> <span class="arg">--quiet --json</span> <span class="kw">| jq '.candidates'</span>
 
-<span class="c"># Promote everything the scanner detects, no prompts</span>
-<span class="cmd">gaia scan</span> <span class="arg">--auto-promote</span>
+<span class="c"># Include globally installed skills, not just this repo</span>
+<span class="cmd">gaia scan</span> <span class="arg">--all</span>
 
 <span class="c"># Scan configured paths plus two extra directories</span>
 <span class="cmd">gaia scan</span> <span class="arg">--dir ~/my-skills --dir ./local-agents</span></pre>

--- a/docs/en/cli-reference.html
+++ b/docs/en/cli-reference.html
@@ -1076,7 +1076,7 @@
         <div class="cmd-card" id="scan">
           <div class="cmd-card-header">
             <span class="cmd-name">gaia scan</span>
-            <span class="cmd-signature">[--quiet] [--auto-promote] [--json]</span>
+            <span class="cmd-signature">[--quiet] [--auto-promote] [--json] [--dir DIR]...</span>
             <span class="gate-badge open">● open</span>
           </div>
           <div class="cmd-body">
@@ -1109,6 +1109,11 @@
                   <td>Write scan results to stdout as machine-readable JSON instead of rendering the tree.</td>
                   <td>false</td>
                 </tr>
+                <tr>
+                  <td>--dir DIR</td>
+                  <td>Scan an extra skill root beyond configured paths (repeatable). Accepts home-relative, absolute, or relative paths. Equivalent to adding to <code>.gaia/config.toml skillDirs=[...]</code>.</td>
+                  <td>—</td>
+                </tr>
               </tbody>
             </table>
             <div class="example-block">
@@ -1120,7 +1125,10 @@
 <span class="cmd">gaia scan</span> <span class="arg">--quiet --json</span> <span class="kw">| jq '.candidates'</span>
 
 <span class="c"># Promote everything the scanner detects, no prompts</span>
-<span class="cmd">gaia scan</span> <span class="arg">--auto-promote</span></pre>
+<span class="cmd">gaia scan</span> <span class="arg">--auto-promote</span>
+
+<span class="c"># Scan configured paths plus two extra directories</span>
+<span class="cmd">gaia scan</span> <span class="arg">--dir ~/my-skills --dir ./local-agents</span></pre>
             </div>
           </div>
         </div>

--- a/docs/en/contributing.html
+++ b/docs/en/contributing.html
@@ -547,7 +547,7 @@
       <section class="section" id="path-a">
         <h2 class="section-title">Path A — <code>gaia push --from-file</code></h2>
         <div class="section-body">
-          <p>Create <code>skills.yml</code> using <code>.github/ISSUE_TEMPLATE/new_skill_intake.yml</code>, then preview it. The CLI and issue form feed the same review queue. AI agents landed in this repo can read <code>AGENTS.md</code> at the root for the fast-path intake guide.</p>
+          <p>Create <code>skills.yml</code> using <code>.github/ISSUE_TEMPLATE/new_skill_intake.yml</code>, then preview it. The CLI and issue form feed the same intake. AI agents landed in this repo can read <code>AGENTS.md</code> at the root for the fast-path intake guide.</p>
           <p>Proposed skills are not in the registry until a maintainer promotes them.</p>
         </div>
 

--- a/docs/en/contributing.html
+++ b/docs/en/contributing.html
@@ -462,9 +462,9 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
@@ -476,7 +476,7 @@
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">Contributing</span>
     <span class="nav-spacer"></span>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <!-- Layout -->
@@ -547,7 +547,7 @@
       <section class="section" id="path-a">
         <h2 class="section-title">Path A — <code>gaia push --from-file</code></h2>
         <div class="section-body">
-          <p>Create <code>skills.yml</code> using <code>.github/ISSUE_TEMPLATE/new_skill_intake.yml</code>, then preview it. The CLI and issue form feed the same review queue.</p>
+          <p>Create <code>skills.yml</code> using <code>.github/ISSUE_TEMPLATE/new_skill_intake.yml</code>, then preview it. The CLI and issue form feed the same review queue. AI agents landed in this repo can read <code>AGENTS.md</code> at the root for the fast-path intake guide.</p>
           <p>Proposed skills are not in the registry until a maintainer promotes them.</p>
         </div>
 
@@ -836,7 +836,7 @@ gaia dev validate --intake   <span class="c"># validate intake batch too</span><
       </section>
 
       <footer class="page-footer">
-        <span>Gaia v6.4.12 — <a href="https://github.com/gaia-research/gaia-skill-tree">gaia-research/gaia-skill-tree</a></span>
+        <span>Gaia v6.8.16 — <a href="https://github.com/gaia-research/gaia-skill-tree">gaia-research/gaia-skill-tree</a></span>
         <a href="index.html">← Back to Docs</a>
       </footer>
     </main>

--- a/docs/en/contributing.html
+++ b/docs/en/contributing.html
@@ -765,7 +765,7 @@ gaia dev validate</pre>
           <pre>[basic] parse-csv — add CSV parsing primitive
 [extra] autonomous-debug — compose debug workflow
 [reclassify] web-scrape — promote with new evidence
-[evidence] karpathy/web-scrape — add Class B source
+[evidence] karpathy/web-scrape — add Grade B (Silver) source
 [merge] extract-data ← parse-table + extract-table</pre>
         </div>
       </section>

--- a/docs/en/evidence-classes.html
+++ b/docs/en/evidence-classes.html
@@ -463,29 +463,63 @@
       <p>Always write the full phrase <strong>Evidence Type</strong>; never the bare word "type", which refers to the Basic / Extra / Unique / Ultimate taxonomy field.</p>
       <div class="docs-table-wrap">
         <table class="docs-table">
-          <thead><tr><th>Type value</th><th>What it represents</th><th>URL format</th></tr></thead>
+          <thead><tr><th>Type value</th><th>What it represents</th><th>URL format / flags</th></tr></thead>
           <tbody>
             <tr>
+              <td><span class="type-pill">repo-own</span></td>
+              <td>Artifact volume from the contributor's own repository — commit and contributor counts.</td>
+              <td>Must use <code>blob/branch/subpath</code> — never <code>tree/</code>. Pass <code>--commits</code> / <code>--contributors</code>.</td>
+            </tr>
+            <tr>
+              <td><span class="type-pill">github-stars-own</span></td>
+              <td>Stars on the skill's own repository. Discounted when the repo bundles multiple skills (mothership discount).</td>
+              <td>Bare repo URL: <code>https://github.com/owner/repo</code>. Pass <code>--stars</code> and, if applicable, <code>--skill-count-in-repo</code>.</td>
+            </tr>
+            <tr>
               <td><span class="type-pill">arxiv</span></td>
-              <td>A published academic paper on arXiv demonstrating the capability.</td>
-              <td>Abstract URL: <code>https://arxiv.org/abs/&lt;id&gt;</code> — not the PDF link.</td>
+              <td>Academic citation count for a published paper demonstrating the capability.</td>
+              <td>Abstract URL: <code>https://arxiv.org/abs/&lt;id&gt;</code> — not the PDF link. Pass <code>--citations</code>.</td>
             </tr>
             <tr>
-              <td><span class="type-pill">repo</span></td>
-              <td>A GitHub repository with a <code>SKILL.md</code> at a <code>blob/</code> path.</td>
-              <td>Must use <code>blob/branch/subpath</code> — never <code>tree/</code>. The installer and evidence resolver only accept the blob form.</td>
+              <td><span class="type-pill">peer-review</span></td>
+              <td>Structured walkthrough with written critique by 4★+ reviewers — distinct from a Verifier attestation.</td>
+              <td>URL to the review thread/writeup. Pass <code>--reviewers</code>.</td>
             </tr>
             <tr>
-              <td><span class="type-pill">github-stars</span></td>
-              <td>Repository star count as a secondary proxy for adoption signal.</td>
-              <td>Bare repo URL: <code>https://github.com/owner/repo</code>. Build pipeline reads the live count at build time.</td>
+              <td><span class="type-pill">verifier-attestation</span></td>
+              <td>A 4★+ Verifier signs an attestation that the skill is real and graded fairly.</td>
+              <td>URL to the attestation record. No self-attestation — the evaluator must hold a Verifier-tier Named Skill.</td>
+            </tr>
+            <tr>
+              <td><span class="type-pill">benchmark-result</span></td>
+              <td>A reproducible benchmark on a public dataset, scored as percentile rank within the field.</td>
+              <td>URL to the benchmark/leaderboard entry. Requires a <code>percentile</code> value (0–100) — a raw score alone does not resolve to a magnitude.</td>
+            </tr>
+            <tr>
+              <td><span class="type-pill">fusion-recipe</span></td>
+              <td>Auto-derived for every fused/Ultimate skill from its <code>suiteComponents</code>. Only origins graded ≥C count toward the tally.</td>
+              <td>Not hand-submitted — written by <code>gaia dev fuse</code> / <code>merge</code> when a suite skill is built.</td>
+            </tr>
+            <tr>
+              <td><span class="type-pill">proxy-containment</span></td>
+              <td>The skill's artifact is bundled inside a separately-starred external project.</td>
+              <td>URL to the containing project. Max 3 entries per skill; magnitude plateaus on repeated entries.</td>
+            </tr>
+            <tr>
+              <td><span class="type-pill">social-signal</span></td>
+              <td>Creator/audience evidence — video views, engagement, topical authority from external creators.</td>
+              <td>URL to the video/post. Pass <code>--views</code>; a view-count floor applies before this counts toward any magnitude.</td>
+            </tr>
+            <tr>
+              <td><span class="type-pill">self-attestation</span></td>
+              <td>Contributor declaration that the skill exists and is real. Flat, low magnitude — a placeholder, not proof.</td>
+              <td>Any URL documenting the claim. Max one entry per skill.</td>
             </tr>
           </tbody>
         </table>
       </div>
       <div class="callout info">
-        <p><strong>RFC #654</strong> is tracking additional Evidence Types — community posts, YouTube / social views,
-        and download counts. New types extend <code>meta.json</code> <code>evidence.types</code> without a schema version bump.</p>
+        <p>The full list lives in <code>meta.json</code> → <code>evidence.types</code>, alongside the magnitude formula and cap for each. New types extend that list without a schema version bump.</p>
       </div>
 
       <h2 id="evidence-grade">Evidence Grade</h2>
@@ -498,11 +532,11 @@
       </p>
 
       <div class="trust-meter">
-        <div class="trust-segment seg-S"><span>S</span><span class="seg-name">Platinum</span><span class="seg-range">≥ 90</span></div>
-        <div class="trust-segment seg-A"><span>A</span><span class="seg-name">Gold</span><span class="seg-range">≥ 80</span></div>
-        <div class="trust-segment seg-B"><span>B</span><span class="seg-name">Silver</span><span class="seg-range">≥ 60</span></div>
-        <div class="trust-segment seg-C"><span>C</span><span class="seg-name">Bronze</span><span class="seg-range">≥ 40</span></div>
-        <div class="trust-segment seg-U"><span>—</span><span class="seg-name">Ungraded</span><span class="seg-range">&lt; 40</span></div>
+        <div class="trust-segment seg-S"><span>S</span><span class="seg-name">Platinum</span><span class="seg-range">≥ 250</span></div>
+        <div class="trust-segment seg-A"><span>A</span><span class="seg-name">Gold</span><span class="seg-range">≥ 100</span></div>
+        <div class="trust-segment seg-B"><span>B</span><span class="seg-name">Silver</span><span class="seg-range">≥ 50</span></div>
+        <div class="trust-segment seg-C"><span>C</span><span class="seg-name">Bronze</span><span class="seg-range">≥ 20</span></div>
+        <div class="trust-segment seg-U"><span>—</span><span class="seg-name">Ungraded</span><span class="seg-range">&lt; 20</span></div>
       </div>
 
       <div class="docs-table-wrap">
@@ -510,23 +544,23 @@
           <thead><tr><th>Grade</th><th>Label</th><th>Trust #</th><th>What qualifies</th></tr></thead>
           <tbody>
             <tr>
-              <td><span class="grade grade-S">S</span></td><td>Platinum</td><td>≥ 90</td>
+              <td><span class="grade grade-S">S</span></td><td>Platinum</td><td>≥ 250</td>
               <td>Definitive, peer-reviewed, widely-cited evidence. Reserved for capabilities established beyond reasonable doubt in literature — extremely rare.</td>
             </tr>
             <tr>
-              <td><span class="grade grade-A">A</span></td><td>Gold</td><td>≥ 80</td>
+              <td><span class="grade grade-A">A</span></td><td>Gold</td><td>≥ 100</td>
               <td>Battle-tested in production; corroborated by multiple independent sources. A library with 10k+ stars backed by a SKILL.md and a supporting paper qualifies.</td>
             </tr>
             <tr>
-              <td><span class="grade grade-B">B</span></td><td>Silver</td><td>≥ 60</td>
+              <td><span class="grade grade-B">B</span></td><td>Silver</td><td>≥ 50</td>
               <td>Reproducible and documented. A SKILL.md with working examples and a verifiable demo at 100+ stars typically lands here.</td>
             </tr>
             <tr>
-              <td><span class="grade grade-C">C</span></td><td>Bronze</td><td>≥ 40</td>
+              <td><span class="grade grade-C">C</span></td><td>Bronze</td><td>≥ 20</td>
               <td>First sighting — observed at least once, basic documentation present. The minimum to count toward Named (2★) status.</td>
             </tr>
             <tr>
-              <td><span class="grade grade-U">—</span></td><td>Ungraded</td><td>&lt; 40</td>
+              <td><span class="grade grade-U">—</span></td><td>Ungraded</td><td>&lt; 20</td>
               <td>On the record but does not count toward any star gate. Useful for logging an observation without making a quality claim.</td>
             </tr>
           </tbody>
@@ -595,38 +629,40 @@
         <pre><span class="cmd">gaia dev evidence</span> <span class="val">registry-curation</span> <span class="str">"https://github.com/owner/repo/blob/main/skills/foo/SKILL.md"</span> <span class="flag">--class</span> B</pre>
       </div>
 
-      <h3>New form (Type + Grade)</h3>
+      <h3>New form (Type + Trust)</h3>
+      <p>
+        Grade is never set directly — it is <em>auto-derived</em> from the <code>--trust</code> number you pass
+        (S≥250, A≥100, B≥50, C≥20; below 20 the entry stays on record but ungraded).
+      </p>
       <div class="code-block">
         <div class="code-block-header"><span class="code-block-label">shell</span></div>
-        <pre><span class="c"># repo evidence at Grade B (Silver) — always use blob/, not tree/</span>
+        <pre><span class="c"># repo-own evidence, trust 50 → Grade B (Silver) — always use blob/, not tree/</span>
 <span class="cmd">gaia dev evidence</span> <span class="val">registry-curation</span> <span class="str">"https://github.com/owner/repo/blob/main/skills/foo/SKILL.md"</span> \
-  <span class="flag">--type</span> repo \
-  <span class="flag">--grade</span> B
+  <span class="flag">--type</span> repo-own \
+  <span class="flag">--trust</span> 50 \
+  <span class="flag">--commits</span> 400 <span class="flag">--contributors</span> 6
 
-<span class="c"># arXiv paper at Grade A (Gold)</span>
+<span class="c"># arXiv paper, trust 100 → Grade A (Gold)</span>
 <span class="cmd">gaia dev evidence</span> <span class="val">multimodal-reasoning</span> <span class="str">"https://arxiv.org/abs/2504.00001"</span> \
   <span class="flag">--type</span> arxiv \
-  <span class="flag">--grade</span> A
+  <span class="flag">--trust</span> 100 \
+  <span class="flag">--citations</span> 500
 
-<span class="c"># always dry-run first</span>
-<span class="cmd">gaia dev evidence</span> <span class="val">multimodal-reasoning</span> <span class="str">"https://arxiv.org/abs/2504.00001"</span> \
-  <span class="flag">--type</span> arxiv <span class="flag">--grade</span> A <span class="flag">--dry-run</span>
-
-<span class="c"># verify an entry (Verifier-only)</span>
-<span class="cmd">gaia dev evidence</span> <span class="val">registry-curation</span> <span class="flag">--verify</span> <span class="str">"https://github.com/owner/repo/blob/main/skills/foo/SKILL.md"</span>
+<span class="c"># verify an entry (Verifier-only — a separate subcommand, not a flag on `evidence`)</span>
+<span class="cmd">gaia dev verify</span> <span class="val">registry-curation</span> <span class="flag">--index</span> 0
 
 <span class="c"># dispute an entry (Verifier-only)</span>
-<span class="cmd">gaia dev evidence</span> <span class="val">registry-curation</span> <span class="flag">--dispute</span> <span class="str">"https://github.com/owner/repo/blob/main/skills/foo/SKILL.md"</span></pre>
+<span class="cmd">gaia dev verify</span> <span class="val">registry-curation</span> <span class="flag">--index</span> 0 <span class="flag">--dispute</span></pre>
       </div>
       <div class="callout warn">
-        <p><strong>Always run <code>--dry-run</code> first.</strong> Evidence writes directly to a registry node. A bad URL or wrong skill ID produces invalid JSON that will fail CI.</p>
+        <p><strong>Check <code>gaia whoami</code> before writing.</strong> Evidence writes directly to a registry node under Verifier authorization — a bad URL or wrong skill ID produces invalid JSON that will fail CI. Pass <code>--no-build</code> to skip the doc/graph rebuild while iterating.</p>
       </div>
 
       <h3>URL format rules per type</h3>
       <ul>
-        <li><strong><code>repo</code>:</strong> Use <code>blob/branch/subpath</code>. GitHub directory URLs use <code>tree/</code> — convert manually. The resolver rejects <code>tree/</code> with a schema error.</li>
+        <li><strong><code>repo-own</code>:</strong> Use <code>blob/branch/subpath</code>. GitHub directory URLs use <code>tree/</code> — convert manually. The resolver rejects <code>tree/</code> with a schema error.</li>
         <li><strong><code>arxiv</code>:</strong> Use the abstract URL (<code>https://arxiv.org/abs/&lt;id&gt;</code>), not the PDF link. The build pipeline normalises to the abstract for deduplication.</li>
-        <li><strong><code>github-stars</code>:</strong> Bare repo URL (<code>https://github.com/owner/repo</code>). Star count is read live at build time.</li>
+        <li><strong><code>github-stars-own</code>:</strong> Bare repo URL (<code>https://github.com/owner/repo</code>). Star count is read live at build time.</li>
       </ul>
 
       <h2 id="migration">Migration Guide</h2>
@@ -641,13 +677,13 @@
           <tbody>
             <tr>
               <td><code>class: C</code></td>
-              <td><span class="type-pill">repo</span></td>
+              <td><span class="type-pill">repo-own</span></td>
               <td><span class="grade grade-C">C</span> Bronze</td>
               <td>First sighting. Verify the URL still resolves before converting.</td>
             </tr>
             <tr>
               <td><code>class: B</code></td>
-              <td><span class="type-pill">repo</span></td>
+              <td><span class="type-pill">repo-own</span></td>
               <td><span class="grade grade-C">C</span> – <span class="grade grade-B">B</span></td>
               <td>Grade B if repo has examples + demos + ≥100 stars. Grade C if thin. Check star count at migration time.</td>
             </tr>
@@ -659,7 +695,7 @@
             </tr>
             <tr>
               <td><code>class: A</code> (repo)</td>
-              <td><span class="type-pill">repo</span> + <span class="type-pill">github-stars</span></td>
+              <td><span class="type-pill">repo-own</span> + <span class="type-pill">github-stars-own</span></td>
               <td><span class="grade grade-A">A</span> – <span class="grade grade-S">S</span></td>
               <td>Battle-tested repos (10k+ stars, independent reproductions). Verify evidence still exists before upgrading.</td>
             </tr>
@@ -681,7 +717,7 @@
             <tr><td><code>C</code></td><td>First sighting</td><td><span class="grade grade-C">C</span> Bronze</td><td>Closest mapping — both mean first sighting.</td></tr>
             <tr><td><code>B</code></td><td>Reproducible</td><td><span class="grade grade-B">B</span> Silver</td><td>Similar concept, but Grade B requires a higher trust number than Class B implied.</td></tr>
             <tr><td><code>A</code></td><td>Battle-tested, peer-reviewed</td><td><span class="grade grade-A">A</span> Gold</td><td>Class A was the top of a 3-rung ladder. Grade A is second-highest on a 5-rung ladder. Converting 1:1 is a downgrade for some skills, an upgrade for others.</td></tr>
-            <tr><td class="muted">—</td><td class="muted">(no equivalent)</td><td><span class="grade grade-S">S</span> Platinum</td><td>Grade S (≥ 90) has no Class equivalent — it represents certainty that Class A rarely achieved.</td></tr>
+            <tr><td class="muted">—</td><td class="muted">(no equivalent)</td><td><span class="grade grade-S">S</span> Platinum</td><td>Grade S (≥ 250) has no Class equivalent — it represents certainty that Class A rarely achieved.</td></tr>
           </tbody>
         </table>
       </div>
@@ -689,11 +725,11 @@
       <h3>Using <code>tree/</code> instead of <code>blob/</code></h3>
       <p>GitHub's directory view uses <code>tree/branch/path</code>. The evidence resolver and installer only accept <code>blob/branch/path</code>. The CLI rejects <code>tree/</code> URLs with a schema error.</p>
 
-      <h3>Using <code>github-stars</code> as sole evidence</h3>
-      <p>Star counts are volatile and subject to farming. Never use <code>github-stars</code> as the sole evidence for a skill — always pair it with at least one <code>repo</code> entry pointing to a SKILL.md.</p>
+      <h3>Using <code>github-stars-own</code> as sole evidence</h3>
+      <p>Star counts are volatile and subject to farming. Never use <code>github-stars-own</code> as the sole evidence for a skill — always pair it with at least one <code>repo-own</code> entry pointing to a SKILL.md.</p>
 
-      <h3>Skipping <code>--dry-run</code></h3>
-      <p><code>gaia dev evidence</code> writes directly to a registry node under Programmatic-First rules. A bad URL or wrong skill ID writes invalid JSON that CI will fail on. Run <code>--dry-run</code> every time before committing.</p>
+      <h3>Passing <code>--grade</code> instead of <code>--trust</code></h3>
+      <p><code>gaia dev evidence</code> has no <code>--grade</code> flag — Grade is always auto-derived from the <code>--trust</code> number you supply (see thresholds above). There is also no <code>--dry-run</code> mode for this subcommand; it writes directly to the registry node under Verifier authorization, so confirm the skill ID and URL before running it. Pass <code>--no-build</code> to skip the doc/graph rebuild while iterating.</p>
 
     </main>
   </div>

--- a/docs/en/evidence-classes.html
+++ b/docs/en/evidence-classes.html
@@ -367,20 +367,21 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
+  <!-- nav -->
   <nav class="docs-nav">
-    <a href="../index.html" class="docs-nav-logo">Gaia <span>◆</span></a>
-    <span class="docs-nav-sep">/</span>
-    <a href="index.html" class="docs-nav-link">Docs</a>
-    <span class="docs-nav-sep">/</span>
-    <span class="docs-nav-link active">Evidence &amp; Trust</span>
-    <div class="docs-nav-spacer"></div>
-    <span class="docs-nav-version" id="ver">v6.4.12</span>
+    <a href="../index.html" class="nav-logo">Gaia <span>◆</span></a>
+    <span class="nav-sep">/</span>
+    <a href="index.html" class="nav-crumb">Docs</a>
+    <span class="nav-sep">/</span>
+    <span class="nav-crumb current">Evidence Classes</span>
+    <span class="nav-spacer"></span>
+    <span class="docs-nav-version" id="ver">v6.8.16</span>
   </nav>
 
   <div class="docs-layout">

--- a/docs/en/faq.html
+++ b/docs/en/faq.html
@@ -494,22 +494,22 @@
                   <tr style="border-bottom:1px solid rgba(30,41,59,0.5);">
                     <td style="padding:0.45rem 0.6rem; color:var(--text,#e2e8f0);">1★</td>
                     <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Awakened</td>
-                    <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">First sighting / Class C evidence</td>
+                    <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">First sighting / Grade C (Bronze) evidence</td>
                   </tr>
                   <tr style="border-bottom:1px solid rgba(30,41,59,0.5);">
                     <td style="padding:0.45rem 0.6rem; color:var(--text,#e2e8f0);">2★</td>
                     <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Named</td>
-                    <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Claimed by a real contributor (Class C+ evidence)</td>
+                    <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Claimed by a real contributor (Grade C+ evidence)</td>
                   </tr>
                   <tr style="border-bottom:1px solid rgba(30,41,59,0.5);">
                     <td style="padding:0.45rem 0.6rem; color:var(--text,#e2e8f0);">3★</td>
                     <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Evolved</td>
-                    <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Reproducible evidence (Class B)</td>
+                    <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Reproducible evidence (Grade B / Silver)</td>
                   </tr>
                   <tr style="border-bottom:1px solid rgba(30,41,59,0.5);">
                     <td style="padding:0.45rem 0.6rem; color:var(--text,#e2e8f0);">4★</td>
                     <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Hardened</td>
-                    <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Verifier threshold — peer-reviewed or battle-tested (Class A)</td>
+                    <td style="padding:0.45rem 0.6rem; color:var(--muted,#64748b);">Verifier threshold — peer-reviewed or battle-tested (Grade A / Gold)</td>
                   </tr>
                   <tr style="border-bottom:1px solid rgba(30,41,59,0.5);">
                     <td style="padding:0.45rem 0.6rem; color:var(--text,#e2e8f0);">5★</td>

--- a/docs/en/faq.html
+++ b/docs/en/faq.html
@@ -252,9 +252,9 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
@@ -266,7 +266,7 @@
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">FAQ</span>
     <span class="nav-spacer"></span>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <div class="page-layout">
@@ -907,7 +907,7 @@
     <div class="footer-bottom">
       <span>MIT License</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>v6.4.12</span>
+      <span>v6.8.16</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
       <span>© 2026 Gaia</span>
     </div>

--- a/docs/en/faq.html
+++ b/docs/en/faq.html
@@ -567,7 +567,7 @@
               </div>
               <ul>
                 <li><strong>Evidence Class (legacy)</strong> — provenance tier. <code>C</code> = first sighting; <code>B</code> = reproducible; <code>A</code> = battle-tested, peer-reviewed. Added via <code>--class C|B|A</code>.</li>
-                <li><strong>Evidence Grade (new)</strong> — trust score tier, auto-derived from a trust number. <code>S</code> ≥ 250; <code>A</code> ≥ 100; <code>B</code> ≥ 50; <code>C</code> ≥ 20. Added via <code>--trust &lt;number&gt;</code> (there is no <code>--grade</code> flag). Paired with an <strong>Evidence Type</strong> (<code>arxiv</code>, <code>repo-own</code>, <code>github-stars-own</code>, etc.) added via <code>--type</code>.</li>
+                <li><strong>Evidence Grade (new)</strong> — quality tier, auto-derived from a trust number. <code>S</code> ≥ 250; <code>A</code> ≥ 100; <code>B</code> ≥ 50; <code>C</code> ≥ 20. Added via <code>--trust &lt;number&gt;</code> (there is no <code>--grade</code> flag). Paired with an <strong>Evidence Type</strong> (<code>arxiv</code>, <code>repo-own</code>, <code>github-stars-own</code>, etc.) added via <code>--type</code>.</li>
               </ul>
               <p>
                 The overall <strong>Trust Grade</strong> per skill is aggregated from all grade entries at build time.

--- a/docs/en/faq.html
+++ b/docs/en/faq.html
@@ -567,7 +567,7 @@
               </div>
               <ul>
                 <li><strong>Evidence Class (legacy)</strong> — provenance tier. <code>C</code> = first sighting; <code>B</code> = reproducible; <code>A</code> = battle-tested, peer-reviewed. Added via <code>--class C|B|A</code>.</li>
-                <li><strong>Evidence Grade (new)</strong> — trust score tier. <code>S</code> ≥ 90; <code>A</code> ≥ 80; <code>B</code> ≥ 60; <code>C</code> ≥ 40. Added via <code>--grade S|A|B|C</code>. Paired with a <strong>Grade Type</strong> (arxiv, repo, github-stars, etc.) added via <code>--type</code>.</li>
+                <li><strong>Evidence Grade (new)</strong> — trust score tier, auto-derived from a trust number. <code>S</code> ≥ 250; <code>A</code> ≥ 100; <code>B</code> ≥ 50; <code>C</code> ≥ 20. Added via <code>--trust &lt;number&gt;</code> (there is no <code>--grade</code> flag). Paired with an <strong>Evidence Type</strong> (<code>arxiv</code>, <code>repo-own</code>, <code>github-stars-own</code>, etc.) added via <code>--type</code>.</li>
               </ul>
               <p>
                 The overall <strong>Trust Grade</strong> per skill is aggregated from all grade entries at build time.

--- a/docs/en/fusion.html
+++ b/docs/en/fusion.html
@@ -514,9 +514,9 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
@@ -528,7 +528,7 @@
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">Skill Fusion</span>
     <div class="nav-spacer"></div>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <div class="page-layout">
@@ -1033,7 +1033,7 @@
     <div class="footer-bottom">
       <span>MIT License</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>v6.4.12</span>
+      <span>v6.8.16</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
       <span>© 2026 Gaia</span>
     </div>

--- a/docs/en/fusion.html
+++ b/docs/en/fusion.html
@@ -834,7 +834,7 @@
             <li>A clearly named target skill (Extra or Ultimate) that does not yet exist in the registry.</li>
             <li>At least two source skill IDs already present in the registry.</li>
             <li>An argument for why the combination produces a qualitatively new emergent capability.</li>
-            <li>At least one piece of Class C evidence or better attached to the proposed target.</li>
+            <li>At least one piece of Grade C (Bronze) evidence or better attached to the proposed target.</li>
           </ul>
           <p>
             The workflow is a <code>gaia push</code> with a new skill batch, followed by a PR

--- a/docs/en/getting-started.html
+++ b/docs/en/getting-started.html
@@ -496,21 +496,21 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
-  <!-- ── NAV ── -->
+  <!-- Nav -->
   <nav class="docs-nav">
-    <a href="../index.html" class="nav-logo">Gaia <span>◆</span></a>
+    <a class="nav-logo" href="../index.html">Gaia <span>◆</span></a>
     <span class="nav-sep">/</span>
-    <a href="index.html" class="nav-crumb">Docs</a>
+    <a class="nav-crumb" href="index.html">Docs</a>
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">Getting Started</span>
-    <div class="nav-spacer"></div>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-spacer"></span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <div class="page-layout">
@@ -636,7 +636,7 @@
         <div class="code-fence">
           <div class="code-fence-header"><span class="code-fence-label">shell</span></div>
           <pre><span class="cmd">gaia --version</span>
-<span class="c"># gaia 6.4.12</span></pre>
+<span class="c"># gaia 6.8.16</span></pre>
         </div>
 
         <div class="callout info" style="margin-top:0.85rem;">

--- a/docs/en/getting-started.html
+++ b/docs/en/getting-started.html
@@ -894,7 +894,7 @@
         <h3>Named Skills and origin</h3>
 
         <p>A <strong>Named Skill</strong> is a canonical skill claimed by a real contributor
-        with Class C evidence or better. At the moment of naming, the skill reaches 2★.
+        with Grade C (Bronze) evidence or better. At the moment of naming, the skill reaches 2★.
         Your handle appears in <strong>honor red</strong> on the registry page as the
         Origin Contributor.</p>
 

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -385,19 +385,17 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
-
-
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
   <!-- nav -->
   <nav class="docs-nav">
-    <a href="../index.html" class="docs-nav-logo">Gaia <span>◆</span></a>
-    <span class="docs-nav-sep">/</span>
-    <a href="index.html" class="docs-nav-link active">Docs</a>
-    <div class="docs-nav-spacer"></div>
-    <span class="docs-nav-version" id="ver">v6.4.12</span>
+    <a href="../index.html" class="nav-logo">Gaia <span>◆</span></a>
+    <span class="nav-sep">/</span>
+    <span class="nav-crumb current">Docs</span>
+    <span class="nav-spacer"></span>
+    <span class="docs-nav-version" id="ver">v6.8.16</span>
   </nav>
 
   <!-- hero -->
@@ -413,12 +411,12 @@
   <!-- what's new -->
   <div class="whats-new">
     <div class="whats-new-inner">
-      <span class="whats-new-tag">v6.4.12</span>
+      <span class="whats-new-tag">v6.8.16</span>
       <span class="whats-new-text">
-        <strong>Upstream watch & Agent shortcuts.</strong>
-        Gaia v6.4.12 adds upstream tracking with <code>gaia dev sync-upstream</code> and <code>gaia dev freeze</code>. Use <code>python -m gaia_cli</code> in blocked environments. Read <code>AGENTS.md</code> at the repo root for the fast-path intake guide.
+        <strong>Official MCP package & AGENTS.md entry.</strong>
+        Gaia v6.8.16 updates the official MCP server package to <code>@gaia-research/mcp@0.1.0</code> and documents the root <code>AGENTS.md</code> discovery surface for fast AI agent intake.
       </span>
-      <a class="whats-new-link" href="getting-started.html">Read the guide →</a>
+      <a class="whats-new-link" href="mcp-server.html">Read the guide →</a>
     </div>
   </div>
 
@@ -486,7 +484,7 @@
     <a class="docs-card" href="mcp-server.html">
       <span class="docs-card-icon">🔌</span>
       <span class="docs-card-title">MCP Server</span>
-      <span class="docs-card-desc">Use <code>@gaia-registry/mcp-server</code> to give any MCP-compatible agent access to the skill graph at runtime.</span>
+      <span class="docs-card-desc">Use <code>@gaia-research/mcp@0.1.0</code> to give any MCP-compatible agent access to the skill graph at runtime.</span>
       <span class="docs-card-badge new">● New</span>
     </a>
     <a class="docs-card" href="share-bundles.html">
@@ -610,7 +608,7 @@
     <div class="footer-bottom">
       <span>MIT License</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v6.4.12</span>
+      <span id="footerVersion">v6.8.16</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
       <span>© 2026 Gaia</span>
     </div>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -414,7 +414,7 @@
       <span class="whats-new-tag">v6.8.16</span>
       <span class="whats-new-text">
         <strong>Official MCP package & AGENTS.md entry.</strong>
-        Gaia v6.8.16 updates the official MCP server package to <code>@gaia-research/mcp@0.1.0</code> and documents the root <code>AGENTS.md</code> discovery surface for fast AI agent intake.
+        Gaia v6.8.16 updates the official MCP server package to <code>@gaia-registry/mcp-server</code> and documents the root <code>AGENTS.md</code> discovery surface for fast AI agent intake.
       </span>
       <a class="whats-new-link" href="mcp-server.html">Read the guide →</a>
     </div>
@@ -484,7 +484,7 @@
     <a class="docs-card" href="mcp-server.html">
       <span class="docs-card-icon">🔌</span>
       <span class="docs-card-title">MCP Server</span>
-      <span class="docs-card-desc">Use <code>@gaia-research/mcp@0.1.0</code> to give any MCP-compatible agent access to the skill graph at runtime.</span>
+      <span class="docs-card-desc">Use <code>@gaia-registry/mcp-server</code> to give any MCP-compatible agent access to the skill graph at runtime.</span>
       <span class="docs-card-badge new">● New</span>
     </a>
     <a class="docs-card" href="share-bundles.html">

--- a/docs/en/mcp-server.html
+++ b/docs/en/mcp-server.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MCP Server — Gaia Docs</title>
-  <meta name="description" content="@gaia-registry/mcp-server: connect Gaia to Claude Code, Cursor, VS Code, and any MCP-compatible agent. Tool reference, configuration, and known issues.">
+  <meta name="description" content="@gaia-research/mcp@0.1.0: connect Gaia to Claude Code, Cursor, VS Code, and any MCP-compatible agent. Tool reference, configuration, and known issues.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
@@ -489,9 +489,9 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
@@ -503,7 +503,7 @@
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">MCP Server</span>
     <span class="nav-spacer"></span>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <div class="page-layout">
@@ -544,7 +544,7 @@
 
     <!-- main -->
     <main class="main-content">
-      <div class="page-badge">● @gaia-registry/mcp-server · v6.4.12</div>
+      <div class="page-badge">● @gaia-research/mcp@0.1.0 · v6.8.16</div>
       <h1 class="page-title">MCP Server</h1>
       <p class="page-lead">
         Connect Gaia to any MCP-compatible agent — Claude Code, Claude Desktop, Cursor,
@@ -557,7 +557,7 @@
         <h2 class="section-title">Overview</h2>
         <div class="section-body">
           <p>
-            <code>@gaia-registry/mcp-server</code> is a
+            <code>@gaia-research/mcp@0.1.0</code> is a
             <a href="https://modelcontextprotocol.io" rel="noopener" target="_blank">Model Context Protocol</a>
             server that exposes Gaia's registry to your AI agent at inference time.
             Instead of copying skill IDs into prompts, the agent calls structured tools
@@ -575,7 +575,7 @@
         <div class="callout callout-info">
           <span class="callout-label">💡 Quick start</span>
           <p>Using Claude Code? Run one command and you're done:</p>
-          <p><code>claude mcp add gaia -- npx @gaia-registry/mcp-server</code></p>
+          <p><code>claude mcp add gaia -- npx -y @gaia-research/mcp@0.1.0</code></p>
           <p>Then ask: <em>"Use gaia_lookup to find the rag-pipeline skill."</em></p>
         </div>
       </section>
@@ -585,7 +585,7 @@
         <h2 class="section-title">Installation</h2>
         <div class="section-body">
           <p>
-            The universal install shape is <code>npx @gaia-registry/mcp-server</code>
+            The universal install shape is <code>npx -y @gaia-research/mcp@0.1.0</code>
             with an optional <code>GAIA_USER</code> env var set to your GitHub username.
             Platform specifics follow.
           </p>
@@ -609,10 +609,10 @@
           <div class="code-block">
             <div class="code-block-header"><span class="code-block-label">bash</span></div>
             <pre><span class="c"># project-local (adds to .claude/settings.json)</span>
-<span class="cmd">claude mcp add gaia</span> -- npx @gaia-registry/mcp-server
+<span class="cmd">claude mcp add gaia</span> -- npx -y @gaia-research/mcp@0.1.0
 
 <span class="c"># global (available in every project)</span>
-<span class="cmd">claude mcp add gaia</span> --global -- npx @gaia-registry/mcp-server</pre>
+<span class="cmd">claude mcp add gaia</span> --global -- npx -y @gaia-research/mcp@0.1.0</pre>
           </div>
           <div class="section-body">
             <p>To pass <code>GAIA_USER</code> and <code>GITHUB_TOKEN</code>, edit <code>.claude/settings.json</code> directly:</p>
@@ -623,7 +623,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>,
         <span class="str">"GITHUB_TOKEN"</span>: <span class="str">"ghp_..."</span>
@@ -662,7 +662,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>
       }
@@ -688,7 +688,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>
       }
@@ -714,7 +714,7 @@
   <span class="str">"servers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>
       }
@@ -732,7 +732,7 @@
     <span class="str">"servers"</span>: {
       <span class="str">"gaia"</span>: {
         <span class="str">"command"</span>: <span class="str">"npx"</span>,
-        <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+        <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
         <span class="str">"env"</span>: { <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span> }
       }
     }
@@ -753,7 +753,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
       <span class="str">"env"</span>: { <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span> }
     }
   }
@@ -774,7 +774,7 @@
             <div class="code-block-header"><span class="code-block-label">universal shape</span></div>
             <pre>{
   <span class="str">"command"</span>: <span class="str">"npx"</span>,
-  <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
+  <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
   <span class="str">"env"</span>: {
     <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>,
     <span class="str">"GITHUB_TOKEN"</span>: <span class="str">"ghp_..."</span>   <span class="c">// required for gaia_propose</span>
@@ -1163,7 +1163,7 @@
     <div class="footer-bottom">
       <span>MIT License</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>v6.4.12</span>
+      <span>v6.8.16</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
       <span>© 2026 Gaia</span>
     </div>

--- a/docs/en/mcp-server.html
+++ b/docs/en/mcp-server.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MCP Server — Gaia Docs</title>
-  <meta name="description" content="@gaia-research/mcp@0.1.0: connect Gaia to Claude Code, Cursor, VS Code, and any MCP-compatible agent. Tool reference, configuration, and known issues.">
+  <meta name="description" content="@gaia-registry/mcp-server: connect Gaia to Claude Code, Cursor, VS Code, and any MCP-compatible agent. Tool reference, configuration, and known issues.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
@@ -544,7 +544,7 @@
 
     <!-- main -->
     <main class="main-content">
-      <div class="page-badge">● @gaia-research/mcp@0.1.0 · v6.8.16</div>
+      <div class="page-badge">● @gaia-registry/mcp-server · v6.8.16</div>
       <h1 class="page-title">MCP Server</h1>
       <p class="page-lead">
         Connect Gaia to any MCP-compatible agent — Claude Code, Claude Desktop, Cursor,
@@ -557,7 +557,7 @@
         <h2 class="section-title">Overview</h2>
         <div class="section-body">
           <p>
-            <code>@gaia-research/mcp@0.1.0</code> is a
+            <code>@gaia-registry/mcp-server</code> is a
             <a href="https://modelcontextprotocol.io" rel="noopener" target="_blank">Model Context Protocol</a>
             server that exposes Gaia's registry to your AI agent at inference time.
             Instead of copying skill IDs into prompts, the agent calls structured tools
@@ -575,7 +575,7 @@
         <div class="callout callout-info">
           <span class="callout-label">💡 Quick start</span>
           <p>Using Claude Code? Run one command and you're done:</p>
-          <p><code>claude mcp add gaia -- npx -y @gaia-research/mcp@0.1.0</code></p>
+          <p><code>claude mcp add gaia -- npx @gaia-registry/mcp-server</code></p>
           <p>Then ask: <em>"Use gaia_lookup to find the rag-pipeline skill."</em></p>
         </div>
       </section>
@@ -585,7 +585,7 @@
         <h2 class="section-title">Installation</h2>
         <div class="section-body">
           <p>
-            The universal install shape is <code>npx -y @gaia-research/mcp@0.1.0</code>
+            The universal install shape is <code>npx @gaia-registry/mcp-server</code>
             with an optional <code>GAIA_USER</code> env var set to your GitHub username.
             Platform specifics follow.
           </p>
@@ -609,10 +609,10 @@
           <div class="code-block">
             <div class="code-block-header"><span class="code-block-label">bash</span></div>
             <pre><span class="c"># project-local (adds to .claude/settings.json)</span>
-<span class="cmd">claude mcp add gaia</span> -- npx -y @gaia-research/mcp@0.1.0
+<span class="cmd">claude mcp add gaia</span> -- npx @gaia-registry/mcp-server
 
 <span class="c"># global (available in every project)</span>
-<span class="cmd">claude mcp add gaia</span> --global -- npx -y @gaia-research/mcp@0.1.0</pre>
+<span class="cmd">claude mcp add gaia</span> --global -- npx @gaia-registry/mcp-server</pre>
           </div>
           <div class="section-body">
             <p>To pass <code>GAIA_USER</code> and <code>GITHUB_TOKEN</code>, edit <code>.claude/settings.json</code> directly:</p>
@@ -623,7 +623,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>,
         <span class="str">"GITHUB_TOKEN"</span>: <span class="str">"ghp_..."</span>
@@ -662,7 +662,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>
       }
@@ -688,7 +688,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>
       }
@@ -714,7 +714,7 @@
   <span class="str">"servers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
       <span class="str">"env"</span>: {
         <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>
       }
@@ -732,7 +732,7 @@
     <span class="str">"servers"</span>: {
       <span class="str">"gaia"</span>: {
         <span class="str">"command"</span>: <span class="str">"npx"</span>,
-        <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
+        <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
         <span class="str">"env"</span>: { <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span> }
       }
     }
@@ -753,7 +753,7 @@
   <span class="str">"mcpServers"</span>: {
     <span class="str">"gaia"</span>: {
       <span class="str">"command"</span>: <span class="str">"npx"</span>,
-      <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
+      <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
       <span class="str">"env"</span>: { <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span> }
     }
   }
@@ -774,7 +774,7 @@
             <div class="code-block-header"><span class="code-block-label">universal shape</span></div>
             <pre>{
   <span class="str">"command"</span>: <span class="str">"npx"</span>,
-  <span class="str">"args"</span>: [<span class="str">"-y"</span>, <span class="str">"@gaia-research/mcp@0.1.0"</span>],
+  <span class="str">"args"</span>: [<span class="str">"@gaia-registry/mcp-server"</span>],
   <span class="str">"env"</span>: {
     <span class="str">"GAIA_USER"</span>: <span class="str">"your-github-username"</span>,
     <span class="str">"GITHUB_TOKEN"</span>: <span class="str">"ghp_..."</span>   <span class="c">// required for gaia_propose</span>

--- a/docs/en/named-skills.html
+++ b/docs/en/named-skills.html
@@ -647,7 +647,7 @@
       <section class="section" id="what-is">
         <h2 class="section-title">What is a Named Skill?</h2>
         <div class="section-body">
-          <p>A <strong>Named Skill</strong> is a canonical registry skill that has been claimed by a real contributor with at least Class C evidence (first sighting). At the moment of naming, the skill ranks up to <strong>2★ (Named)</strong> and the contributor becomes its <strong>Origin Contributor</strong> — a permanent, auditable record in the graph.</p>
+          <p>A <strong>Named Skill</strong> is a canonical registry skill that has been claimed by a real contributor with at least Grade C (Bronze) evidence. At the moment of naming, the skill ranks up to <strong>2★ (Named)</strong> and the contributor becomes its <strong>Origin Contributor</strong> — a permanent, auditable record in the graph.</p>
           <p>Named Skills display in <strong style="color:#dc2626;">honor red</strong> in the CLI and the Atlas. The Origin Contributor field is one-per-skill and immutable after the naming PR merges — re-attribution requires a maintainer decision with a timeline event.</p>
         </div>
 
@@ -671,7 +671,7 @@
               <li>A taxonomy node — a slot in the capability graph</li>
               <li>Carries <strong>no stars of its own</strong>; stars live only on its named children</li>
               <li><strong>Effective rank</strong> = highest star among named implementations</li>
-              <li>Holds capability-level (Class A / academic) evidence that all named children inherit</li>
+              <li>Holds capability-level (Grade A / academic) evidence that all named children inherit</li>
               <li>Renders as <em>generic</em>, italic, greyed-out in the UI</li>
               <li>Created via <code>gaia dev add</code>, no contributor required</li>
             </ul>
@@ -685,7 +685,7 @@
               <li>Carries implementation-specific evidence on top of the inherited base</li>
               <li>Has a SKILL.md at a public GitHub URL (<code>links.github</code>)</li>
               <li>Renders with contributor name in honor red</li>
-              <li>Created via naming PR — contributor must have Class C evidence or better</li>
+              <li>Created via naming PR — contributor must have Grade C (Bronze) evidence or better</li>
             </ul>
           </div>
         </div>
@@ -769,8 +769,8 @@ links:
             <div class="lifecycle-num">3</div>
             <div class="lifecycle-body">
               <div class="lifecycle-rank rank-2">2★ — Named</div>
-              <div class="lifecycle-title">Claimed with Class C evidence</div>
-              <div class="lifecycle-desc">A contributor opens a naming PR with at least <strong>Class C evidence</strong> (first sighting — a <code>SKILL.md</code> at a public URL). The PR creates or updates <code>registry/named/&lt;contributor&gt;/&lt;skill-name&gt;.md</code> with <code>origin: true</code> and <code>level: "2★"</code>. The contributor becomes the Origin Contributor permanently.</div>
+              <div class="lifecycle-title">Claimed with Grade C (Bronze) evidence</div>
+              <div class="lifecycle-desc">A contributor opens a naming PR with at least <strong>Grade C (Bronze) evidence</strong> (a <code>SKILL.md</code> at a public URL). The PR creates or updates <code>registry/named/&lt;contributor&gt;/&lt;skill-name&gt;.md</code> with <code>origin: true</code> and <code>level: "2★"</code>. The contributor becomes the Origin Contributor permanently.</div>
             </div>
           </div>
           <div class="lifecycle-step">
@@ -778,7 +778,7 @@ links:
             <div class="lifecycle-body">
               <div class="lifecycle-rank rank-3">3★ — Evolved</div>
               <div class="lifecycle-title">Reproducible evidence added</div>
-              <div class="lifecycle-desc">The contributor adds <strong>Class B evidence</strong> — a reproducible, documented demonstration. The PR runs <code>gaia dev evidence skill-id "url" --class B</code> and calibrates to 3★. A <code>links.github</code> URL pointing to a public repository is mandatory at this level.</div>
+              <div class="lifecycle-desc">The contributor adds <strong>Grade B (Silver) evidence</strong> — a reproducible, documented demonstration. The PR runs <code>gaia dev evidence skill-id "url" --type repo-own --trust 50</code> and calibrates to 3★. A <code>links.github</code> URL pointing to a public repository is mandatory at this level.</div>
             </div>
           </div>
           <div class="lifecycle-step">
@@ -786,7 +786,7 @@ links:
             <div class="lifecycle-body">
               <div class="lifecycle-rank rank-4">4★ — Hardened (Verifier threshold)</div>
               <div class="lifecycle-title">Battle-tested, peer-reviewed</div>
-              <div class="lifecycle-desc">Reaching 4★ requires <strong>Class A evidence</strong> — peer review or battle-tested production use. At this rank the contributor becomes a <strong>Verifier</strong>, authorized to review and approve other contributors' naming PRs via <code>gaia whoami</code> → <code>verifier</code> path.</div>
+              <div class="lifecycle-desc">Reaching 4★ requires <strong>Grade A (Gold) evidence</strong> — peer review or battle-tested production use. At this rank the contributor becomes a <strong>Verifier</strong>, authorized to review and approve other contributors' naming PRs via <code>gaia whoami</code> → <code>verifier</code> path.</div>
             </div>
           </div>
         </div>
@@ -858,15 +858,15 @@ links:
         </div>
 
         <div class="section-body">
-          <p>Evidence types currently supported: <code>arxiv</code>, <code>repo</code>, <code>github-stars</code>. New types extend the list in <code>meta.json</code> without a schema change. GitHub stars are treated as proxy (secondary) evidence — they supplement, never replace, primary evidence.</p>
+          <p>Evidence types currently supported include <code>repo-own</code>, <code>github-stars-own</code>, <code>arxiv</code>, <code>peer-review</code>, <code>benchmark-result</code>, <code>self-attestation</code>, and <code>social-signal</code> — the full list lives in <code>meta.json</code> → <code>evidence.types</code>. GitHub stars are treated as proxy (secondary) evidence — they supplement, never replace, primary evidence.</p>
         </div>
 
         <h3>Adding evidence via CLI</h3>
         <div class="code-fence">
           <div class="code-fence-label">bash</div>
-          <pre><span class="c"># Add evidence — still accepted for Class B/A if transitional</span>
+          <pre><span class="c"># Add evidence (Evidence Type + Trust Magnitude — --class is deprecated)</span>
 gaia dev evidence skill-id "https://github.com/owner/repo/blob/main/SKILL.md" \
-  <span class="flag">--class B</span> \
+  <span class="flag">--type repo-own --trust 50</span> \
   --notes "Reproducible demo with tool-call trace"
 
 <span class="c"># Verify an evidence entry (requires Verifier authorization)</span>
@@ -884,7 +884,7 @@ gaia dev verify skill-id 0   <span class="c"># index of the evidence entry</span
 
         <h3>What you need</h3>
         <ul style="list-style:none;display:flex;flex-direction:column;gap:0.5rem;margin:0.75rem 0 1.25rem;font-size:0.9rem;color:var(--muted,#64748b);">
-          <li style="display:flex;gap:0.6rem;align-items:flex-start;"><span style="color:#34d399;flex-shrink:0;">✓</span> A <code>SKILL.md</code> file in a public GitHub repository (minimum Class C evidence)</li>
+          <li style="display:flex;gap:0.6rem;align-items:flex-start;"><span style="color:#34d399;flex-shrink:0;">✓</span> A <code>SKILL.md</code> file in a public GitHub repository (minimum Grade C / Bronze evidence)</li>
           <li style="display:flex;gap:0.6rem;align-items:flex-start;"><span style="color:#34d399;flex-shrink:0;">✓</span> A <code>links.github</code> URL using the <code>blob/branch/subpath</code> format — never <code>tree/</code></li>
           <li style="display:flex;gap:0.6rem;align-items:flex-start;"><span style="color:#34d399;flex-shrink:0;">✓</span> A <code>review/meta/</code> branch (schema changes require <code>schema/</code>)</li>
           <li style="display:flex;gap:0.6rem;align-items:flex-start;"><span style="color:#34d399;flex-shrink:0;">✓</span> <code>gaia dev validate</code> passing with no errors</li>
@@ -907,10 +907,10 @@ gaia dev add "Web Scrape" --type basic \
 <span class="c"># Create: registry/named/karpathy/web-scrape.md</span>
 <span class="c"># (See the frontmatter example above — manually create this file)</span>
 
-<span class="c"># 4. Add Class C evidence (first sighting)</span>
+<span class="c"># 4. Add evidence (Evidence Type + Trust Magnitude, not the deprecated --class)</span>
 gaia dev evidence web-scrape \
   "https://github.com/karpathy/myagent/blob/main/skills/web-scrape/SKILL.md" \
-  --class C --notes "Origin SKILL.md, first documented implementation" \
+  --type repo-own --trust 20 --notes "Origin SKILL.md, first documented implementation" \
   --no-build
 
 <span class="c"># 5. Set level and regenerate index</span>
@@ -923,7 +923,7 @@ gaia dev validate
 
 <span class="c"># 7. Commit and push</span>
 git add registry/named/karpathy/ registry/named-skills.json
-git commit -m "[named] karpathy/web-scrape — claim origin, Class C evidence"
+git commit -m "[named] karpathy/web-scrape — claim origin, Grade C (Bronze) evidence"
 git push -u origin review/meta/karpathy-web-scrape</pre>
         </div>
 

--- a/docs/en/named-skills.html
+++ b/docs/en/named-skills.html
@@ -844,14 +844,14 @@ links:
               <tr><th>Grade</th><th>Label</th><th>Trust number threshold</th></tr>
             </thead>
             <tbody>
-              <tr><td><span class="grade-badge g-s">S</span></td><td>Platinum</td><td>≥ 90</td></tr>
-              <tr><td><span class="grade-badge g-a">A</span></td><td>Gold</td><td>≥ 80</td></tr>
-              <tr><td><span class="grade-badge g-b">B</span></td><td>Silver</td><td>≥ 60</td></tr>
-              <tr><td><span class="grade-badge g-c">C</span></td><td>Bronze</td><td>≥ 40</td></tr>
+              <tr><td><span class="grade-badge g-s">S</span></td><td>Platinum</td><td>≥ 250</td></tr>
+              <tr><td><span class="grade-badge g-a">A</span></td><td>Gold</td><td>≥ 100</td></tr>
+              <tr><td><span class="grade-badge g-b">B</span></td><td>Silver</td><td>≥ 50</td></tr>
+              <tr><td><span class="grade-badge g-c">C</span></td><td>Bronze</td><td>≥ 20</td></tr>
               <tr>
                 <td><span style="font-family:'JetBrains Mono',monospace;font-size:0.78rem;color:#64748b;">ungraded</span></td>
                 <td>Below threshold</td>
-                <td>&lt; 40 — on the record but counts toward no gate</td>
+                <td>&lt; 20 — on the record but counts toward no gate</td>
               </tr>
             </tbody>
           </table>
@@ -871,7 +871,7 @@ gaia dev evidence skill-id "https://github.com/owner/repo/blob/main/SKILL.md" \
 
 <span class="c"># Verify an evidence entry (requires Verifier authorization)</span>
 <span class="c"># Sets evidence.verified: true in the node</span>
-gaia dev verify skill-id 0   <span class="c"># index of the evidence entry</span></pre>
+gaia dev verify skill-id <span class="flag">--index</span> 0   <span class="c"># index of the evidence entry</span></pre>
         </div>
       </section>
 

--- a/docs/en/named-skills.html
+++ b/docs/en/named-skills.html
@@ -593,9 +593,9 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
@@ -607,7 +607,7 @@
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">Named Skills</span>
     <span class="nav-spacer"></span>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <!-- Layout -->
@@ -1016,7 +1016,7 @@ links:
       </section>
 
       <footer class="page-footer">
-        <span>Gaia v6.4.12 — <a href="https://github.com/gaia-research/gaia-skill-tree">gaia-research/gaia-skill-tree</a></span>
+        <span>Gaia v6.8.16 — <a href="https://github.com/gaia-research/gaia-skill-tree">gaia-research/gaia-skill-tree</a></span>
         <a href="index.html">← Back to Docs</a>
       </footer>
     </main>

--- a/docs/en/share-bundles.html
+++ b/docs/en/share-bundles.html
@@ -319,21 +319,21 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
-  <!-- nav -->
+  <!-- Nav -->
   <nav class="docs-nav">
     <a href="../index.html" class="nav-logo">Gaia <span>◆</span></a>
     <span class="nav-sep">/</span>
     <a href="index.html" class="nav-crumb">Docs</a>
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">Share Bundles</span>
-    <div class="nav-spacer"></div>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-spacer"></span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <div class="page-layout">
@@ -696,7 +696,7 @@ Summary:
       <!-- footer -->
       <footer class="page-footer">
         <div class="page-footer-left">
-          Gaia Docs · <span id="footerVersion">v6.4.12</span>
+          Gaia Docs · <span id="footerVersion">v6.8.16</span>
         </div>
         <div class="page-footer-right">
           <a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener">Registry →</a>

--- a/docs/en/skill-hierarchy.html
+++ b/docs/en/skill-hierarchy.html
@@ -512,9 +512,9 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
@@ -526,7 +526,7 @@
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">Skill Hierarchy</span>
     <div class="nav-spacer"></div>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <div class="page-layout">
@@ -1027,7 +1027,7 @@
 
   <!-- footer -->
   <footer class="docs-footer">
-    <span class="docs-footer-left">Gaia Registry v6.4.12 — open, evidence-backed skill graph for AI agents.</span>
+    <span class="docs-footer-left">Gaia Registry v6.8.16 — open, evidence-backed skill graph for AI agents.</span>
     <div class="docs-footer-right">
       <a href="index.html" style="color:var(--muted,#64748b);">Docs</a>
       <a href="../index.html" style="color:var(--muted,#64748b);">Atlas</a>

--- a/docs/en/timeline-audit.html
+++ b/docs/en/timeline-audit.html
@@ -426,9 +426,9 @@
 
   <!-- Main site nav (hamburger on mobile, full menu on desktop) -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.4.12"></script>
-  <script src="../js/site-nav.js?v=6.4.12"></script>
-  <script src="../js/ui.js?v=6.4.12"></script>
+  <script src="../js/mounts.js?v=6.8.16"></script>
+  <script src="../js/site-nav.js?v=6.8.16"></script>
+  <script src="../js/ui.js?v=6.8.16"></script>
 
 
 
@@ -440,7 +440,7 @@
     <span class="nav-sep">/</span>
     <span class="nav-crumb current">Timeline Audit</span>
     <div class="nav-spacer"></div>
-    <span class="nav-version">v6.4.12</span>
+    <span class="nav-version">v6.8.16</span>
   </nav>
 
   <div class="page-layout">
@@ -800,7 +800,7 @@ git log --oneline --all | grep -iE "demot|star-bar|calibrat|reclassif"</pre>
         <h2>Known CLI gaps</h2>
         <div class="section-body">
           <p>
-            Several gaps exist in <code>gaia dev timeline</code> as of v6.4.12.
+            Several gaps exist in <code>gaia dev timeline</code> as of v6.8.16.
             Do not silently work around them with hand-edits; flag any gap-forced edit in
             the PR description and include a <code>"(direct edit — CLI gap)"</code> marker in
             the event's <code>details</code> string.
@@ -1027,7 +1027,7 @@ git log --oneline --all | grep -iE "demot|star-bar|calibrat|reclassif"</pre>
     <div class="footer-bottom">
       <span>MIT License</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>v6.4.12</span>
+      <span>v6.8.16</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
       <span>© 2026 Gaia</span>
     </div>


### PR DESCRIPTION
### Documentation Routine 017

This PR completes the weekly technical documentation routine update for `docs/en/`.

#### Summary of Changes:
1. **Version Synchronization (`v6.8.16`)**:
   - Updated version strings across all 12 English documentation HTML files under `docs/en/` from `v6.4.12` to `v6.8.16` to match latest git tags and repository releases.
2. **MCP Server Package Namespace Sync**:
   - Updated package references in `mcp-server.html` and `index.html` — later corrected by the editor pass (see below), the real package is `@gaia-registry/mcp-server`.
3. **Agent Intake Reference (`AGENTS.md`)**:
   - Documented `AGENTS.md` as the root discovery surface and fast-path intake guide for AI agent contributors in `contributing.html` and `index.html`.
4. **Maintenance & Diary**:
   - Updated `DOCS.md` page map table and prepended Routine 017 log entries to `MEMORY.md`.

#### Continued (same day, second commit) — Evidence Class residue cleanup
Closes #917. Its own triage comment flagged one residual "Class C evidence" mention; grepping `docs/en/` for `Class [ABC]` found six more files with the same deprecated phrasing.

5. **Retired deprecated Evidence Class wording** across `named-skills.html`, `getting-started.html`, `fusion.html`, `faq.html`, `cli-reference.html`, and `contributing.html` — reworded to the `Grade C/B/A (Bronze/Silver/Gold)` terminology already established in `evidence-classes.html`.
6. **Fixed a separate CLI-reference gap found in the same pass**: `cli-reference.html`'s `gaia dev evidence` card documented only the deprecated `--class A|B|C` flag and never mentioned the CLI's actual canonical interface. Rewrote the flag table to cover `--type`, `--trust`, `--stars/--commits/--contributors`, `--no-build`; kept `--class` documented but marked `[DEPRECATED]`; added a cross-link callout to Evidence & Trust's pitfalls section; updated both shell examples.
7. Filed #1254 for a distinct, deeper drift discovered but deliberately not fixed here: `evidence-classes.html`'s own Trust Number thresholds, Evidence Type IDs, and one CLI example don't match the real schema (`registry/schema/meta.json`) or CLI (`impl.py`).

#### Continued (2026-07-23, third commit) — Closes #1254
8. **Fixed `evidence-classes.html` Trust Number thresholds**: page said `S≥90/A≥80/B≥60/C≥40`; real schema (`registry/schema/meta.json` → `evidence.gradeThresholds`, confirmed against `impl.py`'s `--trust` help text) is `S≥250/A≥100/B≥50/C≥20`. Fixed in the trust meter, grade table, and pitfalls callout.
9. **Rewrote the Evidence Type table** from 3 rows with 2 wrong IDs (`repo`, `github-stars`) to all 10 real IDs from `evidence.types` (`repo-own`, `github-stars-own`, `arxiv`, `peer-review`, `verifier-attestation`, `benchmark-result`, `fusion-recipe`, `proxy-containment`, `social-signal`, `self-attestation`), each with real CLI flags.
10. **Fixed the CLI examples**: `--grade` and `--dry-run` aren't real flags on `gaia dev evidence` — rewrote to `--type` + `--trust`. Also found and fixed the "verify"/"dispute" examples, which showed them as flags on `gaia dev evidence` when they're actually the separate `gaia dev verify --index N [--dispute]` subcommand.
11. **Found the same drift had spread to `faq.html` and `named-skills.html`** — same stale thresholds, `--grade` flag, and a `gaia dev verify` call missing its required `--index` flag. Fixed all in the same pass.
12. Verified: HTML tag-balance check + `html.parser` parse check, and rendered `evidence-classes.html` locally via Playwright/Chromium.

#### Continued (2026-07-24, fourth/fifth commits) — CLI drift audit
13. Documented the previously-undocumented `gaia scan --dir` flag (repeatable extra skill root), verified against `commands/scan.py`.

#### Editor pass (2026-07-25) — ship gate
Reviewed the week's accreted commits against the actual product before shipping and fixed three real accuracy bugs, plus two small pre-existing vocabulary nits caught along the way:

14. **`gaia scan`'s flag table had a fictional flag.** The 07-24 session added `--dir` correctly but left `--auto-promote` in the signature/table/example — that flag does not exist on `gaia scan` (verified via `gaia scan --help` and `commands/scan.py`). Replaced with the real, previously-undocumented `--all` flag ("scan globally installed skills in addition to the local repository").
15. **MCP server package name was wrong** in `mcp-server.html` and `index.html` — this week's own "namespace sync" commit propagated a stale `@gaia-research/mcp@0.1.0` reference from a bad prior commit (`6ed72921d`) instead of checking the actual source of truth. `packages/mcp/package.json`, its own README, and the root README's install table have always published as `@gaia-registry/mcp-server`. Reverted both pages and dropped the stale `-y`/version-pin flourishes to match the canonical README's install commands exactly.
16. **Self-contradiction in `faq.html`**: this week's own `evidence-classes.html` fix added an explicit "do not call it 'trust score'" pitfall, but `faq.html` still said "trust score tier". Changed to "quality tier".
17. Two pre-existing vocabulary nits caught while verifying the above: "feed the same review queue" → "feed the same intake" (`contributing.html`; CONTEXT.md: Intake, avoid "queue"), and a TOC entry "Combine skills" → "Fuse skills" (`cli-reference.html`; CONTEXT.md: Fusion, avoid "combine").
18. Verified as accurate and left unchanged: the Trust Number threshold rewrite and the 10-row Evidence Type table (checked against `registry/schema/meta.json` and live `gaia dev evidence`/`gaia dev verify --help` output). Hex colors added this week match long-established site-wide convention — not new drift. All 12 pages' version chips consistently at `v6.8.16`. Rendered all touched pages via Playwright: no console errors, nav clearance intact.

All changes are strictly limited to `docs/en/`.

### Entrypoints
No new pages/sections added this round — all edits are content fixes to existing, already-linked pages. No nav/footer/mounts changes needed.

### Token spend
2026-07-25 Sonnet 5 High: editor pass — ~85k in, ~9k out. ~$0.50