### PR TITLE
cli(ygg2): Batch 3b — tear out dead SVG renderer; json emits DAG; validate --named-dir

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -851,6 +851,15 @@ def main():
     parser.add_argument("--graph", default=None, help="Path to gaia.json")
     parser.add_argument("--schema-dir", default=None, help="Path to schema directory")
     parser.add_argument(
+        "--named-dir", default=None,
+        help=(
+            "Path to the named-skills directory. When omitted and --graph points "
+            "at a mock graph, this is derived from the graph's sibling 'named' dir "
+            "so a mock --graph validates its own named skills, not the real "
+            "registry/named (#1223). With neither flag, the real registry is used."
+        ),
+    )
+    parser.add_argument(
         "--check-meta-sync", action="store_true",
         help="Verify meta.json is in sync with gaia.json and bundled copies"
     )
@@ -887,6 +896,25 @@ def main():
         graph_path = args.graph or os.path.join(repo_root, "registry", "gaia.json")
 
     schema_dir = args.schema_dir or os.path.join(repo_root, "registry", "schema")
+
+    # Resolve the named-skills directory. Priority:
+    #   1. explicit --named-dir
+    #   2. derived from a mock --graph (its sibling 'named' dir), so validating a
+    #      mock graph checks the mock's named skills — not the real registry/named
+    #      (#1223).
+    #   3. None → validate_named_skills defaults to the real registry/named.
+    # With neither --graph nor --named-dir, named_dir stays None so real-repo
+    # behavior is unchanged.
+    named_dir = args.named_dir
+    if named_dir is None and args.graph:
+        graph_arg = os.path.abspath(args.graph)
+        base = graph_arg if os.path.isdir(graph_arg) else os.path.dirname(graph_arg)
+        # <base>/named if it exists, else <parent>/named (covers --graph pointing
+        # at a nodes/ dir whose sibling is named/, or at a mock registry root).
+        cand = os.path.join(base, "named")
+        if not os.path.isdir(cand):
+            cand = os.path.join(os.path.dirname(base), "named")
+        named_dir = cand
 
     if not os.path.exists(graph_path):
         print(f"❌ Graph file not found: {graph_path}")
@@ -933,7 +961,7 @@ def main():
 
     # 9. Named skills validation (includes reviewer gate + catalog cross-refs)
     print("   [9/12] Named skills validation...")
-    all_errors.extend(validate_named_skills(graph))
+    all_errors.extend(validate_named_skills(graph, named_dir=named_dir))
 
     # 10. Skill suites validation
     print("   [10/12] Skill suites validation...")

--- a/src/gaia_cli/commands/graph_cmd.py
+++ b/src/gaia_cli/commands/graph_cmd.py
@@ -8,7 +8,7 @@ class GraphCommand(Command):
     def configure(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "--format",
-            choices=("html", "svg", "json"),
+            choices=("html", "json"),
             default="html",
             help="Graph artifact format (default: html)",
         )

--- a/src/gaia_cli/graph.py
+++ b/src/gaia_cli/graph.py
@@ -8,7 +8,6 @@ clone without Graphviz, Matplotlib, or a browser automation dependency.
 from __future__ import annotations
 
 import json
-import math
 import os
 import subprocess
 import sys
@@ -19,35 +18,7 @@ from html import escape
 from pathlib import Path
 from typing import Any
 
-from gaia_cli.formatting import COLOR_LOCAL_USER, tier_hex
-from gaia_cli.leveling import level_summary
 from gaia_cli.registry import named_skills_index_path, registry_graph_path, registry_nodes_dir
-
-# Node fills are sourced from the registry palette (meta.typeColors) via tier_hex so
-# the SVG never drifts from the canonical tokens. Stroke tints are lighter accents
-# with no registry equivalent, so they stay local (issue #332).
-_STROKE_TINTS = {
-    "basic": "#7dd3fc",
-    "extra": "#c4b5fd",
-    "unique": "#a78bfa",
-    "ultimate": "#fde68a",
-}
-_TYPE_LABELS = {
-    "basic": "Basic",
-    "extra": "Extra",
-    "unique": "Unique",
-    "ultimate": "Ultimate",
-}
-PALETTE = {
-    t: {"fill": tier_hex(t), "stroke": _STROKE_TINTS[t], "label": _TYPE_LABELS[t]}
-    for t in _TYPE_LABELS
-}
-# Green highlight for pushable local skills (issue #139), sourced from the shared
-# COLOR_LOCAL_USER token rather than a raw hex literal.
-PUSH_GREEN = "#%02x%02x%02x" % COLOR_LOCAL_USER
-TYPE_ORDER = {"basic": 0, "extra": 1, "unique": 2, "ultimate": 3}
-RADIUS_BY_TYPE = {"basic": 285, "extra": 170, "unique": 112, "ultimate": 54}
-NODE_RADIUS = {"basic": 6, "extra": 10, "unique": 13, "ultimate": 15}
 
 
 def _registry_root(registry_path: str | os.PathLike[str]) -> Path:
@@ -122,109 +93,6 @@ def _warn_enriched_missing_once() -> None:
         "(enriched graph not found locally).",
         file=sys.stderr,
     )
