### PR TITLE
cli: Ygg II Batch 0 — retire self-promote, levelless fusion/awaken card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,8 +159,7 @@ Every change to a user's `skill-trees/<username>/skill-tree.json` **must** be ac
 
 | Operation | CLI command |
 |---|---|
-| Unlock / rank up via scan | `gaia scan` then `gaia promote <skillId>` |
-| Fuse skills | `gaia fuse <skillId>` |
+| Fuse skills (confirm/declare a fusion locally) | `gaia fuse <skillId>` |
 | Append event at current time | `gaia dev timeline <skillId> --user <username> --action <action> --notes "..."` |
 | Backfill a historical event | `gaia dev timeline <skillId> --user <username> --action <action> --notes "..." --timestamp "YYYY-MM-DDTHH:MM:SSZ"` |
 
@@ -189,7 +188,7 @@ All commands default to **local-first** output (user's own skill levels, detecte
 All mutating `gaia dev` subcommands (add, merge, split, rename, calibrate, evidence,
 rm-evidence, link, reclassify, update-named, timeline, rm, verify, build) require
 **Verifier authorization**.  Read-only subcommands (`list`, `audit`, `diff`) and all
-player-facing commands (`gaia promote`, `gaia fuse`, `gaia scan`, `gaia push`) are
+player-facing commands (`gaia fuse`, `gaia scan`, `gaia push`) are
 **never** gated.
 
 Run `gaia whoami` to check your current authorization status and see which path
@@ -232,9 +231,9 @@ Bot actors (`*[bot]`, `jules`, `codex`, `claude-bot`, `gemini-bot`) are always a
 
 CI enforces scope via `.github/workflows/branch-scope.yml`. Schema changes (`registry/schema/`) MUST use a `schema/` branch. Label `skip-scope-check` to bypass in emergencies.
 
-## Promotion Rule
+## No self-promote (Yggdrasil II)
 
-`gaia scan` writes `generated-output/promotion-candidates.json` and renders the user's tree. `gaia promote <skill> --label <level>` may only promote a pair listed in that file; stale candidate files are rejected after 24 hours.
+Rank/level is assigned ONLY by canon curation (dev-gated). The non-dev CLI's job ends at *propose*: `gaia scan` detects the fusions you have the prerequisites for and renders your tree; `gaia fuse` confirms a detected combination or declares a custom fusion locally (levelless — `type: fusion`); `gaia push` proposes the structure to canon, where curation "awakens" it and assigns rank. No non-dev CLI path writes rank/level into `skill-trees/<user>/skill-tree.json`. (There is no `gaia promote` — it was retired in the Ygg II CLI alignment.)
 
 ## Versioning
 

--- a/DEV.md
+++ b/DEV.md
@@ -88,8 +88,8 @@ pip install -e ".[docs]"
 | `gaia dev docs` | Regenerate documentation and assets locally (`gaia docs build` is a deprecated shim) |
 | `gaia dev docs --check` | Regenerate + compare generated docs; fails (exit 1) on drift. NOT read-only — rewrites Class P/S artifacts locally (runs in CI) |
 | `gaia init --user <username>` | Initialize your local Gaia user profile |
-| `gaia scan` | Scan configured paths for skill evidence and generate promotion candidates |
-| `gaia promote <skillId>` | Promote a skill in your tree after a scan |
+| `gaia scan` | Scan configured paths for skill evidence and detect fusions you can propose |
+| `gaia fuse <skillId>` | Confirm a detected combination or declare a custom fusion locally, then `gaia push` to propose it to canon |
 | `gaia tree` | View your local-first user skill tree |
 | `gaia dev list --generic --named` | List generic and named skills |
 | `gaia dev evidence <skillId> <url> --class <S\|A\|B\|C\|D> --type <type>` | Add an evidence row to a skill (use the typed numeric flags below to drive Trust Magnitude correctly) |
@@ -119,7 +119,7 @@ The console script `gaia` is defined in `pyproject.toml` as `gaia = "gaia_cli.ma
 gaia <anything>   ≡   python -m gaia_cli <anything>
 ```
 
-There is nothing to memorize per command — **prefix any `gaia …` invocation with `python -m gaia_cli` instead of `gaia`.** This holds for every top-level command (`scan`, `tree`, `promote`, `skills …`) and every `gaia dev` subcommand. Global flags (`--registry`, `--global/-g`, `--canon`, `--version/-v`) work identically because they live on the root parser.
+There is nothing to memorize per command — **prefix any `gaia …` invocation with `python -m gaia_cli` instead of `gaia`.** This holds for every top-level command (`scan`, `tree`, `fuse`, `skills …`) and every `gaia dev` subcommand. Global flags (`--registry`, `--global/-g`, `--canon`, `--version/-v`) work identically because they live on the root parser.
 
 ```bash
 # Blocked:            gaia dev validate

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Navigate skills:
 <!-- gaia:cli-start -->
 ```text
 usage: gaia [-h] [--registry REGISTRY] [--global] [--version]
-            {help,init,scan,fetch,pull,update,install,uninstall,share,tree,push,propose,version,whoami,login,logout,reset,graph,stats,appraise,promote,fuse,lookup,path,dev,skills}
+            {help,init,scan,fetch,pull,update,install,uninstall,share,tree,push,propose,version,whoami,login,logout,reset,graph,stats,appraise,fuse,lookup,path,dev,skills}
             ...
 
 Gaia Registry CLI
@@ -303,7 +303,6 @@ Getting started:
 
 Daily commands:
   gaia tree [--named] [--title]
-  gaia promote [<skillId>] [--all] [--name <name>]
   gaia appraise [<skillId>]
   gaia stats
   gaia pull

--- a/docs/en/cli-reference.html
+++ b/docs/en/cli-reference.html
@@ -834,7 +834,6 @@
         <ul class="sidebar-links">
           <li><a href="#init"><code>init</code></a></li>
           <li><a href="#scan"><code>scan</code></a></li>
-          <li><a href="#promote"><code>promote</code></a></li>
           <li><a href="#fuse"><code>fuse</code></a></li>
           <li><a href="#tree"><code>tree</code></a></li>
           <li><a href="#push"><code>push</code></a></li>
@@ -928,7 +927,6 @@
           <ul class="toc-section-list">
             <li><a href="#init"><code>init</code> — Initialize config</a></li>
             <li><a href="#scan"><code>scan</code> — Scan for evidence</a></li>
-            <li><a href="#promote"><code>promote</code> — Rank up skill</a></li>
             <li><a href="#fuse"><code>fuse</code> — Combine skills</a></li>
             <li><a href="#tree"><code>tree</code> — Render skill tree</a></li>
             <li><a href="#push"><code>push</code> — Submit intake batch</a></li>
@@ -983,7 +981,7 @@
       <!-- ═══════════════ PLAYER WORKFLOW ═══════════════ -->
       <section class="section" id="player-workflow">
         <h2 class="section-title">Player workflow</h2>
-        <p class="section-desc">Use these commands to scan your local code, promote your skills, and save your progress.
+        <p class="section-desc">Use these commands to scan your local code, fuse your skills, and propose your progress to canon.
         </p>
 
         <!-- init -->
@@ -1074,14 +1072,13 @@
         <div class="cmd-card" id="scan">
           <div class="cmd-card-header">
             <span class="cmd-name">gaia scan</span>
-            <span class="cmd-signature">[--quiet] [--auto-promote] [--json]</span>
+            <span class="cmd-signature">[--quiet] [--json]</span>
             <span class="gate-badge open">● open</span>
           </div>
           <div class="cmd-body">
             <ul class="cmd-desc">
               <li>Scans configured paths for <code>SKILL.md</code> files and agent folders.</li>
-              <li>Saves promotion candidates to your output folder.</li>
-              <li>Expires scan candidate files after 24 hours.</li>
+              <li>Detects the fusions you have the prerequisites for and renders your tree.</li>
             </ul>
             <table class="flag-table">
               <thead>
@@ -1094,12 +1091,7 @@
               <tbody>
                 <tr>
                   <td>--quiet</td>
-                  <td>Suppress per-file scan output; show only the final candidate summary.</td>
-                  <td>false</td>
-                </tr>
-                <tr>
-                  <td>--auto-promote</td>
-                  <td>Automatically promote every scan candidate without prompting.</td>
+                  <td>Suppress per-file scan output; show only the final summary.</td>
                   <td>false</td>
                 </tr>
                 <tr>
@@ -1111,76 +1103,11 @@
             </table>
             <div class="example-block">
               <div class="example-label">examples</div>
-              <pre><span class="c"># Standard scan — shows detected skills and promotion candidates</span>
+              <pre><span class="c"># Standard scan — shows detected skills and ready fusions</span>
 <span class="cmd">gaia scan</span>
 
-<span class="c"># Quiet scan, then inspect candidates in JSON</span>
-<span class="cmd">gaia scan</span> <span class="arg">--quiet --json</span> <span class="kw">| jq '.candidates'</span>
-
-<span class="c"># Promote everything the scanner detects, no prompts</span>
-<span class="cmd">gaia scan</span> <span class="arg">--auto-promote</span></pre>
-            </div>
-          </div>
-        </div>
-
-        <!-- promote -->
-        <div class="cmd-card" id="promote">
-          <div class="cmd-card-header">
-            <span class="cmd-name">gaia promote</span>
-            <span class="cmd-signature">[&lt;skillId&gt;] [--all] [--unique] [--name &lt;label&gt;]</span>
-            <span class="gate-badge open">● open</span>
-          </div>
-          <div class="cmd-body">
-            <ul class="cmd-desc">
-              <li>Promotes one skill or all candidates from your last scan.</li>
-              <li>Requires candidate skills to be listed in a non-stale file.</li>
-              <li>Appends a timeline event to your skill tree file.</li>
-            </ul>
-            <table class="flag-table">
-              <thead>
-                <tr>
-                  <th>Flag</th>
-                  <th>Description</th>
-                  <th>Default</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>&lt;skillId&gt;</td>
-                  <td>Slash-prefixed or bare canonical skill ID, e.g. <code>/web-search</code> or
-                    <code>web-search</code>.
-                  </td>
-                  <td>—</td>
-                </tr>
-                <tr>
-                  <td>--all</td>
-                  <td>Promote every candidate from the most recent scan in one pass.</td>
-                  <td>false</td>
-                </tr>
-                <tr>
-                  <td>--unique</td>
-                  <td>Promote a Basic skill to the Unique tier (requires 4★ and graph-isolation with a named
-                    implementation).</td>
-                  <td>false</td>
-                </tr>
-                <tr>
-                  <td>--name &lt;label&gt;</td>
-                  <td>Optional display name for the skill entry in your tree.</td>
-                  <td>canonical name</td>
-                </tr>
-              </tbody>
-            </table>
-            <div class="example-block">
-              <div class="example-label">examples</div>
-              <pre><span class="c"># Promote a single skill after scanning</span>
-<span class="cmd">gaia scan</span>
-<span class="cmd">gaia promote</span> <span class="arg">/web-search</span>
-
-<span class="c"># Promote every candidate from the last scan</span>
-<span class="cmd">gaia promote</span> <span class="arg">--all</span>
-
-<span class="c"># Promote a Basic skill to Unique tier</span>
-<span class="cmd">gaia promote</span> <span class="arg">code-review --unique</span></pre>
+<span class="c"># Quiet scan, then inspect results in JSON</span>
+<span class="cmd">gaia scan</span> <span class="arg">--quiet --json</span></pre>
             </div>
           </div>
         </div>
@@ -1437,7 +1364,7 @@
           <div class="cmd-body">
             <ul class="cmd-desc">
               <li>Renders a status card for a specific skill.</li>
-              <li>Displays stars, possible actions (<a href="#promote">promote</a>, <a href="#fuse">fuse</a>, <a
+              <li>Displays stars, possible actions (<a href="#fuse">fuse</a>, <a
                   href="#propose">propose</a>), evidence, and installation status.</li>
               <li>Defaults to your last active skill if no argument is passed.</li>
             </ul>

--- a/skill-trees/README.md
+++ b/skill-trees/README.md
@@ -45,11 +45,13 @@ written to `generated-output/tree.md` and `generated-output/tree.html`.
 ## How Skill Trees Grow
 
 1. Run `gaia init --user <you>` in a project.
-2. Run `gaia scan` to detect skills and render your local tree.
-3. Review `generated-output/promotion-candidates.json` for recommended level-ups.
-4. Run `gaia promote <skill>` or `gaia promote --all` to apply only scan-approved
-   promotions. Gaia uses the level suggested by the scan.
-5. Run `gaia push` when you want to submit new skill intake for review.
+2. Run `gaia scan` to detect skills and render your local tree. Scan surfaces
+   the fusions you already have the prerequisites for.
+3. Run `gaia fuse <skill>` to confirm a detected combination or declare a
+   custom fusion locally.
+4. Run `gaia push` to propose new skill intake — including your fusions — for
+   review. Rank/level is assigned only by canon curation; the local CLI never
+   self-assigns a level.
 
 The skill tree is the heart of Gaia: it is the map of what an agent can actually
 do, how those skills combine, and what evidence supports each level.

--- a/src/gaia_cli/CLAUDE.md
+++ b/src/gaia_cli/CLAUDE.md
@@ -212,7 +212,7 @@ rm-evidence, link, reclassify, update-named, timeline, rm, verify, build) are ga
 `require_operator()` in `authz.py` at the dispatch level in `main.py` (`MUTATING_DEV_COMMANDS`
 set).  Read-only subcommands (`list`, `audit`, `diff`) are intentionally ungated.
 
-**Player-facing flows** (`gaia promote`, `gaia fuse`, `gaia scan`, `gaia push`) are
+**Player-facing flows** (`gaia fuse`, `gaia scan`, `gaia push`) are
 **never** gated — only `gaia dev` mutations route through the Verifier check.
 
 **Authorization hierarchy** (`via` values shown in `gaia whoami`):

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -472,7 +472,7 @@ def render_appraise_card(
         skill_data: skill dict from gaia.json
         prereq_status: {prereq_id: True/False} — True = user has it
         derivatives: list of derivative skill dicts [{id, name, type}]
-        actions: list of action labels (e.g. ["[F] Fuse", "[P] Promote"])
+        actions: list of action labels (e.g. ["[F] Fuse", "[S] Scan"])
         owned: whether user owns this skill
         canon: if True, show slash-prefixed IDs
         display_name: optional override for skill name
@@ -751,16 +751,23 @@ def render_path_summary(paths: dict) -> str:
     return f"⚡ {' │ '.join(parts)}"
 
 
-# ─── Promotion prompt ──────────────────────────────────────────────────────
+# ─── Fusion / awaken card ──────────────────────────────────────────────────
 
 
-def render_promotion_prompt(
+def render_fusion_awaken_card(
     skill_data: dict,
-    proposed_level: str,
     canon: bool = False,
     ctx: Optional["LocalContext"] = None,
+    parent_has_named: bool = False,
 ) -> str:
-    """Prompt shown when a skill is eligible for promotion."""
+    """Card shown when the user owns the prerequisites for a fusion.
+
+    Yggdrasil II model: the card ALWAYS shows the fusion (a real generic skill
+    exists) but quotes NO star level — rank is assigned only by canon curation.
+    The "awaken" message (``gaia fuse`` + ``gaia push``) appears ONLY when the
+    generic parent is still EMPTY (no named implementation claimed yet), i.e.
+    the user could be the first to propose an implementation.
+    """
     skill_id = skill_data.get("id", "?")
     skill_type = skill_data.get("type", "fusion")
     prereqs = skill_data.get("prerequisites", [])
@@ -768,10 +775,6 @@ def render_promotion_prompt(
     tc = fg(*TIER_COLORS.get(skill_type, COLOR_GOLD))
     r = reset()
     b = bold()
-
-    from gaia_cli.promotion import LEVEL_NAMES
-
-    level_name = LEVEL_NAMES.get(proposed_level, proposed_level)
 
     lines = [""]
     # Show fusion diagram if skill has prerequisites
@@ -795,23 +798,24 @@ def render_promotion_prompt(
 
     # Build each content row as a (plain, colored) pair. The plain twin drives
     # the box width so the fixed-dash borders can no longer clip the longest
-    # line (issue #118: the Rename? hint overran the old hardcoded 55-dash box).
-    rename_name = display.lstrip("/")
+    # line (issue #118). No level is quoted — rank is a canon-curation concept.
     rows = [
         (
-            f"  {display} can rank up to Level {proposed_level} ({level_name})",
-            f"  {display_colored} can rank up to {b}Level {proposed_level}{r} ({level_name})",
-        ),
-        (
-            f"  Run: gaia promote {skill_id}",
-            f"  Run: {b}gaia promote {skill_id}{r}",
-        ),
-        (
-            f'  Rename? gaia promote {skill_id} --name "{rename_name}"',
-            f'  Rename? {b}gaia promote {skill_id} --name "{rename_name}"{r}',
+            f"  {display} — prerequisites complete",
+            f"  {display_colored} — prerequisites complete",
         ),
     ]
-    title_seg = "─ Promotion Available "
+    # The awaken hint only shows when the generic parent has no named
+    # implementation yet: the user can be first to propose one to canon.
+    if not parent_has_named:
+        rows.append(
+            (
+                f"  Awaken it: gaia fuse {skill_id} → gaia push",
+                f"  Awaken it: {b}gaia fuse {skill_id}{r} → {b}gaia push{r}",
+            )
+        )
+
+    title_seg = "─ Fusion Ready "
     # Inner width spans the space between the ┌ ┐ corners. Size to the widest
     # content row (plus a trailing pad) but never narrower than the title.
     inner = max(*(len(plain) for plain, _ in rows), len(title_seg)) + 1

--- a/src/gaia_cli/commands/progression.py
+++ b/src/gaia_cli/commands/progression.py
@@ -18,33 +18,13 @@ class AppraiseCommand(Command):
         appraise_command(args)
         return 0
 
-class PromoteCommand(Command):
-    name = "promote"
-    help = "Promote a skill eligible for level-up"
-
-    def configure(self, parser: argparse.ArgumentParser) -> None:
-        parser.add_argument(
-            "skillId", nargs="?", default=None, help="Skill ID to promote"
-        )
-        parser.add_argument(
-            "--all", action="store_true", help="Promote every candidate from the last scan"
-        )
-        parser.add_argument(
-            "--name", help="Optional display name for the promoted skill"
-        )
-
-    def execute(self, args: argparse.Namespace) -> int | None:
-        from gaia_cli.main import promote_command
-        promote_command(args)
-        return 0
-
 class FuseCommand(Command):
     name = "fuse"
     help = "Confirm a skill combination or create a custom fusion path"
 
     def configure(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
-            "skillId", nargs="?", default=None, help="Skill ID to fuse or promote"
+            "skillId", nargs="?", default=None, help="Skill ID to fuse"
         )
         parser.add_argument("--name", help="Optional display name for the skill")
         parser.add_argument(
@@ -63,4 +43,4 @@ class FuseCommand(Command):
             pass
         return 0
 
-COMMANDS = [AppraiseCommand(), PromoteCommand(), FuseCommand()]
+COMMANDS = [AppraiseCommand(), FuseCommand()]

--- a/src/gaia_cli/hook.py
+++ b/src/gaia_cli/hook.py
@@ -9,10 +9,47 @@ import os
 
 from gaia_cli.scanner import load_config, scan_repo_detailed
 from gaia_cli.resolver import resolve_skills
-from gaia_cli.registry import registry_graph_path, resolve_registry_path
+from gaia_cli.registry import (
+    registry_graph_path,
+    resolve_registry_path,
+    named_skills_index_path,
+)
 from gaia_cli.treeManager import load_tree
 from gaia_cli.pathEngine import compute_paths, load_paths, save_paths, diff_paths
-from gaia_cli.cardRenderer import render_unlock_card, render_path_summary, render_promotion_prompt
+from gaia_cli.cardRenderer import (
+    render_unlock_card,
+    render_path_summary,
+    render_fusion_awaken_card,
+)
+
+
+def _named_generic_refs(registry_path: str) -> set:
+    """Return the set of generic skill IDs that already have a named
+    implementation (via named-skills.json ``genericSkillRef``).
+
+    Used to decide whether a fusion's generic parent is still EMPTY — the
+    awaken hint (`gaia fuse` + `gaia push`) only shows when it is, so the user
+    can be first to propose an implementation to canon. If the index is
+    unavailable, returns an empty set (treat every parent as empty).
+    """
+    refs: set = set()
+    index_path = named_skills_index_path(registry_path)
+    if not os.path.isfile(index_path):
+        return refs
+    try:
+        with open(index_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return refs
+    entries = []
+    for skills in data.get("buckets", {}).values():
+        entries.extend(skills)
+    entries.extend(data.get("awaitingClassification", []))
+    for entry in entries:
+        ref = entry.get("genericSkillRef")
+        if ref:
+            refs.add(ref)
+    return refs
 
 
 def should_trigger(changed_files: list[str] | None, config: dict) -> bool:
@@ -38,9 +75,8 @@ def hook_entry(event: str = "file_edit", registry_path: str | None = None) -> No
     2. Loads previous paths
     3. Runs scan + resolve + compute
     4. Diffs old vs new paths
-    5. If new nearUnlocks: prints unlock card(s)
-    6. If promotions available: prints promotion prompt
-    7. Saves updated paths
+    5. If new nearUnlocks: prints unlock card(s) + fusion/awaken card(s)
+    6. Saves updated paths
     """
     config = load_config()
     if not config:
@@ -108,15 +144,21 @@ def hook_entry(event: str = "file_edit", registry_path: str | None = None) -> No
         print(render_path_summary(new_paths))
         print()
 
-    # Show promotion prompts
-    if changes.get("promotions_available"):
-        from gaia_cli.promotion import check_promotion_eligibility
-        if tree_data:
-            eligible = check_promotion_eligibility(graph_data, tree_data)
-            for promo in eligible[:2]:
-                skill = skill_map.get(promo["skillId"])
-                if skill:
-                    print(render_promotion_prompt(skill, promo.get("nextLevel", "2★")))
+    # Show fusion/awaken cards for newly-completed fusions. Computed fresh from
+    # nearUnlocks (owned prereqs) — no promote-candidate handshake. The awaken
+    # hint appears only when the fusion's generic parent has no named
+    # implementation yet (the user can be first to propose one to canon).
+    if changes.get("new_near_unlocks"):
+        named_refs = _named_generic_refs(registry)
+        for skill_id in changes["new_near_unlocks"][:2]:
+            skill = skill_map.get(skill_id)
+            if skill:
+                print(
+                    render_fusion_awaken_card(
+                        skill,
+                        parent_has_named=skill_id in named_refs,
+                    )
+                )
 
     # Persist
     save_paths(new_paths)

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -62,7 +62,6 @@ from gaia_cli.registry import (
     generated_output_dir,
     embeddings_path,
     named_skills_index_path,
-    promotion_candidates_path,
     registry_graph_path,
     skill_batches_dir,
     user_tree_path,
@@ -81,13 +80,6 @@ from gaia_cli.cardRenderer import (
     render_appraise_card,
     render_unlock_card,
     render_path_summary,
-)
-from gaia_cli.promotion import (
-    load_promotion_candidates,
-    promote_from_candidates,
-    promotable_candidates,
-    promotion_state,
-    LEVEL_NAMES,
 )
 from gaia_cli.hook import hook_entry
 from gaia_cli.formatting import (
@@ -118,7 +110,6 @@ from gaia_cli.cardRenderer import render_fusion_diagram
 from gaia_cli.interactive import (
     select_skill,
     select_fusion_candidate,
-    select_promotion_candidate,
     select_multiple_skills,
     select_fusion_to_edit,
     _has_interactive,
@@ -151,7 +142,6 @@ Getting started:
 
 Daily commands:
   {_fg(*C5)}gaia tree{_reset()} [--named] [--title]
-  {_fg(*C5)}gaia promote{_reset()} [<skillId>] [--all] [--name <name>]
   {_fg(*C4)}gaia appraise{_reset()} [<skillId>]
   {_fg(*C4)}gaia stats{_reset()}
   {_fg(*C3)}gaia pull{_reset()}
@@ -245,7 +235,6 @@ PUBLIC_COMMANDS = (
     "graph",
     "stats",
     "appraise",
-    "promote",
     "fuse",
     "lookup",
     "path",
@@ -1200,19 +1189,6 @@ def render_user_tree_outputs(
     return html_path, md_path
 
 
-def promote_all_candidates(username: str, registry_path: str) -> list[dict]:
-    promoted = []
-    for candidate in promotable_candidates(registry_path, username=username):
-        promoted.append(
-            promote_from_candidates(
-                username,
-                candidate["skillId"],
-                registry_path,
-            )
-        )
-    return promoted
-
-
 def _entry_role(entry):
     return entry.get("role") or ("origin" if entry.get("origin") is True else "variant")
 
@@ -1399,10 +1375,6 @@ def appraise_command(args):
     actions = []
     if not owned and all(prereq_status.values()) and prereq_status:
         actions.append("[F] Fuse")
-    if owned:
-        state = promotion_state(skill_id, tree, graph_data)
-        if state == "eligible":
-            actions.append("[P] Promote")
     actions.append("[S] Scan")
     if derivatives:
         actions.append("[→] Paths")
@@ -1423,96 +1395,6 @@ def appraise_command(args):
             display_name=display_name,
         )
     )
-    try:
-        candidates = load_promotion_candidates(args.registry).get("candidates", [])
-        matching = [c for c in candidates if c.get("skillId") == skill_id]
-        if matching:
-            labels = ", ".join(c.get("suggestedLevel", "?") for c in matching)
-            print(f"\nLast scan flagged this skill as promotable to: {labels}")
-    except ValueError:
-        pass
-
-
-def promote_command(args):
-    """Run promotion flow for an eligible skill."""
-    config = load_config()
-    if not config:
-        print("Gaia not initialized.")
-        return
-
-    username = config.get("gaiaUser")
-    graph_path = registry_graph_path(args.registry)
-
-    if not os.path.exists(graph_path):
-        print("Registry graph not found.")
-        return
-
-    with open(graph_path, "r", encoding="utf-8") as f:
-        graph_data = json.load(f)
-
-    tree = load_tree(username, registry_path=args.registry)
-    if not tree:
-        if not os.path.exists(promotion_candidates_path(args.registry)):
-            print(
-                "No promotion candidates found. Run `gaia scan` first to detect skills.",
-                file=sys.stderr,
-            )
-        else:
-            print(f"No skill tree found for user '{_fg(*COLOR_LOCAL_USER)}{username}{_reset()}'.", file=sys.stderr)
-        return
-
-    skill_id = getattr(args, "skillId", None)
-    display_name = getattr(args, "name", None)
-
-    try:
-        if getattr(args, "all", False):
-            results = promote_all_candidates(username, args.registry)
-            if not results:
-                print("No skills eligible for promotion.")
-                return
-            for result in results:
-                print(f"Promoted /{result['skillId']} to Level {result['newLevel']}.")
-            return
-        if not skill_id:
-            # Try interactive picker
-            candidates = promotable_candidates(args.registry, username)
-            if candidates:
-                picked = select_promotion_candidate(
-                    candidates, "Select skill to promote:"
-                )
-                if picked:
-                    skill_id = picked
-            if not skill_id:
-                from gaia_cli.registry import promotion_candidates_path
-
-                if not os.path.exists(promotion_candidates_path(args.registry)):
-                    print(
-                        "No promotion candidates found. Run `gaia scan` first to detect skills.",
-                        file=sys.stderr,
-                    )
-                else:
-                    print(
-                        "Usage: gaia promote <skill> or gaia promote --all",
-                        file=sys.stderr,
-                    )
-                sys.exit(2)
-        result = promote_from_candidates(
-            username, skill_id, args.registry, new_display_name=display_name
-        )
-    except ValueError as exc:
-        print(str(exc), file=sys.stderr)
-        sys.exit(1)
-
-    # Show celebration
-    skill_map = {s["id"]: s for s in graph_data.get("skills", [])}
-    skill = skill_map.get(skill_id, {"id": skill_id, "name": skill_id, "type": "basic"})
-    level_name = LEVEL_NAMES.get(result["newLevel"], result["newLevel"])
-    print(
-        f"\n✦ {skill.get('name', skill_id)} promoted to Level {result['newLevel']} ({level_name})!"
-    )
-    if display_name:
-        print(f"  Renamed to: {display_name}")
-    print()
 
 
 def propose_command(args):
@@ -1863,19 +1745,6 @@ def fuse_command(args):
                     )
                 )
 
-            # Check for promotions
-            promo_payload = {}
-            try:
-                promo_payload = load_promotion_candidates(registry_path)
-                if promo_payload.get("candidates"):
-                    choices.append(
-                        questionary.Choice(
-                            "Promote a skill (level-up)", value="promote"
-                        )
-                    )
-            except:
-                pass
-
             choices.extend(
                 [
                     questionary.Choice("Create new custom fusion path", value="new"),
@@ -1902,14 +1771,6 @@ def fuse_command(args):
                 picked = select_fusion_candidate(
                     pending_combos, "Select fusion candidate:"
                 )
-                if picked:
-                    target = picked
-                    break  # Exit loop to perform fusion
-                continue  # Back to menu
-
-            elif choice == "promote":
-                candidates = promo_payload.get("candidates", [])
-                picked = select_promotion_candidate(candidates)
                 if picked:
                     target = picked
                     break  # Exit loop to perform fusion
@@ -1999,15 +1860,6 @@ def fuse_command(args):
                 if not selected:
                     continue  # Back to menu
 
-                # Calculate max star count from prerequisites
-                max_stars = 0
-                for sid in selected:
-                    ss = scan_map.get(sid) or {}
-                    sinfo = skill_info_map.get(sid, {})
-                    lvl = ss.get("level") or sinfo.get("level") or ctx._effective_ranks.get(sid, "0★")
-                    max_stars = max(max_stars, level_num(lvl))
-                max_stars_str = f"{max_stars}★"
-
                 if not target:
                     # Stage 2: pick the target from the same installed/detected list
                     target = select_skill(
@@ -2019,18 +1871,20 @@ def fuse_command(args):
                 if not target:
                     continue  # Back to menu
 
-                # Save fusion with metadata (EXTRA type and inherited level)
+                # Save the custom fusion structurally (Yggdrasil II: type is
+                # `fusion` for any node with >=1 prerequisite; no level is
+                # written locally — rank is assigned only by canon curation
+                # once the structure is pushed and awakened).
                 custom_state.setdefault("customFusions", {})[target] = {
                     "sources": selected,
-                    "type": "extra",
-                    "level": max_stars_str,
+                    "type": "fusion",
                 }
                 os.makedirs(".gaia", exist_ok=True)
                 with open(custom_state_path, "w", encoding="utf-8") as f:
                     json.dump(custom_state, f, indent=2)
 
                 print(
-                    f"\n✓ Saved custom fusion: {' + '.join('/' + s for s in selected)} → /{target} (EXTRA {max_stars_str})"
+                    f"\n✓ Saved custom fusion: {' + '.join('/' + s for s in selected)} → /{target}"
                 )
                 print(
                     f"\n{_fg(*fuse_color)}Note: Custom fusions are saved locally in .gaia/custom_state.json.{_reset()}"
@@ -2040,7 +1894,7 @@ def fuse_command(args):
                 )
                 return
 
-    # If we have a target but didn't go through 'new' flow, it might be a pending combo or promotion
+    # If we have a target but didn't go through 'new' flow, it might be a pending combo
     if not target:
         print(
             f"{_fg(*fuse_color)}Usage: gaia fuse <skill_id>{_reset()}", file=sys.stderr
@@ -2086,24 +1940,8 @@ def fuse_command(args):
         open_pr(username, tree, candidate_result=target)
         return
 
-    # Check promotions next
-    try:
-        payload = load_promotion_candidates(registry_path)
-        if any(c.get("skillId") == target for c in payload.get("candidates", [])):
-            print(f"{_fg(*fuse_color)}Fusing promotion for /{target}...{_reset()}")
-            result = promote_from_candidates(
-                username,
-                target,
-                registry_path,
-                new_display_name=getattr(args, "name", None),
-            )
-            print(f"Promoted /{result['skillId']} to Level {result['newLevel']}.")
-            return
-    except Exception:
-        pass
-
     print(
-        f"{_fg(*fuse_color)}Skill /{target} is not a valid combination or promotion candidate.{_reset()}"
+        f"{_fg(*fuse_color)}Skill /{target} is not a valid combination.{_reset()}"
     )
     print(
         f"{_fg(*fuse_color)}Run `gaia scan` to refresh candidates, or use interactive `{_fg(*COLOR_FUSE_PURPLE)}gaia fuse{_reset()}{_fg(*fuse_color)}` to create a custom path.{_reset()}"
@@ -3698,18 +3536,6 @@ def get_parser():
         default=None,
         help="Skill ID to appraise (default: most recent)",
     )
-    promote_parser = subparsers.add_parser(
-        "promote", help="Promote a skill eligible for level-up"
-    )
-    promote_parser.add_argument(
-        "skillId", nargs="?", default=None, help="Skill ID to promote"
-    )
-    promote_parser.add_argument(
-        "--all", action="store_true", help="Promote every candidate from the last scan"
-    )
-    promote_parser.add_argument(
-        "--name", help="Optional display name for the promoted skill"
-    )
     fuse_parser = subparsers.add_parser(
         "fuse", help="Confirm a skill combination or create a custom fusion path"
     )
@@ -4455,8 +4281,6 @@ def main():
         stats_command(args)
     elif args.command == "appraise":
         appraise_command(args)
-    elif args.command == "promote":
-        promote_command(args)
     elif args.command == "fuse":
         try:
             fuse_command(args)

--- a/src/gaia_cli/promotion.py
+++ b/src/gaia_cli/promotion.py
@@ -1,16 +1,14 @@
-"""Skill-tree level promotion logic.
+"""Canon-side rank/grade helpers.
 
-Provides helpers to check promotion eligibility, advance a skill's level,
-and inspect the current promotion state for a given skill.
+Under Yggdrasil II the non-dev CLI never self-assigns rank — the self-promote
+machinery (candidate handshake, level writes into user trees) has been retired.
+What remains here are the canon-curation helpers consumed by the grading /
+verification pipeline: the Unique-branch gate, the rank-floor rule, the
+evidence-grade reader, and the level-name/level-order metadata.
 """
 
 import json
 import os
-from datetime import date, datetime, timezone
-
-from .treeManager import load_tree, save_tree
-from .registry import promotion_candidates_path, registry_graph_path
-from .leveling import level_index, effective_level
 
 # Grade ordering for evidence rows: S > A > B > C (index 0 = strongest).
 _GRADE_ORDER = ["S", "A", "B", "C"]
@@ -46,21 +44,6 @@ def next_level(current: str) -> str | None:
         return None
     return LEVEL_ORDER[idx + 1]
 
-
-def _get_skill_from_graph(graph_data: dict, skill_id: str) -> dict | None:
-    """Look up a skill node by ID in the graph data."""
-    for skill in graph_data.get("skills", []):
-        if skill["id"] == skill_id:
-            return skill
-    return None
-
-
-def _get_skill_from_tree(tree_data: dict, skill_id: str) -> dict | None:
-    """Look up a skill entry by ID in the user's tree."""
-    for entry in tree_data.get("unlockedSkills", []):
-        if entry["skillId"] == skill_id:
-            return entry
-    return None
 
 
 def _effective_grade(ev: dict) -> str | None:
@@ -151,53 +134,6 @@ def _meets_evidence_floor(graph_skill: dict, target_level: str) -> bool:
         if _GRADE_ORDER.index(grade) <= floor_index:
             return True
     return False
-
-
-def check_promotion_eligibility(graph_data: dict, tree_data: dict) -> list[dict]:
-    """Return a list of skills eligible for promotion.
-
-    Each entry is a dict with keys:
-        - skillId: the skill identifier
-        - currentLevel: the level in the user's tree
-        - nextLevel: the level it would be promoted to
-        - name: display name from the graph
-    """
-    eligible = []
-    for entry in tree_data.get("unlockedSkills", []):
-        skill_id = entry["skillId"]
-        current = entry["level"]
-        target = next_level(current)
-        if target is None:
-            continue
-        graph_skill = _get_skill_from_graph(graph_data, skill_id)
-        if graph_skill is None:
-            continue
-        # Demerits define an explicit progression ceiling for this skill.
-        if graph_skill.get("demerits") and level_index(target) > level_index(effective_level(graph_skill)):
-            continue
-        if _meets_evidence_floor(graph_skill, target):
-            eligible.append({
-                "skillId": skill_id,
-                "currentLevel": current,
-                "nextLevel": target,
-                "suggestedLevel": target,
-                "name": graph_skill.get("name", skill_id),
-                "evidence": graph_skill.get("evidence", []),
-            })
-    return eligible
-
-
-def top_named_level(named_buckets: dict, skill_id: str) -> str | None:
-    """Return the highest named-variant star for a generic id (or None).
-
-    Stars live only on named skills now, so a generic ref's effective rank is
-    the maximum star across its named implementations.
-    """
-    entries = named_buckets.get(skill_id) or []
-    levels = [e.get("level") for e in entries if e.get("level") in LEVEL_ORDER]
-    if not levels:
-        return None
-    return max(levels, key=level_index)
 
 
 # Unique-branch grade gates (Yggdrasil II Q3, amended 2026-07-19): 4★ Unique
@@ -343,226 +279,3 @@ def checkUniqueBranchGate(
         "passed": passed,
     }
 
-
-def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def _parse_scanned_at(value: str) -> datetime | None:
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
-def write_promotion_candidates(registry_path: str, username: str, candidates: list[dict]) -> str:
-    path = promotion_candidates_path(registry_path)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    normalized = []
-    for candidate in candidates:
-        suggested = candidate.get("suggestedLevel") or candidate.get("nextLevel")
-        normalized.append({
-            "skillId": candidate.get("skillId"),
-            "currentLevel": candidate.get("currentLevel"),
-            "suggestedLevel": suggested,
-            "evidence": candidate.get("evidence", []),
-        })
-    payload = {
-        "scannedAt": _utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
-        "username": username,
-        "candidates": normalized,
-    }
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(payload, f, indent=2)
-        f.write("\n")
-    return path
-
-
-def load_promotion_candidates(registry_path: str, max_age_hours: int = 24) -> dict:
-    path = promotion_candidates_path(registry_path)
-    if not os.path.exists(path):
-        raise ValueError("Run `gaia scan` first before promoting skills.")
-    with open(path, "r", encoding="utf-8") as f:
-        payload = json.load(f)
-    scanned_at = _parse_scanned_at(payload.get("scannedAt", ""))
-    if scanned_at is None:
-        raise ValueError("Run `gaia scan` again before promoting skills.")
-    age_seconds = (_utc_now() - scanned_at).total_seconds()
-    if age_seconds > max_age_hours * 60 * 60:
-        raise ValueError("Run `gaia scan` again before promoting skills.")
-    return payload
-
-
-def _candidate_for(payload: dict, skill_id: str) -> dict | None:
-    for candidate in payload.get("candidates", []):
-        if candidate.get("skillId") != skill_id:
-            continue
-        return candidate
-    return None
-
-
-def promotable_candidates(registry_path: str, username: str | None = None) -> list[dict]:
-    payload = load_promotion_candidates(registry_path)
-    if username and payload.get("username") != username:
-        raise ValueError("Run `gaia scan` first for the current user before promoting skills.")
-    return payload.get("candidates", [])
-
-
-def promote_from_candidates(
-    username: str,
-    skill_id: str,
-    registry_path: str,
-    new_display_name: str | None = None,
-) -> dict:
-    payload = load_promotion_candidates(registry_path)
-    if payload.get("username") != username:
-        raise ValueError("Run `gaia scan` first for the current user before promoting skills.")
-    candidate = _candidate_for(payload, skill_id)
-    if candidate is None:
-        raise ValueError("Only skills listed as promotion candidates can be promoted. Run `gaia scan` first.")
-    suggested_level = candidate.get("suggestedLevel")
-    if suggested_level not in LEVEL_ORDER:
-        raise ValueError("Run `gaia scan` again before promoting skills.")
-
-    tree_data = load_tree(username, registry_path)
-    if tree_data is None:
-        raise ValueError(f"No skill tree found for user '{username}'.")
-    entry = _get_skill_from_tree(tree_data, skill_id)
-    if entry is None:
-        raise ValueError("Only skills listed as promotion candidates can be promoted. Run `gaia scan` first.")
-    if entry.get("level") != candidate.get("currentLevel"):
-        raise ValueError("Run `gaia scan` again before promoting skills.")
-
-    previous = entry.get("level")
-    entry["level"] = suggested_level
-    tree_data["updatedAt"] = date.today().isoformat()
-    save_tree(username, tree_data, registry_path)
-
-    from gaia_cli.timeline import append_skill_tree_event
-    append_skill_tree_event(
-        username,
-        skill_id,
-        "ascend" if suggested_level == "6★" else "rank_up",
-        f"Leveled up from {previous} to {suggested_level}",
-        registry_path
-    )
-
-    display_name = new_display_name
-    if display_name is None:
-        graph_path = registry_graph_path(registry_path)
-        if os.path.exists(graph_path):
-            with open(graph_path, "r", encoding="utf-8") as f:
-                graph_data = json.load(f)
-            graph_skill = _get_skill_from_graph(graph_data, skill_id)
-            if graph_skill:
-                display_name = graph_skill.get("name", skill_id)
-    return {
-        "skillId": skill_id,
-        "previousLevel": previous,
-        "newLevel": suggested_level,
-        "displayName": display_name or skill_id,
-    }
-
-
-def promote_skill(
-    username: str,
-    skill_id: str,
-    registry_path: str,
-    new_display_name: str | None = None,
-) -> dict:
-    """Promote a skill to the next level in the user's tree.
-
-    Args:
-        username: GitHub username.
-        skill_id: The skill ID to promote.
-        registry_path: Path to the registry root (where skill-trees/ lives).
-        new_display_name: Optional new display name (unused in tree storage
-            but returned in the result dict for downstream consumers).
-
-    Returns:
-        A dict with keys: skillId, previousLevel, newLevel, displayName.
-
-    Raises:
-        ValueError: If the skill is not found in the tree or is already at max level.
-    """
-    tree_data = load_tree(username, registry_path)
-    if tree_data is None:
-        raise ValueError(f"No skill tree found for user '{username}'.")
-
-    entry = _get_skill_from_tree(tree_data, skill_id)
-    if entry is None:
-        raise ValueError(f"Skill '{skill_id}' not found in {username}'s tree.")
-
-    current = entry["level"]
-    target = next_level(current)
-    if target is None:
-        raise ValueError(
-            f"Skill '{skill_id}' is already at maximum level ({current})."
-        )
-
-    # Update the level in-place
-    entry["level"] = target
-
-    # Update the tree's updatedAt timestamp
-    tree_data["updatedAt"] = date.today().isoformat()
-
-    save_tree(username, tree_data, registry_path)
-
-    from gaia_cli.timeline import append_skill_tree_event
-    append_skill_tree_event(
-        username,
-        skill_id,
-        "ascend" if target == "6★" else "rank_up",
-        f"Leveled up from {current} to {target}",
-        registry_path
-    )
-
-    # Load graph to get display name if not provided
-    display_name = new_display_name
-    if display_name is None:
-        graph_path = registry_graph_path(registry_path)
-        if os.path.exists(graph_path):
-            with open(graph_path, "r", encoding="utf-8") as f:
-                graph_data = json.load(f)
-            graph_skill = _get_skill_from_graph(graph_data, skill_id)
-            if graph_skill:
-                display_name = graph_skill.get("name", skill_id)
-        if display_name is None:
-            display_name = skill_id
-
-    return {
-        "skillId": skill_id,
-        "previousLevel": current,
-        "newLevel": target,
-        "displayName": display_name,
-    }
-
-
-def promotion_state(skill_id: str, tree_data: dict, graph_data: dict) -> str:
-    """Return the promotion state for a skill.
-
-    Possible return values:
-        - "not_unlocked" — skill is not in the user's tree
-        - "max_level" — skill is already at max level (6★)
-        - "eligible" — skill can be promoted (evidence requirement met)
-        - "blocked" — next level requires evidence the graph skill lacks
-    """
-    entry = _get_skill_from_tree(tree_data, skill_id)
-    if entry is None:
-        return "not_unlocked"
-
-    current = entry["level"]
-    target = next_level(current)
-    if target is None:
-        return "max_level"
-
-    graph_skill = _get_skill_from_graph(graph_data, skill_id)
-    if graph_skill is None:
-        return "blocked"
-
-    if _meets_evidence_floor(graph_skill, target):
-        return "eligible"
-
-    return "blocked"

--- a/src/gaia_cli/selector.py
+++ b/src/gaia_cli/selector.py
@@ -79,14 +79,6 @@ def _build_catalogue() -> list[tuple[str, list[MenuItem]]]:
         ],
     )
 
-    promote_item = MenuItem(
-        label="promote", rank="5★", desc="Rank up a detected skill",
-        argv=["promote"],
-        flags=[
-            ("--all", "Promote all candidates"),
-        ],
-    )
-
     graph_item = MenuItem(
         label="graph", rank="1★", desc="Open skills graph",
         argv=["graph"],
@@ -137,7 +129,6 @@ def _build_catalogue() -> list[tuple[str, list[MenuItem]]]:
 
     daily = [
         tree_item,
-        promote_item,
         MenuItem(label="fuse",    rank="5★", desc="Create a skill fusion",  argv=["fuse"]),
         MenuItem(label="pull",    rank="3★", desc="Fetch latest registry",  argv=["pull"]),
         MenuItem(label="appraise",rank="4★", desc="Appraise a skill",       argv=["appraise"]),

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -271,14 +271,14 @@ def test_whoami_output_bootstrap(monkeypatch, registry_bootstrap, capsys):
 
 # ── Regression: player-facing flows are NOT gated ────────────────────────────
 
-def test_promote_command_not_gated(monkeypatch, registry_with_verifier):
-    """gaia promote is player-facing and must never require Verifier auth."""
+def test_fuse_command_not_gated(monkeypatch, registry_with_verifier):
+    """gaia fuse is player-facing and must never require Verifier auth."""
     monkeypatch.setattr("gaia_cli.authz._gaia_user", lambda: "bob")
     monkeypatch.setattr(sys, "argv", [
-        "gaia", "--registry", str(registry_with_verifier), "promote",
+        "gaia", "--registry", str(registry_with_verifier), "fuse",
     ])
-    # gaia promote without a scan candidate just exits(0) or prints a message;
-    # the important invariant is it does NOT exit(1) with an authz error.
+    # gaia fuse without a target just prints a usage message; the important
+    # invariant is it does NOT exit(1) with an authz error.
     try:
         main()
     except SystemExit as e:

--- a/tests/test_card_renderer.py
+++ b/tests/test_card_renderer.py
@@ -12,7 +12,7 @@ from gaia_cli.cardRenderer import (
     render_card,
     render_card_compact,
     render_cards,
-    render_promotion_prompt,
+    render_fusion_awaken_card,
     render_fusion_diagram,
     load_and_render,
     _pad,
@@ -361,47 +361,64 @@ class TestRenderCards:
         assert result == ""
 
 
-class TestRenderPromotionPrompt:
+class TestRenderFusionAwakenCard:
     def test_shows_skill_id_with_slash(self):
-        prompt = render_promotion_prompt(
-            {"id": "plan-and-execute", "name": "Different Registry Name", "type": "extra", "prerequisites": ["a", "b"]},
-            "4★",
+        card = render_fusion_awaken_card(
+            {"id": "plan-and-execute", "name": "Different Registry Name", "type": "fusion", "prerequisites": ["a", "b"]},
         )
-        assert "/plan-and-execute" in prompt
-        assert "gaia promote plan-and-execute" in prompt
+        assert "/plan-and-execute" in card
 
-    def test_shows_level_and_rank_name(self):
-        prompt = render_promotion_prompt({"id": "research-agent", "type": "extra", "prerequisites": ["x"]}, "3★")
-        assert "3★" in prompt
-        assert "gaia promote research-agent" in prompt
+    def test_quotes_no_level_or_medallion(self):
+        """Ygg II: the card quotes NO star level and no Extra/Unique decoration."""
+        card = render_fusion_awaken_card(
+            {"id": "research-agent", "type": "fusion", "prerequisites": ["x"]},
+        )
+        assert "Level" not in card
+        assert "★" not in card
+        assert "Extra" not in card and "Unique" not in card
+        assert "gaia promote" not in card
+
+    def test_awaken_hint_shows_when_parent_empty(self):
+        card = render_fusion_awaken_card(
+            {"id": "research", "type": "fusion", "prerequisites": ["web-search"]},
+            parent_has_named=False,
+        )
+        assert "gaia fuse research" in card
+        assert "gaia push" in card
+
+    def test_awaken_hint_hidden_when_parent_has_named(self):
+        card = render_fusion_awaken_card(
+            {"id": "research", "type": "fusion", "prerequisites": ["web-search"]},
+            parent_has_named=True,
+        )
+        assert "gaia fuse" not in card
+        assert "gaia push" not in card
 
     def test_shows_fusion_diagram_when_prereqs_exist(self):
-        prompt = render_promotion_prompt(
-            {"id": "research", "type": "extra", "prerequisites": ["web-search", "summarize"]},
-            "3★",
+        card = render_fusion_awaken_card(
+            {"id": "research", "type": "fusion", "prerequisites": ["web-search", "summarize"]},
         )
-        assert "──▶" in prompt
+        assert "──▶" in card
 
     def test_box_closes_and_no_cutoff(self):
-        """Regression for #118: the promotion box must size to its content so the
-        Rename? hint is never clipped, and every content row must close with the
-        right border aligned to the top/bottom rules."""
+        """Regression for #118: the box must size to its content so the widest
+        row is never clipped, and every content row must close with the right
+        border aligned to the top/bottom rules."""
         import re
 
-        # A long skill id makes the Rename? line the widest row — the old fixed
-        # 55-dash border cut it off.
-        prompt = render_promotion_prompt(
-            {"id": "autonomous-research-and-synthesis-agent", "type": "extra", "prerequisites": []},
-            "4★",
+        # A long skill id makes the awaken line the widest row.
+        card = render_fusion_awaken_card(
+            {"id": "autonomous-research-and-synthesis-agent", "type": "fusion", "prerequisites": []},
+            parent_has_named=False,
         )
         ansi = re.compile(r"\x1b\[[0-9;]*m")
         box_lines = [
             ansi.sub("", ln)
-            for ln in prompt.split("\n")
+            for ln in card.split("\n")
             if "│" in ln or "┌" in ln or "└" in ln
         ]
-        # The full rename command must appear intact (not truncated with an ellipsis).
-        assert 'gaia promote autonomous-research-and-synthesis-agent --name' in prompt
+        # The full awaken command must appear intact (not truncated).
+        assert "gaia fuse autonomous-research-and-synthesis-agent" in card
         assert "…" not in "".join(box_lines)
         # Top, content, and bottom rows all share one right-edge column.
         edge_cols = {ln.rstrip().index("┐") if "┐" in ln

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -226,7 +226,7 @@ class TestHelp:
             run_cli(monkeypatch, ["--help"])
         out = strip_ansi(capsys.readouterr().out)
         # These appear in COMMAND_USAGE epilog
-        for cmd in ("init", "scan", "push", "tree", "promote"):
+        for cmd in ("init", "scan", "push", "tree", "fuse"):
             assert cmd in out, f"Expected '{cmd}' in --help output"
 
 

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -144,7 +144,6 @@ def test_top_level_help_shows_all_public_commands_with_usage(monkeypatch, capsys
         "release",
         "graph",
         "appraise",
-        "promote",
         "docs",
         "lookup",
         "skills",
@@ -222,9 +221,11 @@ def test_skills_info_accepts_leading_slash_named_skill_id(tmp_path, monkeypatch,
     assert "Test skill." in output
 
 
-def test_promote_label_override_is_not_available(monkeypatch):
+def test_promote_command_is_retired(monkeypatch):
+    """Ygg II no-self-promote: `gaia promote` is fully removed and falls to
+    argparse's invalid-choice error (exit 2)."""
     with pytest.raises(SystemExit) as exc:
-        run_cli(monkeypatch, ["promote", "web-search", "--label", "3★"])
+        run_cli(monkeypatch, ["promote", "web-search"])
     assert exc.value.code == 2
 
 

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -1,8 +1,9 @@
-"""Tests for src/gaia_cli/promotion.py — level promotion logic."""
+"""Tests for src/gaia_cli/promotion.py — canon-side rank/grade helpers.
 
-import json
-import os
-from datetime import date
+Under Yggdrasil II the self-promote machinery (candidate handshake, level
+writes into user trees) has been retired. These tests cover the surviving
+canon-curation helpers plus the pure level/evidence helpers.
+"""
 
 import pytest
 
@@ -10,9 +11,6 @@ from gaia_cli.promotion import (
     LEVEL_ORDER,
     LEVEL_NAMES,
     next_level,
-    check_promotion_eligibility,
-    promote_skill,
-    promotion_state,
     _effective_grade,
     _meets_evidence_floor,
     _holds_bucket_origin,
@@ -24,11 +22,6 @@ from gaia_cli.promotion import (
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-def _make_graph(*skills):
-    """Build a minimal graph_data dict from skill dicts."""
-    return {"skills": list(skills), "edges": []}
 
 
 def _make_skill(skill_id, name=None, level="0★", evidence=None, demerits=None):
@@ -50,39 +43,6 @@ def _make_skill(skill_id, name=None, level="0★", evidence=None, demerits=None)
         "version": "0.1.0",
         "demerits": demerits or [],
     }
-
-
-def _make_tree(username, unlocked_skills):
-    """Build a minimal tree_data dict."""
-    return {
-        "userId": username,
-        "updatedAt": "2026-01-01",
-        "unlockedSkills": unlocked_skills,
-        "pendingCombinations": [],
-        "stats": {
-            "totalUnlocked": len(unlocked_skills),
-            "deepestLineage": 0,
-        },
-    }
-
-
-def _make_unlocked(skill_id, level="1★"):
-    """Build a minimal unlockedSkill entry."""
-    return {
-        "skillId": skill_id,
-        "level": level,
-        "unlockedAt": "2026-01-01",
-        "unlockedIn": "test/repo",
-    }
-
-
-def _write_tree(tmp_path, username, tree_data):
-    """Write tree_data to the expected file path under tmp_path."""
-    tree_dir = tmp_path / "skill-trees" / username
-    tree_dir.mkdir(parents=True, exist_ok=True)
-    tree_path = tree_dir / "skill-tree.json"
-    tree_path.write_text(json.dumps(tree_data, indent=2))
-    return tree_path
 
 
 # ---------------------------------------------------------------------------
@@ -116,206 +76,6 @@ class TestNextLevel:
             visited.append(nxt)
             level = nxt
         assert visited == LEVEL_ORDER
-
-
-# ---------------------------------------------------------------------------
-# Tests: check_promotion_eligibility
-# ---------------------------------------------------------------------------
-
-
-class TestCheckPromotionEligibility:
-    def test_basic_skill_eligible_no_evidence_needed(self):
-        """0★★ -> 1★ requires no evidence, so skill is eligible."""
-        graph = _make_graph(_make_skill("tokenize"))
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "0★")])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 1
-        assert eligible[0]["skillId"] == "tokenize"
-        assert eligible[0]["currentLevel"] == "0★"
-        assert eligible[0]["nextLevel"] == "1★"
-
-    def test_level_I_to_II_eligible_with_class_C_evidence(self):
-        """1★ -> 2★ requires class C/B/A evidence."""
-        ev = [{"class": "C", "source": "http://example.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
-        graph = _make_graph(_make_skill("tokenize", evidence=ev))
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "1★")])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 1
-        assert eligible[0]["nextLevel"] == "2★"
-
-    def test_level_I_to_II_not_eligible_without_evidence(self):
-        """1★ -> 2★ blocked if no evidence at all."""
-        graph = _make_graph(_make_skill("tokenize"))
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "1★")])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 0
-
-    def test_level_II_to_III_requires_class_B(self):
-        """2★ -> 3★ requires class B or A evidence."""
-        ev_c_only = [{"class": "C", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
-        graph = _make_graph(_make_skill("tokenize", evidence=ev_c_only))
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "2★")])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 0  # C is not enough for 3★
-
-    def test_level_II_to_III_eligible_with_class_B(self):
-        ev_b = [{"class": "B", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
-        graph = _make_graph(_make_skill("tokenize", evidence=ev_b))
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "2★")])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 1
-        assert eligible[0]["nextLevel"] == "3★"
-
-    def test_max_level_not_eligible(self):
-        """A skill at 6★ cannot be promoted further."""
-        ev = [{"class": "A", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
-        graph = _make_graph(_make_skill("tokenize", evidence=ev))
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "6★")])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 0
-
-    def test_multiple_skills_mixed_eligibility(self):
-        """Only eligible skills appear in the result list."""
-        ev_b = [{"class": "B", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
-        graph = _make_graph(
-            _make_skill("tokenize", evidence=ev_b),
-            _make_skill("classify"),  # no evidence
-        )
-        tree = _make_tree("alice", [
-            _make_unlocked("tokenize", "0★"),   # eligible (no evidence needed for 0★->1★)
-            _make_unlocked("classify", "1★"),   # not eligible (no evidence for 1★->2★)
-        ])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 1
-        assert eligible[0]["skillId"] == "tokenize"
-
-    def test_skill_not_in_graph_skipped(self):
-        """If a tree skill doesn't exist in the graph, it's skipped."""
-        graph = _make_graph()  # empty graph
-        tree = _make_tree("alice", [_make_unlocked("phantom", "1★")])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 0
-
-    def test_promotion_blocked_by_demerit_ceiling(self):
-        """One demerit can lower effective ceiling so next level is blocked."""
-        ev_b = [{"class": "B", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
-        graph = _make_graph(
-            _make_skill(
-                "tokenize",
-                level="3★",
-                evidence=ev_b,
-                demerits=["heavyweight-dependency"],
-            )
-        )
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "2★")])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 0
-
-
-# ---------------------------------------------------------------------------
-# Tests: promote_skill
-# ---------------------------------------------------------------------------
-
-
-class TestPromoteSkill:
-    def test_promotes_skill_one_level(self, tmp_path):
-        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "1★")])
-        _write_tree(tmp_path, "alice", tree_data)
-        result = promote_skill("alice", "tokenize", str(tmp_path), new_display_name="Tokenize")
-        assert result["skillId"] == "tokenize"
-        assert result["previousLevel"] == "1★"
-        assert result["newLevel"] == "2★"
-        assert result["displayName"] == "Tokenize"
-
-    def test_persists_new_level_to_disk(self, tmp_path):
-        tree_data = _make_tree("bob", [_make_unlocked("classify", "2★")])
-        _write_tree(tmp_path, "bob", tree_data)
-        promote_skill("bob", "classify", str(tmp_path), new_display_name="Classify")
-        # Re-read from disk
-        tree_path = tmp_path / "skill-trees" / "bob" / "skill-tree.json"
-        saved = json.loads(tree_path.read_text())
-        entry = next(s for s in saved["unlockedSkills"] if s["skillId"] == "classify")
-        assert entry["level"] == "3★"
-
-    def test_updates_updated_at(self, tmp_path):
-        tree_data = _make_tree("carol", [_make_unlocked("tokenize", "0★")])
-        _write_tree(tmp_path, "carol", tree_data)
-        promote_skill("carol", "tokenize", str(tmp_path), new_display_name="Tokenize")
-        tree_path = tmp_path / "skill-trees" / "carol" / "skill-tree.json"
-        saved = json.loads(tree_path.read_text())
-        assert saved["updatedAt"] == date.today().isoformat()
-
-    def test_raises_if_no_tree(self, tmp_path):
-        with pytest.raises(ValueError, match="No skill tree found"):
-            promote_skill("nobody", "tokenize", str(tmp_path))
-
-    def test_raises_if_skill_not_in_tree(self, tmp_path):
-        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "1★")])
-        _write_tree(tmp_path, "alice", tree_data)
-        with pytest.raises(ValueError, match="not found"):
-            promote_skill("alice", "nonexistent", str(tmp_path))
-
-    def test_raises_if_already_max_level(self, tmp_path):
-        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "6★")])
-        _write_tree(tmp_path, "alice", tree_data)
-        with pytest.raises(ValueError, match="maximum level"):
-            promote_skill("alice", "tokenize", str(tmp_path))
-
-    def test_reads_display_name_from_graph_when_not_provided(self, tmp_path):
-        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "1★")])
-        _write_tree(tmp_path, "alice", tree_data)
-        # Write a graph file
-        graph_dir = tmp_path / "registry"
-        graph_dir.mkdir(parents=True, exist_ok=True)
-        graph_data = _make_graph(_make_skill("tokenize", name="Tokenize"))
-        (graph_dir / "gaia.json").write_text(json.dumps(graph_data))
-        result = promote_skill("alice", "tokenize", str(tmp_path))
-        assert result["displayName"] == "Tokenize"
-
-    def test_fallback_display_name_when_no_graph(self, tmp_path):
-        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "1★")])
-        _write_tree(tmp_path, "alice", tree_data)
-        # No graph file exists
-        result = promote_skill("alice", "tokenize", str(tmp_path))
-        assert result["displayName"] == "tokenize"
-
-
-# ---------------------------------------------------------------------------
-# Tests: promotion_state
-# ---------------------------------------------------------------------------
-
-
-class TestPromotionState:
-    def test_not_unlocked(self):
-        graph = _make_graph(_make_skill("tokenize"))
-        tree = _make_tree("alice", [])
-        assert promotion_state("tokenize", tree, graph) == "not_unlocked"
-
-    def test_max_level(self):
-        graph = _make_graph(_make_skill("tokenize"))
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "6★")])
-        assert promotion_state("tokenize", tree, graph) == "max_level"
-
-    def test_eligible_no_evidence_needed(self):
-        graph = _make_graph(_make_skill("tokenize"))
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "0★")])
-        assert promotion_state("tokenize", tree, graph) == "eligible"
-
-    def test_eligible_with_evidence(self):
-        ev = [{"class": "B", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
-        graph = _make_graph(_make_skill("tokenize", evidence=ev))
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "1★")])
-        assert promotion_state("tokenize", tree, graph) == "eligible"
-
-    def test_blocked_by_evidence(self):
-        graph = _make_graph(_make_skill("tokenize"))  # no evidence
-        tree = _make_tree("alice", [_make_unlocked("tokenize", "1★")])
-        assert promotion_state("tokenize", tree, graph) == "blocked"
-
-    def test_blocked_skill_not_in_graph(self):
-        graph = _make_graph()  # empty
-        tree = _make_tree("alice", [_make_unlocked("phantom", "2★")])
-        assert promotion_state("phantom", tree, graph) == "blocked"
 
 
 # ---------------------------------------------------------------------------
