### PR TITLE
infra: CI guard against stale hardcoded version stamps

### DIFF
--- a/.github/workflows/version-stamp-guard.yml
+++ b/.github/workflows/version-stamp-guard.yml
@@ -1,0 +1,45 @@
+name: Version Stamp Guard
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'registry/render/**'
+      - 'scripts/check_version_stamps.py'
+      - '.github/workflows/version-stamp-guard.yml'
+  push:
+    branches:
+      - 'main'
+      - 'dev/**'
+      - 'infra/**'
+    paths:
+      - 'src/**'
+      - 'registry/render/**'
+      - 'scripts/check_version_stamps.py'
+      - '.github/workflows/version-stamp-guard.yml'
+  # Allow manual runs for debugging
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  version-stamp-guard:
+    name: Version Stamp Guard (literal-semver GAIA_VERSION)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run version-stamp guard
+        run: python scripts/check_version_stamps.py
+        # Exit code 0  → pass (no literal version stamps in scope)
+        # Exit code 1  → fail (hardcoded window.GAIA_VERSION = "X.Y.Z" found)

--- a/registry/render/gaia.html
+++ b/registry/render/gaia.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>mbtiongson1/gaia-skill-tree - Gaia Skill Graph</title>
-  <script>window.GAIA_VERSION = "4.3.12";</script>
+  <script>window.GAIA_VERSION = "";</script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">

