### PR TITLE
fix(security): resolve 8 CodeQL high-severity alerts from PR #1185

### DIFF
--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -1575,9 +1575,20 @@
       }
       repoBlock.style.display = "block";
       currentState.selectedRepo = repos[0];
-      repoList.innerHTML = repos.map((r, i) =>
-        `<label><input type="radio" name="bd-repo" value="${r}" ${i === 0 ? "checked" : ""}>${r}</label>`
-      ).join("");
+      // Build radio labels via the DOM API so repo names (user-derived) are set
+      // as text/value properties and never reinterpreted as HTML (avoids DOM-XSS).
+      repoList.innerHTML = "";
+      repos.forEach((r, i) => {
+        const label = document.createElement("label");
+        const input = document.createElement("input");
+        input.type = "radio";
+        input.name = "bd-repo";
+        input.value = r;
+        if (i === 0) input.checked = true;
+        label.appendChild(input);
+        label.appendChild(document.createTextNode(r));
+        repoList.appendChild(label);
+      });
       repoList.querySelectorAll("input[name='bd-repo']").forEach((el) => {
         el.addEventListener("change", () => {
           currentState.selectedRepo = el.value;

--- a/docs/codex.html
+++ b/docs/codex.html
@@ -827,10 +827,21 @@
     const consoleBox = document.getElementById("simulatorConsole");
     let isRunning = false;
 
-    function addLog(msg, type = "system") {
+    const escLog = (s) => String(s).replace(/[&<>"']/g, (c) => (
+      { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+    ));
+
+    // Plain text by default (msg is escaped). Pass { html: true } only for
+    // author-controlled markup strings — any interpolated runtime value inside
+    // those must be run through escLog() at the call site first.
+    function addLog(msg, type = "system", opts = {}) {
       const line = document.createElement("div");
       line.className = `console-line ${type}`;
-      line.innerHTML = msg;
+      if (opts.html) {
+        line.innerHTML = msg;
+      } else {
+        line.textContent = msg;
+      }
       consoleBox.appendChild(line);
       consoleBox.scrollTop = consoleBox.scrollHeight;
     }
@@ -976,9 +987,9 @@
 
                   promptBox.remove();
                   addLog(`[User] Submitted Review Decisions:`, "user");
-                  addLog(` - <code>literature-search</code>: <strong>${dec1.toUpperCase()}</strong>`, "user");
-                  addLog(` - <code>openai/swarm</code>: <strong>${dec2.toUpperCase()}</strong>`, "user");
-                  addLog(` - <code>arxiv-lookup</code>: <strong>${dec3.toUpperCase()}</strong>`, "user");
+                  addLog(` - <code>literature-search</code>: <strong>${escLog(dec1.toUpperCase())}</strong>`, "user", { html: true });
+                  addLog(` - <code>openai/swarm</code>: <strong>${escLog(dec2.toUpperCase())}</strong>`, "user", { html: true });
+                  addLog(` - <code>arxiv-lookup</code>: <strong>${escLog(dec3.toUpperCase())}</strong>`, "user", { html: true });
 
                   const acceptedCount = (dec1 === 'accept' ? 1 : 0) + (dec2 === 'accept' || dec2 === 'rename' ? 1 : 0) + (dec3 === 'accept' ? 1 : 0);
 

--- a/docs/en/cli-reference.html
+++ b/docs/en/cli-reference.html
@@ -2438,9 +2438,16 @@
             const cmdCard = row.closest('.cmd-card');
             let cmdName = cmdCard ? cmdCard.querySelector('.cmd-name').textContent.trim() : '';
 
-            // Wrap the original flag content inside a .flag-text span
-            const originalHTML = firstCell.innerHTML;
-            firstCell.innerHTML = `<span class="flag-text copyable-flag-text" title="Click to copy flag name">${originalHTML}</span>`;
+            // Wrap the original flag content inside a .flag-text span by moving
+            // the existing child nodes (not via innerHTML round-trip, which would
+            // re-parse cell content as HTML — avoids DOM-XSS).
+            const flagSpan = document.createElement('span');
+            flagSpan.className = 'flag-text copyable-flag-text';
+            flagSpan.title = 'Click to copy flag name';
+            while (firstCell.firstChild) {
+              flagSpan.appendChild(firstCell.firstChild);
+            }
+            firstCell.appendChild(flagSpan);
 
             // Click listener for the flag name text to copy just the flag option
             const flagText = firstCell.querySelector('.flag-text');

--- a/docs/js/hoh-modal.js
+++ b/docs/js/hoh-modal.js
@@ -295,7 +295,13 @@
           .then(function (svgText) {
             // Strip XML prolog so the SVG inlines cleanly.
             var clean = svgText.replace(/^<\?xml[^>]*\?>\s*/, '');
-            stage.innerHTML = clean;
+            // Parse as SVG and adopt the root node rather than assigning
+            // innerHTML with fetched text (avoids DOM-XSS from the fetch sink).
+            var doc = new DOMParser().parseFromString(clean, 'image/svg+xml');
+            var svgEl = doc.documentElement;
+            if (svgEl && svgEl.nodeName.toLowerCase() === 'svg') {
+              stage.replaceChildren(document.importNode(svgEl, true));
+            }
           })
           .catch(function () { /* keep mock */ });
       } else {

--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -2192,7 +2192,7 @@
         var clean = String(c).replace(/^@/, '');
         var avatarSrc = 'https://github.com/' + encodeURIComponent(clean) + '.png?size=32';
         var identicon = 'https://github.com/identicons/' + encodeURIComponent(clean) + '.png';
-        var errAttr = "if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk='1';this.src='" + identicon.replace(/'/g, "\\'") + "';}";
+        var errAttr = "if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk='1';this.src='" + identicon.replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "';}";
         // E3: GitHub avatar framed by gold wreath (matches chart-bar appendAvatarWreath pattern)
         var avatarHtml =
           '<span class="lb-ms-avatar" style="background:oklch(0.55 0.18 ' + handleHue(c) + ')">' +

--- a/scripts/check_taxonomy_authority.py
+++ b/scripts/check_taxonomy_authority.py
@@ -144,7 +144,7 @@ EXCLUDE_GLOBS = [
 ]
 
 # Inline <script> extraction for .html files.
-SCRIPT_BLOCK = re.compile(r"<script\b[^>]*>(.*?)</script>", re.IGNORECASE | re.DOTALL)
+SCRIPT_BLOCK = re.compile(r"<script\b[^>]*>(.*?)</script\s*>", re.IGNORECASE | re.DOTALL)
 
 
 def isComment(line: str, isPython: bool) -> bool:


### PR DESCRIPTION
## Summary

Resolves the **8 high-severity CodeQL alerts** flagged on the Yggdrasil II staging integration PR (#1185, check run 89552403597). All are the JS/Python "unsafe HTML" family; every fix is **behavior-preserving** (identical rendered output / matcher behavior).

## Alerts fixed

| # | File | Rule | Fix |
|---|------|------|-----|
| 1 | `scripts/check_taxonomy_authority.py` | Bad HTML filtering regexp | `</script>` → `</script\s*>` so the guard's inline-`<script>` extractor matches end tags with trailing whitespace (`</script >`) |
| 2–4 | `docs/badges/index.html` | DOM text reinterpreted as HTML | `renderRepoPicker` builds radio labels via the DOM API (`createElement` + `createTextNode`) instead of interpolating user-derived repo names into `innerHTML` — matches the DOM-XSS-safe pattern already used by the sibling `entries.forEach` block |
| 5 | `docs/codex.html` | DOM text reinterpreted as HTML | `addLog()` now escapes by default (`textContent`); the three author-controlled markup lines opt in via `{ html: true }`, and their interpolated `<select>` decision values are run through a new `escLog()` helper |
| 6 | `docs/en/cli-reference.html` | DOM text reinterpreted as HTML | Flag-cell wrap moves existing child nodes into the `.flag-text` span instead of an `innerHTML` read/re-inject round-trip |
| 7 | `docs/js/hoh-modal.js` | DOM text reinterpreted as HTML | Fetched OG SVG is parsed with `DOMParser` (`image/svg+xml`) and adopted via `importNode` instead of `innerHTML` on the fetch response text |
| 8 | `docs/trust/leaderboard/leaderboard.js` | Incomplete string escaping | Inline `onerror` `src` now escapes backslash before quote (`\` then `'`) |

Most inputs are registry-controlled (contributor handles, approved repo names) or constrained `<select>` values, so real-world exploitability was low — but these are legitimate sinks and the fixes are the correct DOM-safe patterns, not suppressions.

## Testing

- `python scripts/check_taxonomy_authority.py` → PASS (0 sites); regex verified against `</script>`, `</script >`, `</script  >`, `<SCRIPT>`.
- `node --check` on `hoh-modal.js`, `leaderboard.js`, and the extracted inline `<script>` blocks of all three HTML files → all parse.
- `pytest tests/test_generate_badges.py` → 6 passed.
- `py_compile` on the guard script → OK.

## Entrypoints

N/A — waived. No new user-facing page or section; this PR only hardens existing surfaces (badges, codex, cli-reference, HoH modal, leaderboard). No nav/footer/mount/cache-bust changes.

## Notes

- Scope: all 6 files are under `docs/` and `scripts/` — within the `infra/` branch allowlist.
- Base is `dev/yggdrasil-ii-staging` (not `main`) so it folds into the staging integration before #1185 lands.
- `docs/badges/index.html` is a core page — reviewer should confirm `/badges/?u=mattpocock&s=grill-me` and the repo-picker radios still render after merge.
