### PR TITLE
cli(ygg2): Batch 3a — gaia graph consumes the enriched 3D World Tree graph

### DIFF
--- a/src/gaia_cli/graph.py
+++ b/src/gaia_cli/graph.py
@@ -73,6 +73,57 @@ def load_named_skills(registry_path: str | os.PathLike[str] = ".") -> dict[str, 
         return json.load(f)
 
 
+def resolve_enriched_graph_path(root: Path, custom: str | os.PathLike[str] | None = None) -> Path | None:
+    """Locate the enriched 3D World Tree graph, if one is available locally.
+
+    The lean registry/gaia.json lacks the branch/namedMaxLevel/cluster/rank
+    fields the site's 3D renderer needs for a non-degraded view. Those are baked
+    into docs/graph/gaia.json at release time. This picks the enriched copy when
+    present, in priority order:
+
+      (a) an explicit path passed by the caller,
+      (b) .gaia/registry/graph/gaia.json  (written by `gaia fetch`),
+      (c) <root>/docs/graph/gaia.json     (a repo checkout).
+
+    Returns the first existing path, or None if no enriched graph is found (the
+    caller then falls back to the lean registry/gaia.json).
+    """
+    if custom is not None:
+        p = Path(custom)
+        if p.exists():
+            return p
+    candidates = [
+        Path.cwd() / ".gaia" / "registry" / "graph" / "gaia.json",
+        root / "docs" / "graph" / "gaia.json",
+    ]
+    for cand in candidates:
+        if cand.exists():
+            return cand
+    return None
+
+
+def load_enriched_graph(path: Path) -> dict[str, Any]:
+    """Load an enriched graph JSON from `path`."""
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+_ENRICHED_WARNED = False
+
+
+def _warn_enriched_missing_once() -> None:
+    """Print a one-time stderr hint when no enriched 3D graph is found locally."""
+    global _ENRICHED_WARNED
+    if _ENRICHED_WARNED:
+        return
+    _ENRICHED_WARNED = True
+    print(
+        "Note: run 'gaia fetch' for the full 3D skill-tree view "
+        "(enriched graph not found locally).",
+        file=sys.stderr,
+    )
+
+
 def _stable_angle(skill_id: str, index: int, total: int) -> float:
     # Deterministic jitter prevents same-type nodes from forming a perfectly
     # uniform ring while keeping output stable across machines.
@@ -440,6 +491,10 @@ def render_html(
     if "meta" not in graph:
         graph["meta"] = {"levelColors": {}, "levelLabels": {}}
 
+    # Read the version dynamically from the embedded graph rather than hardcoding
+    # (decorative surfaces must never carry a stale baked-in version — see #807).
+    _graph_version = escape(str(graph.get("version", "")), quote=True)
+
     watermark_style = ""
     watermark_html = ""
     if is_workspace_mode:
@@ -484,7 +539,7 @@ def render_html(
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{_display_title}</title>
   <script>
-    window.GAIA_VERSION = "4.3.12";
+    window.GAIA_VERSION = "{_graph_version}";
     // Point icon base to a path that we will intercept in fetch
     window.gaiaIconBase = function() {{ return 'assets/icons.svg'; }};
   </script>
@@ -568,7 +623,14 @@ def write_graph_artifact(
     is_workspace: bool = False,
 ) -> tuple[Path, dict[str, Any]]:
     root = _registry_root(registry_path)
-    graph = load_graph(root)
+    enriched_path = resolve_enriched_graph_path(root)
+    if enriched_path is not None:
+        graph = load_enriched_graph(enriched_path)
+    else:
+        graph = load_graph(root)
+        # Degrade gracefully: the lean registry/gaia.json renders the 3D tree
+        # all-grey/collapsed. Hint the user (once) toward the enriched view.
+        _warn_enriched_missing_once()
     named_buckets = load_named_skills(root).get("buckets", {})
 
     if custom:
@@ -633,6 +695,9 @@ def write_graph_artifact(
                     "type": "basic",
                     "level": "0★",
                     "prerequisites": csk.get("prerequisites", []),
+                    # Mark uncanonized local skills so the frontend (PR 3c) can
+                    # render them green-starless. Canon skills never carry this.
+                    "custom": True,
                 }
 
         if known_only:

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -2778,6 +2778,7 @@ def fetch_command(args):
                 if m.name.startswith("registry/gaia.json")
                 or m.name.startswith("registry/named-skills.json")
                 or m.name.startswith("registry/named/")
+                or m.name.startswith("docs/graph/")
             ]
             tar.extractall(path=Path(tmpdir) / "unpacked", members=members_to_extract, filter="data")
 
@@ -2833,7 +2834,20 @@ def fetch_command(args):
                 shutil.rmtree(dest_named_dir)
             shutil.copytree(src_named_dir, dest_named_dir)
 
+        # enriched 3D graph (docs/graph/) — the site-served World Tree assets.
+        # The lean registry/gaia.json lacks the branch/namedMaxLevel/cluster/rank
+        # fields the 3D renderer needs; docs/graph/gaia.json carries them. `gaia
+        # graph` prefers this enriched copy when embedding.
+        src_graph_dir = Path(tmpdir) / "unpacked" / "docs" / "graph"
+        dest_graph_dir = registry_dir / "graph"
+        if src_graph_dir.exists():
+            if dest_graph_dir.exists():
+                shutil.rmtree(dest_graph_dir)
+            shutil.copytree(src_graph_dir, dest_graph_dir)
+
     print(f"Registry updated to {tag} at {registry_dir}/")
+    if (registry_dir / "graph").exists():
+        print("Enriched 3D graph updated — run `gaia graph` for the full World Tree view.")
     print("Run `gaia scan` to update your skill tree against the new registry.")
 
 

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -716,6 +716,53 @@ class TestFetch:
         data = json.loads((project / ".gaia" / "registry" / "gaia.json").read_text(encoding="utf-8"))
         assert data["version"] == "fetched"
 
+    def test_fetch_unpacks_enriched_docs_graph(self, project: Path, monkeypatch: pytest.MonkeyPatch):
+        """fetch must unpack docs/graph/ from the tarball into .gaia/registry/graph/.
+
+        The enriched World Tree graph (docs/graph/gaia.json) carries branch/
+        namedMaxLevel/cluster fields the lean registry/gaia.json lacks. `gaia
+        graph` prefers this copy for the full 3D view.
+        """
+        import io
+        import tarfile as _tarfile
+
+        buf = io.BytesIO()
+        with _tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            gaia_data = json.dumps({"version": "test", "skills": []}).encode("utf-8")
+            info = _tarfile.TarInfo(name="registry/gaia.json")
+            info.size = len(gaia_data)
+            tar.addfile(info, io.BytesIO(gaia_data))
+            named_data = json.dumps({"buckets": {}}).encode("utf-8")
+            info2 = _tarfile.TarInfo(name="registry/named-skills.json")
+            info2.size = len(named_data)
+            tar.addfile(info2, io.BytesIO(named_data))
+            # Enriched docs/graph/gaia.json (carries branch/namedMaxLevel)
+            enriched = json.dumps({
+                "version": "test",
+                "skills": [{"id": "web-search", "branch": "research", "namedMaxLevel": "3★"}],
+            }).encode("utf-8")
+            info3 = _tarfile.TarInfo(name="docs/graph/gaia.json")
+            info3.size = len(enriched)
+            tar.addfile(info3, io.BytesIO(enriched))
+            # a nested member to confirm the whole tree is copied
+            idx = json.dumps({"index": []}).encode("utf-8")
+            info4 = _tarfile.TarInfo(name="docs/graph/named/index.json")
+            info4.size = len(idx)
+            tar.addfile(info4, io.BytesIO(idx))
+        tarball = buf.getvalue()
+
+        _patch_fetch_urlopen(monkeypatch, tarball)
+        run_cli(monkeypatch, ["fetch"])
+
+        graph_dir = project / ".gaia" / "registry" / "graph"
+        assert (graph_dir / "gaia.json").exists(), \
+            ".gaia/registry/graph/gaia.json must be written by fetch"
+        assert (graph_dir / "named" / "index.json").exists(), \
+            "the whole docs/graph/ tree must be copied, including nested members"
+        enriched_data = json.loads((graph_dir / "gaia.json").read_text(encoding="utf-8"))
+        assert enriched_data["skills"][0]["branch"] == "research"
+        assert enriched_data["skills"][0]["namedMaxLevel"] == "3★"
+
     def test_fetch_downgrade_blocked(self, project: Path, monkeypatch: pytest.MonkeyPatch, capsys):
         """Attempting to fetch an older registry version must block and exit with 1."""
         # 1. Seed local registry with v2.0.0

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -424,3 +424,106 @@ class TestPushableHighlight:
         render_graph = graph_mod.build_render_graph(self._graph())
         svg = graph_mod.render_svg(render_graph)
         assert "Pushable:" not in svg
+
+
+class TestEnrichedGraphPreference:
+    """Batch 3a - gaia graph prefers the enriched 3D World Tree graph."""
+
+    def _write_enriched(self, root, *, version="9.9.9"):
+        """Write an enriched .gaia/registry/graph/gaia.json carrying branch/namedMaxLevel."""
+        graph_dir = root / ".gaia" / "registry" / "graph"
+        graph_dir.mkdir(parents=True, exist_ok=True)
+        enriched = {
+            "version": version,
+            "generatedAt": "2026-07-23",
+            "skills": [
+                {
+                    "id": "tokenize",
+                    "name": "Tokenize",
+                    "type": "basic",
+                    "level": "1★",
+                    "branch": "core",
+                    "namedMaxLevel": "4★",
+                    "cluster": "foundations",
+                    "prerequisites": [],
+                },
+            ],
+        }
+        (graph_dir / "gaia.json").write_text(json.dumps(enriched), encoding="utf-8")
+        return graph_dir / "gaia.json"
+
+    def test_resolve_prefers_fetched_graph(self, tmp_path, monkeypatch):
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        enriched_path = self._write_enriched(tmp_path)
+
+        resolved = graph_mod.resolve_enriched_graph_path(graph_mod._registry_root(root))
+        assert resolved == enriched_path
+
+    def test_resolve_returns_none_when_absent(self, tmp_path, monkeypatch):
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        assert graph_mod.resolve_enriched_graph_path(graph_mod._registry_root(root)) is None
+
+    def test_render_html_embeds_enriched_graph(self, tmp_path, monkeypatch):
+        """render_html must embed the enriched graph (branch/namedMaxLevel), not the lean one."""
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        self._write_enriched(tmp_path)
+
+        out_path, graph = graph_mod.write_graph_artifact(root, fmt="html")
+        html = out_path.read_text(encoding="utf-8")
+
+        assert '"branch": "core"' in html
+        assert '"namedMaxLevel"' in html
+        assert '"id": "research"' not in html
+        assert graph.get("skills", [{}])[0].get("branch") == "core"
+
+    def test_lean_fallback_warns_once(self, tmp_path, monkeypatch, capsys):
+        """With no enriched graph, render falls back to lean + a stderr hint."""
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(graph_mod, "_ENRICHED_WARNED", False)
+
+        out_path, graph = graph_mod.write_graph_artifact(root, fmt="html")
+        html = out_path.read_text(encoding="utf-8")
+        err = capsys.readouterr().err
+
+        assert '"id": "research"' in html
+        assert "run 'gaia fetch'" in err
+
+    def test_version_read_from_graph_not_hardcoded(self, tmp_path, monkeypatch):
+        """window.GAIA_VERSION must reflect the embedded graph version, not a baked-in literal."""
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        self._write_enriched(tmp_path, version="12.3.4")
+
+        out_path, _ = graph_mod.write_graph_artifact(root, fmt="html")
+        html = out_path.read_text(encoding="utf-8")
+        assert 'window.GAIA_VERSION = "12.3.4"' in html
+        assert "4.3.12" not in html
+
+
+class TestCustomNodeFlag:
+    """Batch 3a - uncanonized local skills carry a `custom` flag for the frontend."""
+
+    def test_custom_skill_carries_custom_flag(self, tmp_path, monkeypatch):
+        root = _make_registry(tmp_path, skills=[
+            {"id": "registry-skill", "name": "Registry Skill", "type": "basic",
+             "level": "1★", "prerequisites": []},
+        ])
+        _make_skill(tmp_path, os.path.join(".agents", "skills"), "local-only",
+                     name="Local Only", description="A local-only custom skill")
+        monkeypatch.chdir(tmp_path)
+
+        _, graph = graph_mod.write_graph_artifact(root, fmt="json", custom=True)
+        by_id = {sk["id"].lstrip("/"): sk for sk in graph["skills"]}
+        assert by_id["local-only"].get("custom") is True
+
+    def test_canon_skill_has_no_custom_flag(self, tmp_path, monkeypatch):
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        _, graph = graph_mod.write_graph_artifact(root, fmt="html")
+        for sk in graph.get("skills", []):
+            assert "custom" not in sk


### PR DESCRIPTION
## Batch 3a — gaia graph 3D data path

Makes `gaia graph` render the SAME 3D World Tree as the website, scoped to the user's tree, by feeding the site's renderer the ENRICHED graph instead of the lean `registry/gaia.json`.

- `gaia fetch`: also unpacks `docs/graph/` from the release tarball (already packaged, previously discarded) into `.gaia/registry/graph/`.
- `gaia graph`: prefers the enriched `graph/gaia.json` (fetched, or repo `docs/graph/`) when embedding; degrades gracefully to lean + a 'run gaia fetch' hint. Enriched base applies to both canon and custom modes.
- Custom nodes carry a `custom` flag (frontend green-starless render lands in a follow-up design PR).
- Fixed the hardcoded stale `window.GAIA_VERSION` (now read dynamically from the embedded graph).

Thin data-pump: the CLI holds ZERO taxonomy/color/layout logic — enrichment is produced once by the site build, shipped in the tarball, consumed here. Zero drift by construction.

### Entrypoints
N/A — CLI command behavior change, no new web page/section.

### Testing
- pytest tests/test_graph.py tests/test_cli_core.py — green (pre-existing PALETTE-drift red is PR 3b's to remove).

Umbrella: #1225
