### PR TITLE
cli(ygg2): Batch 2 — gaia stats consumes meta-driven type axis (basic/fusion)

### DIFF
--- a/src/gaia_cli/commands/stats.py
+++ b/src/gaia_cli/commands/stats.py
@@ -13,6 +13,7 @@ from gaia_cli.formatting import (
     TIER_COLORS,
     RANK_COLORS,
     TYPE_SYMBOLS,
+    TYPE_LABELS,
     _use_color,
     _fg,
     _reset,
@@ -23,13 +24,6 @@ from gaia_cli.registry import (
     registry_graph_path,
     named_skills_index_path,
 )
-
-TYPE_LABELS = {
-    "basic": "Basic Skill",
-    "extra": "Extra Skill",
-    "unique": "Unique Skill",
-    "ultimate": "Ultimate Skill",
-}
 
 LEVEL_LABELS = {
     "0★": "Basic",
@@ -42,7 +36,10 @@ LEVEL_LABELS = {
 }
 
 LEVEL_ORDER = ("0★", "1★", "2★", "3★", "4★", "5★", "6★")
-TYPE_ORDER = ("basic", "extra", "unique", "ultimate")
+# Type axis is meta.json-driven ({basic, fusion} in Yggdrasil II); derive the
+# render order from the imported meta-driven TYPE_LABELS keys rather than
+# re-authoring the legacy 4-type literal.
+TYPE_ORDER = tuple(TYPE_LABELS.keys())
 EVIDENCE_ORDER = ("A", "B", "C")
 _EVIDENCE_RANK = {
     klass: rank for rank, klass in enumerate(reversed(EVIDENCE_ORDER), start=1)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -95,7 +95,7 @@ def test_render_stats_includes_registry_health_sections(tmp_path):
 
     assert "Gaia Registry — 4 skills  1 edges" in output
     assert "Type breakdown" in output
-    assert "Basic Skill" in output
+    assert "Basic" in output
     assert "Level breakdown" in output
     assert "Effective level breakdown" in output
     assert "Demerits" in output


### PR DESCRIPTION
## Batch 2 — `gaia stats` display alignment

Drops the hardcoded legacy 4-type axis (`basic/extra/unique/ultimate`) from `stats.py` and consumes the meta.json-driven `TYPE_LABELS`/`TYPE_SYMBOLS`/`TIER_COLORS` from `formatting.py`. Type buckets are now `basic`/`fusion` only, matching the Yggdrasil II type axis.

### Changes
- `src/gaia_cli/commands/stats.py`: deleted local `TYPE_LABELS` dict; import it from `formatting.py` (meta-driven); `TYPE_ORDER` derived from meta-driven keys, not re-authored.
- `tests/test_stats.py`: label assertion updated from legacy `Basic Skill` to meta-driven `Basic`.

### Testing
- `pytest tests/test_stats*.py` green (5 passed).
- Manual `gaia stats` → Type breakdown shows basic/fusion only, no empty legacy rows.

### Entrypoints
N/A — CLI display change, no new user-facing page/section.

Umbrella: #1225
Resolves #1222
