### PR TITLE
cli: rekey legacy extra->fusion literals; prune --ultimate flags

### DIFF
--- a/src/gaia_cli/commands/push.py
+++ b/src/gaia_cli/commands/push.py
@@ -160,11 +160,6 @@ class ProposeCommand(Command):
             "--target", help="Named skill target in contributor/skill-name format"
         )
         parser.add_argument(
-            "--ultimate",
-            action="store_true",
-            help="Require that the selected skill is ultimate",
-        )
-        parser.add_argument(
             "--yes", "-y", "--y", action="store_true", help="Use defaults without interactive prompts"
         )
         parser.add_argument(

--- a/src/gaia_cli/commands/share_cmd.py
+++ b/src/gaia_cli/commands/share_cmd.py
@@ -39,11 +39,6 @@ class InstallCommand(Command):
             help="List and interactively select skills to install",
         )
         parser.add_argument(
-            "--ultimate",
-            action="store_true",
-            help="Batch-install all component skills (alias for --suite)",
-        )
-        parser.add_argument(
             "--suite",
             action="store_true",
             help="Batch-install all component skills for a suite",

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -149,7 +149,7 @@ Daily commands:
   {_fg(*C5)}gaia path{_reset()} <skillId> [--owned-only] [--json]
   {_fg(*C2)}gaia lookup{_reset()} <skillId>
   {_fg(*C1)}gaia graph{_reset()} [--format html|json] [-o <path>] [--no-open]
-  {_fg(*COLOR_FUSE_PURPLE)}gaia propose{_reset()} [<skillId>] [--ultimate] [--target <name>] [--no-pr]
+  {_fg(*COLOR_FUSE_PURPLE)}gaia propose{_reset()} [<skillId>] [--target <name>] [--no-pr]
 
 Skills:
   {_rainbow_text("gaia skills")} <list|search|info|install|uninstall>
@@ -1064,7 +1064,7 @@ def scan_command(args):
                 print("\nNew fusion candidates:")
                 for c in combos:
                     result_skill = skill_map.get(c["candidateResult"], {})
-                    result_type = result_skill.get("type", "extra")
+                    result_type = result_skill.get("type", "fusion")
                     print(
                         render_fusion_diagram(
                             c["detectedSkills"],
@@ -1412,16 +1412,6 @@ def propose_command(args):
     if not skill:
         print(f"Skill '{skill_id}' not found in canonical graph.")
         return
-    if getattr(args, "ultimate", False) and skill.get("type") != "ultimate":
-        print(
-            f"Skill '{skill_id}' is not an ultimate skill. Use --ultimate only for ultimate skills."
-        )
-        return
-    if not getattr(args, "ultimate", False) and skill.get("type") == "ultimate":
-        print(
-            "Tip: this is an ultimate skill. Re-run with `gaia propose /<skill> --ultimate`."
-        )
-
     print(f"Appraisal: /{skill['id']} ({skill.get('type', 'unknown')})")
     print(f"Name: {skill.get('name', skill['id'])}")
     print(f"Description: {skill.get('description', '')}")
@@ -2347,7 +2337,7 @@ def install_command(args):
         sys.exit(2)
 
     # Use suite logic if flagged or implicitly requested
-    if getattr(args, "ultimate", False) or getattr(args, "suite", False):
+    if getattr(args, "suite", False):
         success = install_suite(args.skill_id, args.registry, location=location)
     else:
         success = install_skill(args.skill_id, args.registry, location=location)
@@ -3320,11 +3310,6 @@ def get_parser():
         help="List and interactively select skills to install",
     )
     install_parser.add_argument(
-        "--ultimate",
-        action="store_true",
-        help="Batch-install all component skills (alias for --suite)",
-    )
-    install_parser.add_argument(
         "--suite",
         action="store_true",
         help="Batch-install all component skills for a suite",
@@ -3428,11 +3413,6 @@ def get_parser():
     )
     propose_parser.add_argument(
         "--target", help="Named skill target in contributor/skill-name format"
-    )
-    propose_parser.add_argument(
-        "--ultimate",
-        action="store_true",
-        help="Require that the selected skill is ultimate",
     )
     propose_parser.add_argument(
         "--yes", "-y", "--y", action="store_true", help="Use defaults without interactive prompts"

--- a/src/gaia_cli/localContext.py
+++ b/src/gaia_cli/localContext.py
@@ -144,18 +144,18 @@ class LocalContext:
                             skill_map[target] = {
                                 "id": target,
                                 "name": target,
-                                "type": "extra",
+                                "type": "fusion",
                                 "level": "1★",
                                 "prerequisites": sources,
                                 "description": f"Custom fusion of {', '.join(sources)}",
                                 "local": True
                             }
                         else:
-                            # Existing skill: ensure it has the prerequisites and type 'extra'
+                            # Existing skill: ensure it has the prerequisites and type 'fusion'
                             sdata = skill_map[target]
                             sdata["prerequisites"] = list(set(sdata.get("prerequisites", [])) | set(sources))
                             if sdata.get("type") == "basic":
-                                sdata["type"] = "extra"
+                                sdata["type"] = "fusion"
             except Exception:
                 pass
 

--- a/src/gaia_cli/push.py
+++ b/src/gaia_cli/push.py
@@ -261,11 +261,11 @@ def build_skill_batch(raw_tokens, config, registry_root, now=None, source_repo=N
                     if isinstance(data, dict):
                         sources = data.get("sources", [])
                         level = data.get("level", "1★")
-                        stype = data.get("type", "extra")
+                        stype = data.get("type", "fusion")
                     else:
                         sources = data
                         level = "1★"
-                        stype = "extra"
+                        stype = "fusion"
                     
                     proposed_combos.append({
                         "candidateResult": target,

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -57,7 +57,7 @@ def _make_custom_state(tmp_dir):
         "customFusions": {
             "/research-fusion": {
                 "sources": ["/web-search", "/semantic-search"],
-                "type": "extra",
+                "type": "fusion",
                 "level": "1★",
             }
         },


### PR DESCRIPTION
## Summary

Mechanical cleanup of retired schema literals and flags following the Yggdrasil II migration (skill types collapsed from `extra`/`ultimate`/`unique` into a single `fusion`; valid types are now `basic`/`fusion`). Part of the umbrella #1225 Yggdrasil II CLI alignment — DoD #2 follow-up cleanup.

### `extra` -> `fusion` literal rekey
- `src/gaia_cli/localContext.py`: customFusions loading now synthesizes `type: "fusion"` skill_map entries and upgrades basic skills to `fusion` (was `extra`).
- `src/gaia_cli/push.py`: `stype` defaults changed from `"extra"` to `"fusion"` (both the dict-source and bare-list-source branches).
- `src/gaia_cli/impl.py`: `result_type` default changed from `"extra"` to `"fusion"`.
- `tests/test_push.py`: customFusions fixture `type` changed to `"fusion"`.

### Prune `gaia propose --ultimate`
`propose` no longer type-gates. Removed both the rejection and tip `if` blocks in `impl.py`; propose now proceeds uniformly for basic/fusion skills. Removed `[--ultimate]` from the usage banner and the argparse wiring in both the dead legacy `get_parser()` duplicate (`impl.py`) and the live `ProposeCommand.configure()` (`commands/push.py`).

### Prune `gaia install --ultimate`
`--suite` is now the only batch/suite install flag. Removed the `--ultimate` alias argparse block from the dead legacy parser (`impl.py`) and the live `InstallCommand.configure()` (`commands/share_cmd.py`), and dropped the `ultimate` half of the OR in the install dispatch (`impl.py`).

## Test plan
- `grep -rn '"--ultimate"' src/gaia_cli/` → zero matches.
- `grep -rn 'args, "ultimate"' src/gaia_cli/impl.py` → zero matches.
- `python3 -m py_compile` on all five edited source files → OK.
- `pytest tests/test_push.py tests/test_suite_install.py -q` → 28 passed, 5 skipped, 4 failed. The 4 failures are pre-existing environmental failures (`FileNotFoundError: registry/gaia.json`, a gitignored Class P artifact absent from the worktree) — confirmed reproducing on the pre-change baseline; unrelated to this change.

CI does not need to pass here — batch-reviewed during staging integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
