### PR TITLE
infra(seo): GA4 analytics injection across all public docs pages

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -899,6 +899,14 @@
   "url": "https://gaiaskilltree.com/about.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body class="about-page">

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -299,6 +299,14 @@
   "url": "https://gaiaskilltree.com/api/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body>

--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -878,6 +878,14 @@
   "url": "https://gaiaskilltree.com/badges/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="process-page">
   <nav id="site-nav"></nav>

--- a/docs/benchmarks/humaneval-v1/index.html
+++ b/docs/benchmarks/humaneval-v1/index.html
@@ -182,6 +182,14 @@
   "url": "https://gaiaskilltree.com/benchmarks/humaneval-v1/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <nav id="site-nav"></nav>

--- a/docs/benchmarks/humaneval/index.html
+++ b/docs/benchmarks/humaneval/index.html
@@ -282,6 +282,14 @@
   "url": "https://gaiaskilltree.com/benchmarks/humaneval/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <nav id="site-nav"></nav>

--- a/docs/benchmarks/index.html
+++ b/docs/benchmarks/index.html
@@ -402,6 +402,14 @@
   "url": "https://gaiaskilltree.com/benchmarks/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <nav id="site-nav"></nav>

--- a/docs/benchmarks/methodology/index.html
+++ b/docs/benchmarks/methodology/index.html
@@ -212,6 +212,14 @@
   "url": "https://gaiaskilltree.com/benchmarks/methodology/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <nav id="site-nav"></nav>

--- a/docs/benchmarks/mmlu-v1/index.html
+++ b/docs/benchmarks/mmlu-v1/index.html
@@ -198,6 +198,14 @@
   "url": "https://gaiaskilltree.com/benchmarks/mmlu-v1/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <nav id="site-nav"></nav>

--- a/docs/benchmarks/mmlu/index.html
+++ b/docs/benchmarks/mmlu/index.html
@@ -205,6 +205,14 @@
   "url": "https://gaiaskilltree.com/benchmarks/mmlu/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <nav id="site-nav"></nav>

--- a/docs/codex.html
+++ b/docs/codex.html
@@ -440,6 +440,14 @@
   "url": "https://gaiaskilltree.com/codex.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="process-page">
 

--- a/docs/codex/trust-methodology.html
+++ b/docs/codex/trust-methodology.html
@@ -311,6 +311,14 @@
   "url": "https://gaiaskilltree.com/codex/trust-methodology.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="process-page">
 

--- a/docs/en/cli-reference.html
+++ b/docs/en/cli-reference.html
@@ -803,6 +803,14 @@
   "url": "https://gaiaskilltree.com/en/cli-reference.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body>

--- a/docs/en/contributing.html
+++ b/docs/en/contributing.html
@@ -463,6 +463,14 @@
   "url": "https://gaiaskilltree.com/en/contributing.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/evidence-classes.html
+++ b/docs/en/evidence-classes.html
@@ -364,6 +364,14 @@
   "url": "https://gaiaskilltree.com/en/evidence-classes.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/faq.html
+++ b/docs/en/faq.html
@@ -251,6 +251,14 @@
   "url": "https://gaiaskilltree.com/en/faq.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/fusion.html
+++ b/docs/en/fusion.html
@@ -513,6 +513,14 @@
   "url": "https://gaiaskilltree.com/en/fusion.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/getting-started.html
+++ b/docs/en/getting-started.html
@@ -491,6 +491,14 @@
   "url": "https://gaiaskilltree.com/en/getting-started.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -379,6 +379,14 @@
   "url": "https://gaiaskilltree.com/en/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/mcp-server.html
+++ b/docs/en/mcp-server.html
@@ -488,6 +488,14 @@
   "url": "https://gaiaskilltree.com/en/mcp-server.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/named-skills.html
+++ b/docs/en/named-skills.html
@@ -589,6 +589,14 @@
   "url": "https://gaiaskilltree.com/en/named-skills.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/share-bundles.html
+++ b/docs/en/share-bundles.html
@@ -318,6 +318,14 @@
   "url": "https://gaiaskilltree.com/en/share-bundles.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/skill-hierarchy.html
+++ b/docs/en/skill-hierarchy.html
@@ -511,6 +511,14 @@
   "url": "https://gaiaskilltree.com/en/skill-hierarchy.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/en/timeline-audit.html
+++ b/docs/en/timeline-audit.html
@@ -424,6 +424,14 @@
   "url": "https://gaiaskilltree.com/en/timeline-audit.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/evidence/index.html
+++ b/docs/evidence/index.html
@@ -627,6 +627,14 @@
   "url": "https://gaiaskilltree.com/evidence/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body class="evidence-page">