@@ -410,18 +170,6 @@ class TestGradeTranslation:
                         "date": "2026-01-01", "notes": "no grade or class"}],
         )
         assert _meets_evidence_floor(skill, "2★") is False
-
-    # Integration: grade-only evidence propagates through check_promotion_eligibility.
-    def test_grade_only_evidence_enables_eligibility(self):
-        """A skill with grade-only evidence is included in promotion candidates."""
-        ev = [{"grade": "B", "source": "http://x.com", "evaluator": "x",
-               "date": "2026-01-01", "notes": ""}]
-        graph = _make_graph(_make_skill("graded-skill", evidence=ev))
-        tree = _make_tree("alice", [_make_unlocked("graded-skill", "2★")])
-        eligible = check_promotion_eligibility(graph, tree)
-        assert len(eligible) == 1
-        assert eligible[0]["skillId"] == "graded-skill"
-        assert eligible[0]["nextLevel"] == "3★"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry_layout.py
+++ b/tests/test_registry_layout.py
@@ -1,13 +1,6 @@
 import json
-from datetime import datetime, timedelta, timezone
 
 import pytest
-
-from gaia_cli.promotion import (
-    load_promotion_candidates,
-    promote_from_candidates,
-    write_promotion_candidates,
-)
 
 pytestmark = [pytest.mark.integration]
 
