### PR TITLE
infra(tokens): emit --ev-type-* evidence-type color tokens

### DIFF
--- a/scripts/generateCssTokens.py
+++ b/scripts/generateCssTokens.py
@@ -297,6 +297,36 @@ def build_tokens_css(gaia: dict) -> str:
     body.append(f"  --color-local-user: {_local_user_hex};")
     body.append(f"  --color-local-user-rgb: {_local_user_rgb};")
 
+    # ── Evidence TYPE tokens (provenance color axis) ─────────────────────────
+    # Evidence Type ≠ rank ≠ branch. Each canonical evidence type gets its own
+    # --ev-type-<name> color so pills stop borrowing --tier-*/--rank-* (which
+    # conflated provenance with skill rank — see TOKEN-POLLUTION-AUDIT.md, T16-T18).
+    # Hues are the source of truth from docs/evidence/ (the evidence library
+    # page). Kebab-case names match the schema evidence.types values and the
+    # .ev-type-pill.type-<name> consumer classes in styles.css.
+    body.append("")
+    body.append(
+        "  /* ── Evidence Type tokens (provenance axis — NOT rank/branch) ─── */"
+    )
+    ev_type_colors = {
+        "repo": "#38bdf8",
+        "repo-own": "#38bdf8",
+        "peer-review": "#38bdf8",
+        "github-stars": "#f59e0b",
+        "github-stars-own": "#f59e0b",
+        "fusion-recipe": "#f59e0b",
+        "proxy-containment": "#7c3aed",
+        "verifier-attestation": "#e879f9",
+        "benchmark-result": "#c084fc",
+        "arxiv": "#c084fc",
+        "self-attestation": "#94a3b8",
+        "social-signal": "#34d399",
+    }
+    for name, hex_val in ev_type_colors.items():
+        rgb_triplet = _rgb_str(_hex_to_rgb_triplet(hex_val))
+        body.append(f"  --ev-type-{name}: {hex_val};")
+        body.append(f"  --ev-type-{name}-rgb: {rgb_triplet};")
+
     body.append("}")
     body.append("")
     return "\n".join(body)


### PR DESCRIPTION
## Summary

Adds an **Evidence Type** color token family (`--ev-type-<name>`) to the `tokens.css` generator. Evidence Type is a provenance axis — distinct from rank and branch — and its pills were borrowing `--tier-*`/`--rank-*` tokens (part of the rank/type pollution documented in `founder/reports/design-review-2026-07-20/TOKEN-POLLUTION-AUDIT.md` and fixed on #1246, T16–T18).

Hues sourced from `docs/evidence/` (the evidence library page): cyan repos/peer-review, gold github-stars/fusion-recipe, violet proxy-containment, fuchsia verifier-attestation, light-purple benchmark/arxiv, slate self-attestation, green social-signal.

## Base = staging (not main)

Branched from `origin/dev/yggdrasil-ii-staging` and **targets staging** — the whole Yggdrasil II epic integrates there, and the staging generator carries the `--color-local-user` block (Ygg-II PR 3c) that `main`'s generator does not. Building off main risked drift; this inserts cleanly after the local-user block. (Supersedes the earlier main-based PR #1269, now closed.)

## Generator-only (no tokens.css in the diff)

`docs/css/tokens.css` regenerates from the **Class P (gitignored)** `registry/gaia.json` via `gaia dev docs` on staging. Committing a local regen would carry stale `meta.typeColors`. Staging regen materializes this block against the correct current meta.

## Consumers

`.ev-type-pill.type-<name>` on #1246 already reference `var(--ev-type-<name>, #<hue>)` with the canonical hue as fallback — they render correctly until this lands + staging regens.

## Entrypoints

Token-generator change only. **Waived** (no new surface).

## Token spend
- 2026-07-25 Opus 4.8 (superadmin / orchestrator-only): --ev-type-* generator block, rebased onto staging. ~40k in, ~7k out. ~$2.5