--- a/docs/graph/index.html
+++ b/docs/graph/index.html
@@ -13,6 +13,14 @@
   "url": "https://gaiaskilltree.com/graph/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <p>Redirecting to the <a href="../">Gaia skill graph</a>…</p>

--- a/docs/heroes/index.html
+++ b/docs/heroes/index.html
@@ -38,6 +38,14 @@
   "url": "https://gaiaskilltree.com/heroes/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <!-- Site navigation -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -296,6 +296,14 @@
   }
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body class="home-page">
@@ -1550,9 +1558,6 @@ Use https://github.com/gaia-research/gaia-skill-tree as the source of truth and 
        src="https://static.scarf.sh/a.png?x-pxid=b8e05c84-1886-4b68-b80c-7b00cdb68f94"
        alt="" style="display:none" />
 
-<!-- impeccable-live-start -->
-<script src="http://localhost:8400/live.js"></script>
-<!-- impeccable-live-end -->
 </body>
 
 </html>

--- a/docs/meta.html
+++ b/docs/meta.html
@@ -107,6 +107,14 @@
   "url": "https://gaiaskilltree.com/meta.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="process-page">
 

--- a/docs/meta/reports/2026-05-25-programmatic-registry-audit.html
+++ b/docs/meta/reports/2026-05-25-programmatic-registry-audit.html
@@ -392,6 +392,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-05-25-programmatic-registry-audit.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-05-31-starless-skills-update.html
+++ b/docs/meta/reports/2026-05-31-starless-skills-update.html
@@ -181,6 +181,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-05-31-starless-skills-update.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-06-02-june-week-1-meta-update.html
+++ b/docs/meta/reports/2026-06-02-june-week-1-meta-update.html
@@ -181,6 +181,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-06-02-june-week-1-meta-update.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-06-03-chained-curation-thirteen-starless-references-and-a-unique-reclassification.html
+++ b/docs/meta/reports/2026-06-03-chained-curation-thirteen-starless-references-and-a-unique-reclassification.html
@@ -181,6 +181,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-06-03-chained-curation-thirteen-starless-references-and-a-unique-reclassification.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-06-14-the-gaia-trust-methodology-evidence-types-grades-and-inherited-standing.html
+++ b/docs/meta/reports/2026-06-14-the-gaia-trust-methodology-evidence-types-grades-and-inherited-standing.html
@@ -181,6 +181,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-06-14-the-gaia-trust-methodology-evidence-types-grades-and-inherited-standing.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-06-15-the-gaia-trust-methodology-evidence-types-grades-and-inherited-standing.html
+++ b/docs/meta/reports/2026-06-15-the-gaia-trust-methodology-evidence-types-grades-and-inherited-standing.html
@@ -617,6 +617,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-06-15-the-gaia-trust-methodology-evidence-types-grades-and-inherited-standing.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-06-17-g7-trust-magnitude-supersedes-the-2026-06-15-methodology.html
+++ b/docs/meta/reports/2026-06-17-g7-trust-magnitude-supersedes-the-2026-06-15-methodology.html
@@ -182,6 +182,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-06-17-g7-trust-magnitude-supersedes-the-2026-06-15-methodology.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-06-20-gaia-trust-infrastructure-a-june-2026-retrospective.html
+++ b/docs/meta/reports/2026-06-20-gaia-trust-infrastructure-a-june-2026-retrospective.html
@@ -182,6 +182,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-06-20-gaia-trust-infrastructure-a-june-2026-retrospective.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-07-03-curation-report-addy-osmani-7-skill-suite-integration.html
+++ b/docs/meta/reports/2026-07-03-curation-report-addy-osmani-7-skill-suite-integration.html
@@ -182,6 +182,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-07-03-curation-report-addy-osmani-7-skill-suite-integration.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-07-03-gsd-suite-curation.html
+++ b/docs/meta/reports/2026-07-03-gsd-suite-curation.html
@@ -182,6 +182,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-07-03-gsd-suite-curation.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/meta/reports/2026-07-13-firecrawl-suite-curation-and-origin-recalibration.html
+++ b/docs/meta/reports/2026-07-13-firecrawl-suite-curation-and-origin-recalibration.html
@@ -182,6 +182,14 @@
   "url": "https://gaiaskilltree.com/meta/reports/2026-07-13-firecrawl-suite-curation-and-origin-recalibration.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
 

--- a/docs/named/index.html
+++ b/docs/named/index.html
@@ -40,6 +40,14 @@
   "url": "https://gaiaskilltree.com/named/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body class="named-explorer-page">

--- a/docs/named/report.html
+++ b/docs/named/report.html
@@ -594,6 +594,14 @@
   "url": "https://gaiaskilltree.com/named/report.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body class="report-page">

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -138,6 +138,14 @@
   "url": "https://gaiaskilltree.com/privacy.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body>