@@ -56,63 +49,3 @@ def test_write_skill_batch_uses_registry_for_review(tmp_path):
     assert batch_path == str(tmp_path / "registry-for-review" / "skill-batches" / "batch-1.json")
     assert json.loads((tmp_path / "registry-for-review" / "skill-batches" / "batch-1.json").read_text()) == batch
 
-
-def test_promotion_candidates_round_trip(tmp_path):
-    candidates = [
-        {
-            "skillId": "web-search",
-            "currentLevel": "2★",
-            "suggestedLevel": "3★",
-            "evidence": [{"source": "scan"}],
-        }
-    ]
-
-    path = write_promotion_candidates(str(tmp_path), "alice", candidates)
-    loaded = load_promotion_candidates(str(tmp_path), max_age_hours=24)
-
-    assert path == str(tmp_path / "generated-output" / "promotion-candidates.json")
-    assert loaded["username"] == "alice"
-    assert loaded["candidates"] == candidates
-
-
-def test_promotion_refuses_missing_or_stale_candidates(tmp_path):
-    with pytest.raises(ValueError, match="Run `gaia scan` first"):
-        load_promotion_candidates(str(tmp_path), max_age_hours=24)
-
-    out_dir = tmp_path / "generated-output"
-    out_dir.mkdir()
-    stale = {
-        "scannedAt": (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat().replace("+00:00", "Z"),
-        "username": "alice",
-        "candidates": [],
-    }
-    (out_dir / "promotion-candidates.json").write_text(json.dumps(stale), encoding="utf-8")
-
-    with pytest.raises(ValueError, match="Run `gaia scan` again"):
-        load_promotion_candidates(str(tmp_path), max_age_hours=24)
-
-
-def test_promote_from_candidates_uses_scan_suggested_level(tmp_path):
-    save_tree(
-        "alice",
-        {
-            "userId": "alice",
-            "updatedAt": "2026-05-01",
-            "unlockedSkills": [
-                {"skillId": "web-search", "level": "2★", "unlockedAt": "2026-05-01", "unlockedIn": "test"},
-                {"skillId": "parse-html", "level": "2★", "unlockedAt": "2026-05-01", "unlockedIn": "test"},
-            ],
-        },
-        registry_path=str(tmp_path),
-    )
-    write_promotion_candidates(
-        str(tmp_path),
-        "alice",
-        [{"skillId": "web-search", "currentLevel": "2★", "suggestedLevel": "3★", "evidence": []}],
-    )
-
-    result = promote_from_candidates("alice", "web-search", str(tmp_path))
-    assert result["newLevel"] == "3★"
-
-    with pytest.raises(ValueError, match="Only skills listed as promotion candidates can be promoted"):
-        promote_from_candidates("alice", "parse-html", str(tmp_path))


### PR DESCRIPTION
## Ygg II Batch 0 — "No self-promote"

Part of the Yggdrasil II CLI-alignment sprint. Umbrella: #1225.

Under Yggdrasil II, rank/level is assigned **only** by canon curation (dev-gated). The non-dev CLI's job ends at *propose* (`gaia scan → gaia fuse → gaia push`). This PR retires the ungated self-promote mechanic that wrote rank directly into the user's `skill-tree.json`, and replaces the scan "Promotion Available" card with a **levelless fusion/awaken card**.

Discovered during the Batch 1 dry-run (the 4★-fusion mislabel was a symptom); ratified by the maintainer 2026-07-23. No dedicated issue — this is in-sprint work under umbrella #1225. Full spec: `docs/agents/ygg2-cli-alignment-plan.md` (§ BATCH 0).

### What changed
- **Deleted `gaia promote`** — command class, argparse, dispatch, `PUBLIC_COMMANDS`/usage entry. Clean delete (no shim); `gaia promote` now falls to argparse `invalid choice`.
- **Deleted bulk `--all` self-promote** (`promote_all_candidates`) and the `promote_command` impl.
- **Excised 5 self-promote fns** from `promotion.py` (`promote_from_candidates`, `promote_skill`, `write_promotion_candidates`, `load_promotion_candidates`, `check_promotion_eligibility`). **Kept** the canon-side helpers `checkUniqueBranchGate`, `_passes_rank_floor`, `effectiveGrade`, `LEVEL_NAMES` (imported by `verification.py` + `scripts/migrate_taxonomy_v6.py`).
- **Reshaped the scan card** — `render_promotion_prompt` → `render_fusion_awaken_card`: quotes NO star level, no Extra/Unique/medallion decoration; the awaken hint (`gaia fuse` + `gaia push`) appears only when the generic parent is empty. `hook.py` computes it fresh from `nearUnlocks` (no candidate file).
- **Custom `gaia fuse`** now writes `type:"fusion"` with **no `level`** (canon-tied combo mirror keeps its inherited `levelFloor` — that mirrors canon, not self-declaration).
- **appraise** — dropped the "promotable to Level N" hint.
- **Docs sweep** + removed the phantom `--auto-promote` references from `docs/en/cli-reference.html`.
- **Tests aligned** — retired self-promote coverage, kept canon-helper coverage.

### Invariant
No non-dev CLI path writes rank/level into `skill-trees/<user>/skill-tree.json`. The only `unlockedSkills.append` is the sanctioned canon-tied combo mirror.

### Tests
`pytest tests/`: 4 fewer failures than base, zero new (the 4 removed are the retired self-promote tests). The 2 residual `TestGradeTranslation` failures are **pre-existing** on the base branch (a `schema/`-scope `evidenceFloors` regression in staging — see below).

### Scope note
Touches `docs/en/cli-reference.html` (`.html`, outside the `cli/` `*.md` glob) — `skip-scope-check` applied, consistent with the umbrella #1248's own scope note.

### Out-of-scope finding (flagging, not fixing here)
`registry/schema/meta.json` `evidenceFloors` exists on `main` but was dropped in `dev/yggdrasil-ii-staging` → `_meets_evidence_floor` always passes. Untouchable from a `cli/` branch; candidate for a `schema/` follow-up.

### Token spend
2026-07-23 Opus 4.x: ~155k in, ~34k out (implementation subagent) + ~46k (baseline suite verification). Orchestrator planning/verification additional.