-
-
-def _stable_angle(skill_id: str, index: int, total: int) -> float:
-    # Deterministic jitter prevents same-type nodes from forming a perfectly
-    # uniform ring while keeping output stable across machines.
-    seed = sum((i + 1) * ord(ch) for i, ch in enumerate(skill_id))
-    jitter = ((seed % 997) / 997.0 - 0.5) * (math.tau / max(total, 1)) * 0.35
-    return math.tau * index / max(total, 1) + jitter - math.pi / 2
-
-
-def _named_max_levels(named_buckets: dict[str, Any]) -> dict[str, str]:
-    """Map generic skill id -> highest named-variant star (generics are rank-less)."""
-    order = ["2★", "3★", "4★", "5★", "6★"]
-    out: dict[str, str] = {}
-    for ref, entries in (named_buckets or {}).items():
-        levels = [e.get("level") for e in entries if e.get("level") in order]
-        if levels:
-            out[ref] = max(levels, key=order.index)
-    return out
-
-
-def build_render_graph(
-    graph: dict[str, Any], width: int = 1280, height: int = 880,
-    named_buckets: dict[str, Any] | None = None,
-    pushable: set[str] | None = None,
-) -> dict[str, Any]:
-    skills = graph.get("skills", [])
-    pushable = pushable or set()
-    named_max = _named_max_levels(named_buckets or {})
-    groups: dict[str, list[dict[str, Any]]] = {
-        "basic": [],
-        "extra": [],
-        "unique": [],
-        "ultimate": [],
-    }
-    for skill in skills:
-        groups.setdefault(skill.get("type", "basic"), []).append(skill)
-
-    for bucket in groups.values():
-        bucket.sort(
-            key=lambda s: (str(named_max.get(s.get("id"), "")), str(s.get("name", s.get("id", ""))))
-        )
-
-    cx, cy = width / 2, height / 2
-    nodes: list[dict[str, Any]] = []
-    for skill_type in ("basic", "extra", "unique", "ultimate"):
-        bucket = groups.get(skill_type, [])
-        radius = RADIUS_BY_TYPE.get(skill_type, 220)
-        for i, skill in enumerate(bucket):
-            sid = (skill.get("id") or "").lstrip("/")
-            angle = _stable_angle(sid, i, len(bucket))
-            local_radius = radius if len(bucket) > 1 else 0
-            x = cx + math.cos(angle) * local_radius
-            y = cy + math.sin(angle) * local_radius
-            star = named_max.get(skill.get("id")) or named_max.get(sid)
-            level_meta = level_summary(skill)
-            nodes.append(
-                {
-                    "id": sid,
-                    "label": skill.get("name") or sid,
-                    "type": skill_type,
-                    # Generic refs are rank-less — prefer the top named-variant
-                    # star; fall back to any legacy level for back-compat.
-                    "level": star or skill.get("level", ""),
-                    "effectiveLevel": star or level_meta["effectiveLevel"],
-                    "levelMeta": level_meta,
-                    "demerits": level_meta["demerits"],
-                    "description": skill.get("description", ""),
-                    "x": round(x, 3),
-                    "y": round(y, 3),
-                    "radius": NODE_RADIUS.get(skill_type, 7),
-                    "pushable": sid in pushable,
-                }
-            )
-
-    skill_ids = {node["id"] for node in nodes}
-    edges: list[dict[str, Any]] = []
-    for skill in skills:
-        target = (skill.get("id") or "").lstrip("/")
-        if target not in skill_ids:
-            continue
-        for source in skill.get("prerequisites", []) or []:
-            source = source.lstrip("/")
-            if source in skill_ids:
-                edges.append(
-                    {
-                        "source": source,
-                        "target": target,
-                        "type": skill.get("type", "basic"),
-                    }
-                )
-
-    nodes.sort(
-        key=lambda n: (TYPE_ORDER.get(str(n.get("type")), 9), str(n.get("label", "")))
-    )
-    return {
-        "version": graph.get("version"),
-        "generatedAt": graph.get("generatedAt"),
-        "width": width,
-        "height": height,
-        "nodes": nodes,
-        "edges": edges,
-    }
 
 
 def write_gexf(
@@ -357,116 +225,6 @@ def write_gexf(
         tree.write(f, xml_declaration=True, encoding="UTF-8")
 
     return out_path
-
-
-def render_svg(render_graph: dict[str, Any], is_workspace_mode: bool = False) -> str:
-    width = int(render_graph.get("width", 1280))
-    height = int(render_graph.get("height", 880))
-    nodes = render_graph.get("nodes", [])
-    edges = render_graph.get("edges", [])
-    node_by_id = {node["id"]: node for node in nodes}
-
-    lines = [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">',
-        '<title id="title">Gaia AI Agent Skill Graph</title>',
-        '<desc id="desc">Canonical Gaia skill graph rendered from registry/gaia.json, with basic skills on the outer ring, extra skills in the middle ring, and ultimate skills at the core.</desc>',
-        "<defs>",
-        '<radialGradient id="bg" cx="50%" cy="45%" r="70%"><stop offset="0%" stop-color="#172554"/><stop offset="55%" stop-color="#06111f"/><stop offset="100%" stop-color="#030712"/></radialGradient>',
-        '<filter id="glow" x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="4" result="blur"/><feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge></filter>',
-        "</defs>",
-        f'<rect width="{width}" height="{height}" fill="url(#bg)"/>',
-        '<g opacity="0.32" stroke="#334155" stroke-width="1" fill="none">',
-        f'<circle cx="{width / 2:.1f}" cy="{height / 2:.1f}" r="{RADIUS_BY_TYPE["basic"]}"/>',
-        f'<circle cx="{width / 2:.1f}" cy="{height / 2:.1f}" r="{RADIUS_BY_TYPE["extra"]}"/>',
-        f'<circle cx="{width / 2:.1f}" cy="{height / 2:.1f}" r="{RADIUS_BY_TYPE["ultimate"]}"/>',
-        "</g>",
-        '<g class="edges" fill="none">',
-    ]
-
-    for edge in edges:
-        source = node_by_id.get(edge.get("source"))
-        target = node_by_id.get(edge.get("target"))
-        if not source or not target:
-            continue
-        color = PALETTE.get(str(edge.get("type")), PALETTE["basic"])["fill"]
-        lines.append(
-            f'<line x1="{source["x"]}" y1="{source["y"]}" x2="{target["x"]}" y2="{target["y"]}" stroke="{color}" stroke-opacity="0.32" stroke-width="1.15"/>'
-        )
-    lines.append("</g>")
-
-    lines.append('<g class="nodes" filter="url(#glow)">')
-    for node in nodes:
-        color = PALETTE.get(str(node.get("type")), PALETTE["basic"])
-        # Pushable local skills (issue #139) are highlighted green so the operator
-        # can see at a glance what `gaia push` would propose.
-        if node.get("pushable"):
-            fill = stroke = PUSH_GREEN
-        else:
-            fill, stroke = color["fill"], color["stroke"]
-        lines.append(
-            f'<circle cx="{node["x"]}" cy="{node["y"]}" r="{node["radius"]}" fill="{fill}" stroke="{stroke}" stroke-width="1.6"><title>{escape(str(node.get("label", "")))}</title></circle>'
-        )
-    lines.append("</g>")
-
-    lines.append(
-        '<g class="labels" font-family="Inter, ui-sans-serif, system-ui, sans-serif" text-anchor="middle">'
-    )
-    for node in nodes:
-        typ = str(node.get("type"))
-        if (
-            typ == "basic"
-            and int(sum(ord(c) for c in str(node.get("id", ""))) % 4) != 0
-        ):
-            continue
-        color = PALETTE.get(typ, PALETTE["basic"])["fill"]
-        size = 10 if typ == "basic" else 12 if typ == "extra" else 16
-        weight = 600 if typ != "ultimate" else 800
-        y = float(node["y"]) - float(node["radius"]) - 7
-        lines.append(
-            f'<text x="{node["x"]}" y="{y:.1f}" fill="{color}" font-size="{size}" font-weight="{weight}" opacity="0.92">{escape(str(node.get("label", "")))}</text>'
-        )
-    lines.append("</g>")
-
-    legend_x = 44
-    legend_y = height - 110
-    lines.extend(
-        [
-            '<g font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#cbd5e1">',
-            f'<text x="{legend_x}" y="{legend_y - 22}" font-size="20" font-weight="800" fill="#e2e8f0">Gaia Skill Graph</text>',
-        ]
-    )
-    for i, skill_type in enumerate(("basic", "extra", "unique", "ultimate")):
-        y = legend_y + i * 28
-        color = PALETTE[skill_type]
-        count = sum(1 for node in nodes if node.get("type") == skill_type)
-        lines.append(
-            f'<circle cx="{legend_x + 8}" cy="{y - 5}" r="6" fill="{color["fill"]}"/>'
-        )
-        lines.append(
-            f'<text x="{legend_x + 24}" y="{y}">{color["label"]}: {count}</text>'
-        )
-    # Pushable highlight legend (issue #139) — only shown when the local graph has
-    # skills that `gaia push` would propose.
-    pushable_count = sum(1 for node in nodes if node.get("pushable"))
-    if pushable_count:
-        y = legend_y + 4 * 28
-        lines.append(
-            f'<circle cx="{legend_x + 8}" cy="{y - 5}" r="6" fill="{PUSH_GREEN}"/>'
-        )
-        lines.append(
-            f'<text x="{legend_x + 24}" y="{y}">Pushable: {pushable_count}</text>'
-        )
-    lines.append("</g>")
-    if is_workspace_mode:
-        # Semi-transparent diagonal watermark text overlay
-        lines.append(
-            f'<text x="{width / 2:.1f}" y="{height / 2:.1f}" fill="#334155" opacity="0.15" '
-            f'font-size="64" font-weight="900" font-family="sans-serif" text-anchor="middle" '
-            f'transform="rotate(-30 {width / 2:.1f} {height / 2:.1f})">WORKSPACE ONLY</text>'
-        )
-    lines.append("</svg>")
-    return "\n".join(lines) + "\n"
 
 
 def _html_json(data: dict[str, Any]) -> str:
@@ -718,26 +476,12 @@ def write_graph_artifact(
         graph["skills"] = [sk for sk in canon_skills.values() if sk["id"] in display_ids]
         graph["version"] = "local-custom"
 
-    # Highlight the skills that `gaia push` would propose (issue #139). Only the
-    # local/custom graph carries this — the canonical registry graph has no
-    # per-user push state.
-    pushable_ids: set[str] = set()
-    if custom:
-        try:
-            from gaia_cli import scanner
-            from gaia_cli.push import pushable_skill_ids
-            pushable_ids = pushable_skill_ids(scanner.load_config(), str(root))
-        except Exception:
-            pushable_ids = set()
-    render_graph = build_render_graph(graph, named_buckets=named_buckets, pushable=pushable_ids)
     fmt = fmt.lower()
     if output is None:
         if custom:
             local_dir = Path(".gaia")
             if fmt == "html":
                 output = local_dir / "render" / "gaia.html"
-            elif fmt == "svg":
-                output = local_dir / "gaia.svg"
             else:
                 output = local_dir / "render" / "latest.json"
         else:
@@ -745,8 +489,6 @@ def write_graph_artifact(
             reg_dir = Path(registry_dir(root))
             if fmt == "html":
                 output = reg_dir / "render" / "gaia.html"
-            elif fmt == "svg":
-                output = reg_dir / "gaia.svg"
             else:
                 output = reg_dir / "render" / "latest.json"
     out_path = Path(output)
@@ -769,10 +511,11 @@ def write_graph_artifact(
             render_html(graph, load_named_skills(root), user_ctx=user_ctx, icons_svg=icons_svg, is_workspace_mode=is_workspace),
             encoding="utf-8",
         )
-    elif fmt == "svg":
-        out_path.write_text(render_svg(render_graph, is_workspace_mode=is_workspace), encoding="utf-8")
     elif fmt == "json":
-        out_path.write_text(json.dumps(render_graph, indent=2) + "\n", encoding="utf-8")
+        # Emit the same enriched DAG the HTML path embeds (skills[] with
+        # type/branch/namedMaxLevel/… + prerequisite edges), NOT an x/y ring
+        # render graph — `gaia graph` is a thin data-pump for the 3D World Tree.
+        out_path.write_text(json.dumps(graph, indent=2) + "\n", encoding="utf-8")
     else:
         raise ValueError(f"Unsupported graph format: {fmt}")
     return out_path, graph

--- a/src/gaia_cli/graph.py
+++ b/src/gaia_cli/graph.py
@@ -73,6 +73,57 @@ def load_named_skills(registry_path: str | os.PathLike[str] = ".") -> dict[str, 
         return json.load(f)
 
 
+def resolve_enriched_graph_path(root: Path, custom: str | os.PathLike[str] | None = None) -> Path | None:
+    """Locate the enriched 3D World Tree graph, if one is available locally.
+
+    The lean registry/gaia.json lacks the branch/namedMaxLevel/cluster/rank
+    fields the site's 3D renderer needs for a non-degraded view. Those are baked
+    into docs/graph/gaia.json at release time. This picks the enriched copy when
+    present, in priority order:
+
+      (a) an explicit path passed by the caller,
+      (b) .gaia/registry/graph/gaia.json  (written by `gaia fetch`),
+      (c) <root>/docs/graph/gaia.json     (a repo checkout).
+
+    Returns the first existing path, or None if no enriched graph is found (the
+    caller then falls back to the lean registry/gaia.json).
+    """
+    if custom is not None:
+        p = Path(custom)
+        if p.exists():
+            return p
+    candidates = [
+        Path.cwd() / ".gaia" / "registry" / "graph" / "gaia.json",
+        root / "docs" / "graph" / "gaia.json",
+    ]
+    for cand in candidates:
+        if cand.exists():
+            return cand
+    return None
+
+
+def load_enriched_graph(path: Path) -> dict[str, Any]:
+    """Load an enriched graph JSON from `path`."""
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+_ENRICHED_WARNED = False
+
+
+def _warn_enriched_missing_once() -> None:
+    """Print a one-time stderr hint when no enriched 3D graph is found locally."""
+    global _ENRICHED_WARNED
+    if _ENRICHED_WARNED:
+        return
+    _ENRICHED_WARNED = True
+    print(
+        "Note: run 'gaia fetch' for the full 3D skill-tree view "
+        "(enriched graph not found locally).",
+        file=sys.stderr,
+    )
+
+
 def _stable_angle(skill_id: str, index: int, total: int) -> float:
     # Deterministic jitter prevents same-type nodes from forming a perfectly
     # uniform ring while keeping output stable across machines.
@@ -440,6 +491,10 @@ def render_html(
     if "meta" not in graph:
         graph["meta"] = {"levelColors": {}, "levelLabels": {}}
 
+    # Read the version dynamically from the embedded graph rather than hardcoding
+    # (decorative surfaces must never carry a stale baked-in version — see #807).
+    _graph_version = escape(str(graph.get("version", "")), quote=True)
+
     watermark_style = ""
     watermark_html = ""
     if is_workspace_mode:
@@ -484,7 +539,7 @@ def render_html(
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{_display_title}</title>
   <script>
-    window.GAIA_VERSION = "4.3.12";
+    window.GAIA_VERSION = "{_graph_version}";
     // Point icon base to a path that we will intercept in fetch
     window.gaiaIconBase = function() {{ return 'assets/icons.svg'; }};
   </script>
@@ -568,7 +623,14 @@ def write_graph_artifact(
     is_workspace: bool = False,
 ) -> tuple[Path, dict[str, Any]]:
     root = _registry_root(registry_path)
-    graph = load_graph(root)
+    enriched_path = resolve_enriched_graph_path(root)
+    if enriched_path is not None:
+        graph = load_enriched_graph(enriched_path)
+    else:
+        graph = load_graph(root)
+        # Degrade gracefully: the lean registry/gaia.json renders the 3D tree
+        # all-grey/collapsed. Hint the user (once) toward the enriched view.
+        _warn_enriched_missing_once()
     named_buckets = load_named_skills(root).get("buckets", {})
 
     if custom:
@@ -633,6 +695,9 @@ def write_graph_artifact(
                     "type": "basic",
                     "level": "0★",
                     "prerequisites": csk.get("prerequisites", []),
+                    # Mark uncanonized local skills so the frontend (PR 3c) can
+                    # render them green-starless. Canon skills never carry this.
+                    "custom": True,
                 }
 
         if known_only:

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -2778,6 +2778,7 @@ def fetch_command(args):
                 if m.name.startswith("registry/gaia.json")
                 or m.name.startswith("registry/named-skills.json")
                 or m.name.startswith("registry/named/")
+                or m.name.startswith("docs/graph/")
             ]
             tar.extractall(path=Path(tmpdir) / "unpacked", members=members_to_extract, filter="data")
 
@@ -2833,7 +2834,20 @@ def fetch_command(args):
                 shutil.rmtree(dest_named_dir)
             shutil.copytree(src_named_dir, dest_named_dir)
 
+        # enriched 3D graph (docs/graph/) — the site-served World Tree assets.
+        # The lean registry/gaia.json lacks the branch/namedMaxLevel/cluster/rank
+        # fields the 3D renderer needs; docs/graph/gaia.json carries them. `gaia
+        # graph` prefers this enriched copy when embedding.
+        src_graph_dir = Path(tmpdir) / "unpacked" / "docs" / "graph"
+        dest_graph_dir = registry_dir / "graph"
+        if src_graph_dir.exists():
+            if dest_graph_dir.exists():
+                shutil.rmtree(dest_graph_dir)
+            shutil.copytree(src_graph_dir, dest_graph_dir)
+
     print(f"Registry updated to {tag} at {registry_dir}/")
+    if (registry_dir / "graph").exists():
+        print("Enriched 3D graph updated — run `gaia graph` for the full World Tree view.")
     print("Run `gaia scan` to update your skill tree against the new registry.")
 
 

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -148,7 +148,7 @@ Daily commands:
   {_fg(*COLOR_FUSE_PURPLE)}gaia fuse{_reset()} <skillId> [--name <name>]
   {_fg(*C5)}gaia path{_reset()} <skillId> [--owned-only] [--json]
   {_fg(*C2)}gaia lookup{_reset()} <skillId>
-  {_fg(*C1)}gaia graph{_reset()} [--format html|svg|json] [-o <path>] [--no-open]
+  {_fg(*C1)}gaia graph{_reset()} [--format html|json] [-o <path>] [--no-open]
   {_fg(*COLOR_FUSE_PURPLE)}gaia propose{_reset()} [<skillId>] [--ultimate] [--target <name>] [--no-pr]
 
 Skills:
@@ -3496,7 +3496,7 @@ def get_parser():
     )
     graph_parser.add_argument(
         "--format",
-        choices=("html", "svg", "json"),
+        choices=("html", "json"),
         default="html",
         help="Graph artifact format (default: html)",
     )

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -716,6 +716,53 @@ class TestFetch:
         data = json.loads((project / ".gaia" / "registry" / "gaia.json").read_text(encoding="utf-8"))
         assert data["version"] == "fetched"
 
+    def test_fetch_unpacks_enriched_docs_graph(self, project: Path, monkeypatch: pytest.MonkeyPatch):
+        """fetch must unpack docs/graph/ from the tarball into .gaia/registry/graph/.
+
+        The enriched World Tree graph (docs/graph/gaia.json) carries branch/
+        namedMaxLevel/cluster fields the lean registry/gaia.json lacks. `gaia
+        graph` prefers this copy for the full 3D view.
+        """
+        import io
+        import tarfile as _tarfile
+
+        buf = io.BytesIO()
+        with _tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            gaia_data = json.dumps({"version": "test", "skills": []}).encode("utf-8")
+            info = _tarfile.TarInfo(name="registry/gaia.json")
+            info.size = len(gaia_data)
+            tar.addfile(info, io.BytesIO(gaia_data))
+            named_data = json.dumps({"buckets": {}}).encode("utf-8")
+            info2 = _tarfile.TarInfo(name="registry/named-skills.json")
+            info2.size = len(named_data)
+            tar.addfile(info2, io.BytesIO(named_data))
+            # Enriched docs/graph/gaia.json (carries branch/namedMaxLevel)
+            enriched = json.dumps({
+                "version": "test",
+                "skills": [{"id": "web-search", "branch": "research", "namedMaxLevel": "3★"}],
+            }).encode("utf-8")
+            info3 = _tarfile.TarInfo(name="docs/graph/gaia.json")
+            info3.size = len(enriched)
+            tar.addfile(info3, io.BytesIO(enriched))
+            # a nested member to confirm the whole tree is copied
+            idx = json.dumps({"index": []}).encode("utf-8")
+            info4 = _tarfile.TarInfo(name="docs/graph/named/index.json")
+            info4.size = len(idx)
+            tar.addfile(info4, io.BytesIO(idx))
+        tarball = buf.getvalue()
+
+        _patch_fetch_urlopen(monkeypatch, tarball)
+        run_cli(monkeypatch, ["fetch"])
+
+        graph_dir = project / ".gaia" / "registry" / "graph"
+        assert (graph_dir / "gaia.json").exists(), \
+            ".gaia/registry/graph/gaia.json must be written by fetch"
+        assert (graph_dir / "named" / "index.json").exists(), \
+            "the whole docs/graph/ tree must be copied, including nested members"
+        enriched_data = json.loads((graph_dir / "gaia.json").read_text(encoding="utf-8"))
+        assert enriched_data["skills"][0]["branch"] == "research"
+        assert enriched_data["skills"][0]["namedMaxLevel"] == "3★"
+
     def test_fetch_downgrade_blocked(self, project: Path, monkeypatch: pytest.MonkeyPatch, capsys):
         """Attempting to fetch an older registry version must block and exit with 1."""
         # 1. Seed local registry with v2.0.0

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -60,7 +60,7 @@ def make_registry(root):
                     {
                         "id": "research",
                         "name": "Research",
-                        "type": "extra",
+                        "type": "fusion",
                         "level": "3★",
                         "demerits": ["experimental-feature"],
                         "prerequisites": ["tokenize"],
@@ -104,15 +104,6 @@ def test_write_graph_artifact_defaults_to_standalone_html(tmp_path):
     assert 'fetch("graph/gaia.json")' not in html
 
 
-def test_write_graph_artifact_keeps_svg_default_path(tmp_path):
-    root = make_registry(tmp_path)
-
-    out_path, _ = graph_mod.write_graph_artifact(root, fmt="svg")
-
-    assert out_path == root / "registry" / "gaia.svg"
-    assert out_path.read_text(encoding="utf-8").startswith("<?xml")
-
-
 def test_write_graph_artifact_keeps_render_json_default_path(tmp_path):
     root = make_registry(tmp_path)
 
@@ -120,13 +111,14 @@ def test_write_graph_artifact_keeps_render_json_default_path(tmp_path):
 
     assert out_path == root / "registry" / "render" / "latest.json"
     data = json.loads(out_path.read_text(encoding="utf-8"))
-    assert data["nodes"][0]["id"] == "tokenize"
-    research_node = next(node for node in data["nodes"] if node["id"] == "research")
-    assert research_node["effectiveLevel"] == "2★"
-    assert research_node["levelMeta"]["baseLevel"] == "3★"
-    assert research_node["levelMeta"]["effectiveLevel"] == "2★"
-    assert research_node["demerits"] == ["experimental-feature"]
-    assert data["edges"] == [{"source": "tokenize", "target": "research", "type": "extra"}]
+    # json mode now emits the enriched DAG (skills[] + prerequisite edges),
+    # not an x/y-coordinate ring render graph.
+    skills_by_id = {sk["id"]: sk for sk in data["skills"]}
+    assert set(skills_by_id) == {"tokenize", "research"}
+    assert skills_by_id["research"]["type"] == "fusion"
+    assert skills_by_id["research"]["prerequisites"] == ["tokenize"]
+    # No ring-layout coordinates leak into the DAG output.
+    assert all("x" not in sk and "y" not in sk for sk in data["skills"])
 
 
 def test_graph_command_defaults_to_html_and_opens_it(tmp_path, monkeypatch):
@@ -208,7 +200,7 @@ class TestRed_WriteGraphArtifactCustom:
         data = json.loads(out_path.read_text(encoding="utf-8"))
 
         # The custom graph should contain local-only skill from scan
-        node_ids = {n["id"] for n in data["nodes"]}
+        node_ids = {n["id"].lstrip("/") for n in data["skills"]}
         assert "local-only" in node_ids, (
             "custom=True graph should include locally scanned skills"
         )
@@ -254,7 +246,7 @@ class TestGreen_CustomGraphMatchesScan:
             root, fmt="json", custom=True
         )
         data = json.loads(out_path.read_text(encoding="utf-8"))
-        node_ids = {n["id"] for n in data["nodes"]}
+        node_ids = {n["id"].lstrip("/") for n in data["skills"]}
 
         assert node_ids == expected_ids, (
             f"Custom graph nodes {node_ids} should match scan output {expected_ids}"
@@ -282,7 +274,7 @@ class TestGreen_CustomGraphMatchesScan:
         edges = data.get("edges", [])
         # Edges depend on whether prerequisites parse correctly as a list
         # from the simple frontmatter parser. This validates the integration.
-        node_ids = {n["id"] for n in data["nodes"]}
+        node_ids = {n["id"].lstrip("/") for n in data["skills"]}
         assert "parent-skill" in node_ids
         assert "child-skill" in node_ids
 
@@ -331,99 +323,6 @@ class TestScrutiny_ShowTreeCustomMode:
         assert "web-search" not in out, (
             "Canonical-only skill should not appear in custom mode"
         )
-
-
-@pytest.mark.integration
-class TestScrutiny_CustomGraphSchema:
-    """Scrutiny #3: custom graph schema consumed by build_render_graph.
-
-    The synthetic graph dict uses 'version': 'local-custom' and a flat
-    'skills' list. Verify build_render_graph can consume this without errors.
-    """
-
-    def test_build_render_graph_handles_custom_schema(self):
-        """build_render_graph should not crash on the custom graph schema."""
-        custom_graph = {
-            "version": "local-custom",
-            "skills": [
-                {"id": "my-skill", "name": "My Skill", "type": "basic",
-                 "level": "0★", "prerequisites": []},
-                {"id": "my-other", "name": "Other Skill", "type": "basic",
-                 "level": "0★", "prerequisites": ["my-skill"]},
-            ],
-        }
-
-        render_graph = graph_mod.build_render_graph(custom_graph)
-
-        # Should produce valid nodes
-        assert len(render_graph["nodes"]) == 2
-        node_ids = {n["id"] for n in render_graph["nodes"]}
-        assert node_ids == {"my-skill", "my-other"}
-
-        # Should produce the prerequisite edge
-        assert len(render_graph["edges"]) == 1
-        assert render_graph["edges"][0]["source"] == "my-skill"
-        assert render_graph["edges"][0]["target"] == "my-other"
-
-        # Version should carry through
-        assert render_graph["version"] == "local-custom"
-
-
-class TestPaletteFromRegistry:
-    """#332 — PALETTE fills must track the registry tokens, not a drifted copy."""
-
-    def test_palette_fills_match_tier_hex(self):
-        from gaia_cli.formatting import tier_hex
-
-        for skill_type in ("basic", "extra", "unique", "ultimate"):
-            assert graph_mod.PALETTE[skill_type]["fill"] == tier_hex(skill_type)
-
-    def test_extra_and_ultimate_no_longer_drifted(self):
-        # The old hardcoded values were extra=#a78bfa and ultimate=#fbbf24.
-        # After sourcing from the registry they must be the canonical tokens.
-        assert graph_mod.PALETTE["extra"]["fill"] == "#c084fc"
-        assert graph_mod.PALETTE["ultimate"]["fill"] == "#f59e0b"
-
-    def test_no_raw_push_green_hex(self):
-        from gaia_cli.formatting import COLOR_LOCAL_USER
-
-        assert graph_mod.PUSH_GREEN == "#%02x%02x%02x" % COLOR_LOCAL_USER
-
-
-class TestPushableHighlight:
-    """#139 — pushable local skills render green with a legend entry."""
-
-    def _graph(self):
-        return {
-            "version": "local-custom",
-            "skills": [
-                {"id": "alpha", "name": "Alpha", "type": "basic",
-                 "level": "0★", "prerequisites": []},
-                {"id": "beta", "name": "Beta", "type": "basic",
-                 "level": "0★", "prerequisites": []},
-            ],
-        }
-
-    def test_pushable_flag_set_on_nodes(self):
-        render_graph = graph_mod.build_render_graph(self._graph(), pushable={"alpha"})
-        by_id = {n["id"]: n for n in render_graph["nodes"]}
-        assert by_id["alpha"]["pushable"] is True
-        assert by_id["beta"]["pushable"] is False
-
-    def test_pushable_defaults_false(self):
-        render_graph = graph_mod.build_render_graph(self._graph())
-        assert all(n["pushable"] is False for n in render_graph["nodes"])
-
-    def test_svg_renders_pushable_green_and_legend(self):
-        render_graph = graph_mod.build_render_graph(self._graph(), pushable={"alpha"})
-        svg = graph_mod.render_svg(render_graph)
-        assert graph_mod.PUSH_GREEN in svg
-        assert "Pushable: 1" in svg
-
-    def test_svg_no_pushable_legend_when_none(self):
-        render_graph = graph_mod.build_render_graph(self._graph())
-        svg = graph_mod.render_svg(render_graph)
-        assert "Pushable:" not in svg
 
 
 class TestEnrichedGraphPreference:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -424,3 +424,106 @@ class TestPushableHighlight:
         render_graph = graph_mod.build_render_graph(self._graph())
         svg = graph_mod.render_svg(render_graph)
         assert "Pushable:" not in svg
+
+
+class TestEnrichedGraphPreference:
+    """Batch 3a - gaia graph prefers the enriched 3D World Tree graph."""
+
+    def _write_enriched(self, root, *, version="9.9.9"):
+        """Write an enriched .gaia/registry/graph/gaia.json carrying branch/namedMaxLevel."""
+        graph_dir = root / ".gaia" / "registry" / "graph"
+        graph_dir.mkdir(parents=True, exist_ok=True)
+        enriched = {
+            "version": version,
+            "generatedAt": "2026-07-23",
+            "skills": [
+                {
+                    "id": "tokenize",
+                    "name": "Tokenize",
+                    "type": "basic",
+                    "level": "1★",
+                    "branch": "core",
+                    "namedMaxLevel": "4★",
+                    "cluster": "foundations",
+                    "prerequisites": [],
+                },
+            ],
+        }
+        (graph_dir / "gaia.json").write_text(json.dumps(enriched), encoding="utf-8")
+        return graph_dir / "gaia.json"
+
+    def test_resolve_prefers_fetched_graph(self, tmp_path, monkeypatch):
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        enriched_path = self._write_enriched(tmp_path)
+
+        resolved = graph_mod.resolve_enriched_graph_path(graph_mod._registry_root(root))
+        assert resolved == enriched_path
+
+    def test_resolve_returns_none_when_absent(self, tmp_path, monkeypatch):
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        assert graph_mod.resolve_enriched_graph_path(graph_mod._registry_root(root)) is None
+
+    def test_render_html_embeds_enriched_graph(self, tmp_path, monkeypatch):
+        """render_html must embed the enriched graph (branch/namedMaxLevel), not the lean one."""
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        self._write_enriched(tmp_path)
+
+        out_path, graph = graph_mod.write_graph_artifact(root, fmt="html")
+        html = out_path.read_text(encoding="utf-8")
+
+        assert '"branch": "core"' in html
+        assert '"namedMaxLevel"' in html
+        assert '"id": "research"' not in html
+        assert graph.get("skills", [{}])[0].get("branch") == "core"
+
+    def test_lean_fallback_warns_once(self, tmp_path, monkeypatch, capsys):
+        """With no enriched graph, render falls back to lean + a stderr hint."""
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(graph_mod, "_ENRICHED_WARNED", False)
+
+        out_path, graph = graph_mod.write_graph_artifact(root, fmt="html")
+        html = out_path.read_text(encoding="utf-8")
+        err = capsys.readouterr().err
+
+        assert '"id": "research"' in html
+        assert "run 'gaia fetch'" in err
+
+    def test_version_read_from_graph_not_hardcoded(self, tmp_path, monkeypatch):
+        """window.GAIA_VERSION must reflect the embedded graph version, not a baked-in literal."""
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        self._write_enriched(tmp_path, version="12.3.4")
+
+        out_path, _ = graph_mod.write_graph_artifact(root, fmt="html")
+        html = out_path.read_text(encoding="utf-8")
+        assert 'window.GAIA_VERSION = "12.3.4"' in html
+        assert "4.3.12" not in html
+
+
+class TestCustomNodeFlag:
+    """Batch 3a - uncanonized local skills carry a `custom` flag for the frontend."""
+
+    def test_custom_skill_carries_custom_flag(self, tmp_path, monkeypatch):
+        root = _make_registry(tmp_path, skills=[
+            {"id": "registry-skill", "name": "Registry Skill", "type": "basic",
+             "level": "1★", "prerequisites": []},
+        ])
+        _make_skill(tmp_path, os.path.join(".agents", "skills"), "local-only",
+                     name="Local Only", description="A local-only custom skill")
+        monkeypatch.chdir(tmp_path)
+
+        _, graph = graph_mod.write_graph_artifact(root, fmt="json", custom=True)
+        by_id = {sk["id"].lstrip("/"): sk for sk in graph["skills"]}
+        assert by_id["local-only"].get("custom") is True
+
+    def test_canon_skill_has_no_custom_flag(self, tmp_path, monkeypatch):
+        root = make_registry(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        _, graph = graph_mod.write_graph_artifact(root, fmt="html")
+        for sk in graph.get("skills", []):
+            assert "custom" not in sk


### PR DESCRIPTION
## Batch 3b — SVG teardown + validate.py --named-dir

`gaia graph` is now a thin data-pump for the site's 3D World Tree (PR 3a). This removes the dead hand-built static SVG renderer entirely.

- Deleted `render_svg`, `build_render_graph`, and the SVG-only type/color/radius constants (`PALETTE`, `RADIUS_BY_TYPE`, `_STROKE_TINTS`, `TYPE_ORDER`, etc.). `graph.py` now holds ZERO skill-type→color/radius logic.
- Removed `--format svg`; kept `html` (default) + `json`. `json` now emits the DAG graph data (type/branch/etc.), not the old x/y-coordinate render graph.
- Deleted the SVG/PALETTE-drift tests — this clears the known-red `test_extra_and_ultimate_no_longer_drifted`. Fixture retyped extra→fusion.
- `scripts/validate.py --named-dir`: a mock `--graph` now validates the mock's named dir, not real `registry/named` (#1223). Real-repo behavior unchanged.

### Scope note
Touches `scripts/validate.py` (outside `cli/` allowlist) → `skip-scope-check` applied (founder standing pre-approval).

### Testing
- pytest tests/test_graph.py tests/test_cli_core.py — fully green (PALETTE red removed).
- scripts/validate.py on real repo — unchanged; on a mock --graph — zero spurious errors.

Umbrella: #1225
Resolves #1223
Resolves #1224