--- a/docs/reports/2026-28/index.html
+++ b/docs/reports/2026-28/index.html
@@ -349,6 +349,14 @@
   "url": "https://gaiaskilltree.com/reports/2026-28/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <nav id="site-nav"></nav>

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -302,6 +302,14 @@
   "url": "https://gaiaskilltree.com/reports/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <nav id="site-nav"></nav>

--- a/docs/share/index.html
+++ b/docs/share/index.html
@@ -27,6 +27,14 @@
   "url": "https://gaiaskilltree.com/share/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body class="share-page">

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -34,6 +34,14 @@
   "url": "https://gaiaskilltree.com/skills/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <div id="site-nav"></div>

--- a/docs/starless.html
+++ b/docs/starless.html
@@ -134,6 +134,14 @@
   "url": "https://gaiaskilltree.com/starless.html"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="process-page">
 

--- a/docs/trending/index.html
+++ b/docs/trending/index.html
@@ -35,6 +35,14 @@
   "url": "https://gaiaskilltree.com/trending/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 
 <body class="trending-page">

--- a/docs/trust/index.html
+++ b/docs/trust/index.html
@@ -17,6 +17,14 @@
   "url": "https://gaiaskilltree.com/trust/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body>
   <p>This page has moved. <a href="../codex/trust-methodology.html">Go to Trust Methodology →</a></p>

--- a/docs/trust/leaderboard/index.html
+++ b/docs/trust/leaderboard/index.html
@@ -22,6 +22,14 @@
   "url": "https://gaiaskilltree.com/trust/leaderboard/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="lb-dark-page">
   <nav id="site-nav"></nav>

--- a/docs/trust/ledger/index.html
+++ b/docs/trust/ledger/index.html
@@ -24,6 +24,14 @@
   "url": "https://gaiaskilltree.com/trust/ledger/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="process-page ledger-page">
 

--- a/docs/u/0xdarkmatter/index.html
+++ b/docs/u/0xdarkmatter/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/0xdarkmatter"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/Manavarya09/index.html
+++ b/docs/u/Manavarya09/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/Manavarya09"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/Taoidle/index.html
+++ b/docs/u/Taoidle/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/Taoidle"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/addy-osmani/index.html
+++ b/docs/u/addy-osmani/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/addy-osmani"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/anthropic/index.html
+++ b/docs/u/anthropic/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/anthropic"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/bradautomates/index.html
+++ b/docs/u/bradautomates/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/bradautomates"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/browser-use/index.html
+++ b/docs/u/browser-use/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/browser-use"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/browserbase/index.html
+++ b/docs/u/browserbase/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/browserbase"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/caioribeiroclw-pixel/index.html
+++ b/docs/u/caioribeiroclw-pixel/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/caioribeiroclw-pixel"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/changkun/index.html
+++ b/docs/u/changkun/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/changkun"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/devin-ai/index.html
+++ b/docs/u/devin-ai/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/devin-ai"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/favorchurch/index.html
+++ b/docs/u/favorchurch/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/favorchurch"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/firecrawl/index.html
+++ b/docs/u/firecrawl/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/firecrawl"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/gaia-research/index.html
+++ b/docs/u/gaia-research/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/gaia-research"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/gaiabot/index.html
+++ b/docs/u/gaiabot/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/gaiabot"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/garrytan/index.html
+++ b/docs/u/garrytan/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/garrytan"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/getagentseal/index.html
+++ b/docs/u/getagentseal/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/getagentseal"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/glincker/index.html
+++ b/docs/u/glincker/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/glincker"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/google-deepmind/index.html
+++ b/docs/u/google-deepmind/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/google-deepmind"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/gooseworks/index.html
+++ b/docs/u/gooseworks/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/gooseworks"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/gsd-build/index.html
+++ b/docs/u/gsd-build/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/gsd-build"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/huggingface/index.html
+++ b/docs/u/huggingface/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/huggingface"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/index.html
+++ b/docs/u/index.html
@@ -34,6 +34,14 @@
   "url": "https://gaiaskilltree.com/u/"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-directory-page">
 