--- a/scripts/check_version_stamps.py
+++ b/scripts/check_version_stamps.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+check_version_stamps.py — CI guard against stale HARDCODED version stamps
+
+A `window.GAIA_VERSION = "4.3.12";` literal was hand-typed into
+src/gaia_cli/graph.py on 2026-06-09 and rotted silently for 6 weeks (the repo
+moved to 6.8.15) with nothing catching it: verify_lockstep.py checks only the
+four manifests (not source), the docs `--check` normalizes the stamp away
+before comparing, and the CLI's HTML output is not a tracked docs/ file. This
+guard closes that gap.
+
+THE DISCRIMINATOR — literal vs. interpolated
+  VIOLATION : window.GAIA_VERSION = "4.3.12";      (a literal \\d+\\.\\d+\\.\\d+)
+  PASS      : window.GAIA_VERSION = "{version}";   (Python f-string interp)
+              window.GAIA_VERSION = "{{ version }}"; (Jinja interp)
+  These interpolated forms have `{` where the digits would be, so a literal-
+  semver regex never matches them. The guard fails ONLY on the hardcoded form.
+
+EXIT CODES
+  0  — clean (zero literal-semver GAIA_VERSION stamps in scope)
+  1  — one or more literal-semver stamps found in a non-allowlisted file
+
+SCAN SCOPE  (keeps false positives near-zero)
+  src/**                   — CLI source and templates
+  registry/render/**       — checked-in sample render output
+
+  NOT scanned (each would flood false positives):
+    docs/**                — build OUTPUT; fixed by regen, covered by other guards
+    tests/**               — fixtures legitimately hardcode versions like "9.9.9"
+    scripts/**/templates/*.j2 — Jinja {{ }} forms pass the regex anyway
+
+ALLOWLIST_PATHS
+  Intentionally EMPTY. The known offenders are FIXED in-tree, not whitelisted.
+  Present for future ergonomics, matching check_rank_vocabulary.py /
+  validate_redaction.py.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Force UTF-8 output on Windows so unicode chars in print() don't crash
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ('utf-8', 'utf8'):
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')  # type: ignore[attr-defined]
+if sys.stderr.encoding and sys.stderr.encoding.lower() not in ('utf-8', 'utf8'):
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')  # type: ignore[attr-defined]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+# ---------------------------------------------------------------------------
+# The literal-semver stamp pattern.
+# Matches ONLY the hardcoded form (digits between the quotes); interpolated
+# forms — "{version}" (f-string) or "{{ version }}" (Jinja) — never match
+# because a literal-semver regex requires digits where the `{` sits.
+# ---------------------------------------------------------------------------
+
+LITERAL_STAMP = re.compile(r'''window\.GAIA_VERSION\s*=\s*["']\d+\.\d+\.\d+["']''')
+
+# ---------------------------------------------------------------------------
+# Scan scope — glob roots relative to repo root.
+# ---------------------------------------------------------------------------
+
+SCAN_GLOBS = [
+    'src/**/*',
+    'registry/render/**/*',
+]
+
+# ---------------------------------------------------------------------------
+# Allowlist — paths (relative to repo root, POSIX) exempted from the guard.
+# EMPTY: the known offenders are fixed in-tree, not whitelisted. Present for
+# future ergonomics only.
+# ---------------------------------------------------------------------------
+
+ALLOWLIST_PATHS = frozenset()
+
+
+def is_allowlisted(rel_path: str) -> bool:
+    """Return True if this path is exempt from the guard."""
+    return rel_path.replace('\\', '/') in ALLOWLIST_PATHS
+
+
+def collect_files(repo_root: Path):
+    """Yield (Path, rel_path_str) for every file in the scan scope."""
+    seen: set[str] = set()
+    for glob in SCAN_GLOBS:
+        for p in repo_root.glob(glob):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(repo_root).as_posix()
+            if rel in seen:
+                continue
+            seen.add(rel)
+            yield p, rel
+
+
+def scan(repo_root: Path):
+    hard_violations: list[tuple[str, int, str]] = []  # (rel_path, lineno, snippet)
+    soft_violations: list[tuple[str, int, str]] = []  # same, but allowlisted
+
+    for file_path, rel_path in collect_files(repo_root):
+        try:
+            text = file_path.read_text(encoding='utf-8', errors='replace')
+        except (OSError, PermissionError) as exc:
+            print(f'  [SKIP] {rel_path}: {exc}', file=sys.stderr)
+            continue
+
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if LITERAL_STAMP.search(line):
+                entry = (rel_path, lineno, line.strip()[:120])
+                if is_allowlisted(rel_path):
+                    soft_violations.append(entry)
+                else:
+                    hard_violations.append(entry)
+
+    return hard_violations, soft_violations
+
+
+def main():
+    print('=== Version Stamp Guard ===')
+    print(f'Repo root : {REPO_ROOT}')
+    print(f'Scope     : src/**, registry/render/**')
+    print(f'Fails on  : literal-semver window.GAIA_VERSION = "X.Y.Z" (interpolated forms pass)')
+    print()
+
+    hard, soft = scan(REPO_ROOT)
+
+    if soft:
+        print('-- ALLOWLISTED (warn, does not fail CI) --')
+        for rel_path, lineno, snippet in soft:
+            print(f'  [WARN] {rel_path}:{lineno}  {snippet!r}')
+        print()
+
+    if hard:
+        print('-- HARD VIOLATIONS (must fix before merging) --')
+        for rel_path, lineno, snippet in hard:
+            print(f'  [FAIL] {rel_path}:{lineno}  {snippet!r}')
+            print(f'           → hardcoded version stamp; interpolate it dynamically instead '
+                  f'(e.g. f\'window.GAIA_VERSION = "{{version}}";\'). '
+                  f'See CLAUDE.md § "Decorative assets must NOT carry version metadata".')
+        print()
+        print(f'RESULT: FAIL — {len(hard)} literal stamp(s) in {len({h[0] for h in hard})} file(s)')
+        return 1
+
+    print('RESULT: PASS — 0 literal version stamps in scope.')
+    if soft:
+        print(f'         ({len(soft)} allowlisted hit(s) — warn only)')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/gaia_cli/graph.py
+++ b/src/gaia_cli/graph.py
@@ -484,7 +484,7 @@ def render_html(
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{_display_title}</title>
   <script>
-    window.GAIA_VERSION = "4.3.12";
+    window.GAIA_VERSION = "{escape(str(graph.get('version') or ''))}";
     // Point icon base to a path that we will intercept in fetch
     window.gaiaIconBase = function() {{ return 'assets/icons.svg'; }};
   </script>


### PR DESCRIPTION
## Version-stamp guard

`window.GAIA_VERSION = "4.3.12"` was hand-typed in source and rotted 6 weeks (repo now 6.8.15) with no guard catching it — lockstep checks only the 4 manifests, and the docs `--check` normalizes the stamp away before comparing.

Adds `scripts/check_version_stamps.py`: fails CI if a literal-semver `window.GAIA_VERSION` stamp appears in `src/**` or `registry/render/**` (dynamic interpolated forms pass). Empty allowlist — the known offenders are FIXED, not whitelisted.

- Fixed `registry/render/gaia.html` (stale 4.3.12 sample -> empty stamp, matching versionless regen output).
- Made `src/gaia_cli/graph.py` stamp dynamic (matches PR 3a).
- Dedicated workflow `version-stamp-guard.yml` (triggers on src/registry-render changes; docs-cohesion only runs at 10+ files, so a dedicated workflow is more reliable for small stamp diffs).

### Scope note
Touches `registry/render/gaia.html` (outside `infra/` allowlist) -> `skip-scope-check` applied (founder standing pre-approval).

### Testing
- Guard exits 0 on the fixed tree; verified it exits 1 + reports file:line on an injected literal stamp.
- Regex discriminates correctly: f-string `{version}`, Jinja `{{ version }}`, graph.py's dynamic form, and empty stamp all pass; only literal semver fails.

Umbrella: #1225