--- a/docs/u/intelligentcode-ai/index.html
+++ b/docs/u/intelligentcode-ai/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/intelligentcode-ai"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/karpathy/index.html
+++ b/docs/u/karpathy/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/karpathy"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/langgenius/index.html
+++ b/docs/u/langgenius/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/langgenius"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/laravel/index.html
+++ b/docs/u/laravel/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/laravel"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/martin-stepanoski/index.html
+++ b/docs/u/martin-stepanoski/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/martin-stepanoski"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/mattpocock/index.html
+++ b/docs/u/mattpocock/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/mattpocock"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/mbtiongson1/index.html
+++ b/docs/u/mbtiongson1/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/mbtiongson1"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/nexu-io/index.html
+++ b/docs/u/nexu-io/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/nexu-io"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/nousresearch/index.html
+++ b/docs/u/nousresearch/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/nousresearch"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/obra/index.html
+++ b/docs/u/obra/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/obra"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/openai/index.html
+++ b/docs/u/openai/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/openai"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/pbakaus/index.html
+++ b/docs/u/pbakaus/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/pbakaus"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/pexp13/index.html
+++ b/docs/u/pexp13/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/pexp13"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/rico-favor/index.html
+++ b/docs/u/rico-favor/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/rico-favor"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/ruvnet/index.html
+++ b/docs/u/ruvnet/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/ruvnet"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/safishamsi/index.html
+++ b/docs/u/safishamsi/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/safishamsi"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/santifer/index.html
+++ b/docs/u/santifer/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/santifer"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/sickn33/index.html
+++ b/docs/u/sickn33/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/sickn33"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/spring-ai/index.html
+++ b/docs/u/spring-ai/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/spring-ai"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/stanfordnlp/index.html
+++ b/docs/u/stanfordnlp/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/stanfordnlp"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/upsonic/index.html
+++ b/docs/u/upsonic/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/upsonic"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/vercel/index.html
+++ b/docs/u/vercel/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/vercel"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/xquik-dev/index.html
+++ b/docs/u/xquik-dev/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/xquik-dev"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/yonatangross/index.html
+++ b/docs/u/yonatangross/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/yonatangross"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/docs/u/yundu-ai/index.html
+++ b/docs/u/yundu-ai/index.html
@@ -37,6 +37,14 @@
   "sameAs": "https://github.com/yundu-ai"
 }
 </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TS7N9T92BM" data-ga4="G-TS7N9T92BM"></script>
+  <script data-ga4="G-TS7N9T92BM">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TS7N9T92BM');
+  </script>
 </head>
 <body class="profile-page">
 

--- a/scripts/inject_ga4.py
+++ b/scripts/inject_ga4.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Inject GA4 gtag snippet into all public docs HTML files (idempotent)."""
+
+import re
+import sys
+from pathlib import Path
+
+GA_ID = "G-TS7N9T92BM"
+MARKER = f'data-ga4="{GA_ID}"'
+
+SNIPPET = f"""  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={GA_ID}" {MARKER}></script>
+  <script {MARKER}>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){{dataLayer.push(arguments);}}
+    gtag('js', new Date());
+    gtag('config', '{GA_ID}');
+  </script>"""
+
+SKIP_DIRS = {"samples", "archive", "audits", "experiments"}
+
+DOCS = Path(__file__).parent.parent / "docs"
+
+
+def should_skip(path: Path) -> bool:
+    return any(part in SKIP_DIRS for part in path.parts)
+
+
+def inject(path: Path, check: bool) -> bool:
+    text = path.read_text(encoding="utf-8")
+    if MARKER in text:
+        return False  # already present
+    if check:
+        print(f"MISSING GA4: {path.relative_to(DOCS.parent)}")
+        return True
+    updated = re.sub(r"(</head>)", SNIPPET + r"\n\1", text, count=1, flags=re.IGNORECASE)
+    if updated == text:
+        print(f"WARNING: no </head> found in {path}", file=sys.stderr)
+        return False
+    path.write_text(updated, encoding="utf-8")
+    print(f"injected: {path.relative_to(DOCS.parent)}")
+    return True
+
+
+def main():
+    check = "--check" in sys.argv
+    changed = []
+    for html in sorted(DOCS.rglob("*.html")):
+        if not should_skip(html.relative_to(DOCS)):
+            if inject(html, check):
+                changed.append(html)
+    if check and changed:
+        sys.exit(1)
+    print(f"\n{'Would update' if check else 'Updated'} {len(changed)} file(s).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds GA4 measurement ID `G-TS7N9T92BM` to all 99 public HTML pages under `docs/` via a new idempotent injector script (`scripts/inject_ga4.py`)
- Strips the dev live-reload script (`localhost:8400/live.js`) that was leaking into production `docs/index.html`
- Skips non-public dirs: `samples/`, `archive/`, `audits/`, `experiments/`

## Entrypoints

No new user-facing pages added — analytics only. N/A for nav/mount registration.

## Files changed

- `scripts/inject_ga4.py` — new idempotent injector; run with `--check` to verify no pages are missing GA4
- `docs/**/*.html` (99 files) — GA4 snippet injected before `</head>`

## Test plan

- [ ] Verify GA4 fires on gaiaskilltree.com after merge (Google Analytics → Realtime view)
- [ ] Confirm `samples/`, `archive/`, `audits/`, `experiments/` pages have no GA4 snippet
- [ ] Re-run `python scripts/inject_ga4.py --check` — should report 0 missing files
- [ ] Confirm `localhost:8400/live.js` no longer appears in `docs/index.html`