### PR TITLE
fix(leaderboard): suite bars never render — branchOf reads unpopulated field

### DIFF
--- a/docs/trust/leaderboard/leaderboard.css
+++ b/docs/trust/leaderboard/leaderboard.css
@@ -28,13 +28,15 @@
 }
 
 /* ── Sticky left-rail Table of Contents (desktop only) ──
-   Selector must be nav.lb-toc (not .lb-toc) to outweigh the global
-   `nav:not(.footer-cols)` rule in docs/css/styles.css L300, which otherwise
-   forces position:fixed across the top of the viewport and removes the TOC
-   from the grid — collapsing the layout to look single-column.
-   Specificity ties at (0,1,1); leaderboard.css loads after styles.css so it wins.
-   We also explicitly null the inherited fixed/background/border/padding/z-index. */
-nav.lb-toc {
+   Selector must out-weigh the global `nav:not(.footer-cols):not(.footer-rail)`
+   rule in docs/css/styles.css, which otherwise forces position:fixed across the
+   top of the viewport and removes the TOC from the grid — collapsing column 1
+   to 220px and jamming the whole page into it (blank main panel).
+   That global rule is specificity (0,2,1) (element + two :not() classes), so a
+   bare `nav.lb-toc` at (0,1,1) LOSES and the TOC pops out of flow. We mirror the
+   global's :not() chain to reach (0,3,1), which strictly beats it regardless of
+   load order. Also explicitly null the inherited fixed/background/border/padding/z-index. */
+nav.lb-toc:not(.footer-cols):not(.footer-rail) {
   position: sticky;
   top: 140px;
   left: auto;
@@ -976,7 +978,7 @@ nav.lb-toc a.is-active .lb-toc-icon { opacity: 1; }
     grid-template-columns: 220px 1fr;
     gap: 2rem;
   }
-  nav.lb-toc {
+  nav.lb-toc:not(.footer-cols):not(.footer-rail) {
     display: flex;
   }
   .lb-registry-grid {

--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -118,6 +118,9 @@
     rank6: tok('--rank-6-rgb') || '251, 191, 36',
     honorRed: tok('--honor-red-rgb') || '239, 68, 68',
     basic: tok('--tier-basic-rgb') || '56, 189, 248',
+    unique4: tok('--tier-unique-rgb') || '124, 58, 237',
+    unique5: tok('--tier-unique-5-rgb') || '178, 106, 58',
+    unique6: tok('--tier-unique-6-rgb') || '224, 137, 74',
     muted: tok('--muted') || 'rgb(100, 116, 139)',
     text: tok('--text') || 'rgb(226, 232, 240)',
     border: tok('--border') || 'rgb(30, 41, 59)'
@@ -184,13 +187,32 @@
   // Keyed by branch ('standard'|'suite'|'unique'), NOT by the dead enum
   // (basic/extra/unique/ultimate). Branch is READ from the emitted field via
   // GaiaSemantics.branchOf — never read from skill.type directly.
-  // Token source: --tier-basic-rgb (56,189,248), --tier-fusion-rgb (245,158,11),
-  //               --tier-unique-rgb (124,58,237). No hex literals (CI guard E7).
+  // Token source: --tier-basic-rgb (56,189,248), --tier-fusion-rgb (245,158,11).
+  // Unique branch is level-sensitive — see uniqueColors(). No hex literals (CI guard E7).
   var BRANCH_COLORS = {
     standard: { top: [56,  189, 248], bot: [30,  100, 160] },   // --tier-basic-rgb
-    suite:    { top: [245, 158,  11], bot: [160,  90,   5] },   // --tier-fusion-rgb (gold)
-    unique:   { top: [124,  58, 237], bot: [60,   25, 140] }    // --tier-unique-rgb (darker plaque)
+    suite:    { top: [245, 158,  11], bot: [160,  90,   5] }    // --tier-fusion-rgb (gold)
   };
+
+  // Level-sensitive color stops for the unique branch.
+  // 4★ = --tier-unique-rgb (violet), 5★ = --tier-unique-5-rgb (burnished copper),
+  // 6★ = --tier-unique-6-rgb (ember copper). Deliberately off the suite gold axis.
+  function uniqueColors(level) {
+    var n = parseInt(level) || 0;
+    var rawMap = {
+      6: TOKENS.unique6 || '224, 137, 74',
+      5: TOKENS.unique5 || '178, 106, 58'
+    };
+    var raw = (n >= 6 ? rawMap[6] : (n === 5 ? rawMap[5] : (TOKENS.unique4 || '124, 58, 237')));
+    var parts = raw.split(',').map(function(s) { return parseInt(s.trim(), 10) || 0; });
+    var top = [parts[0], parts[1], parts[2]];
+    var bot = [
+      Math.round(top[0] * 0.55),
+      Math.round(top[1] * 0.55),
+      Math.round(top[2] * 0.55)
+    ];
+    return { top: top, bot: bot };
+  }
 
   // Grade accent cap colors (solid RGBA strings)
   var GRADE_CAP_COLOR = {
@@ -203,6 +225,7 @@
   // Resolve branch color stops for a skill node.
   // node may carry .type and .suiteComponents; level is the star level.
   // Falls back to 'standard' when GaiaSemantics hasn't loaded yet.
+  // Unique branch is level-sensitive — delegates to uniqueColors(level).
   function typeColors(nodeOrType, level) {
     var branch = 'standard';
     var gs = (typeof window !== 'undefined' && window.GaiaSemantics);
@@ -213,6 +236,7 @@
       if (nodeOrType === 'fusion') branch = 'suite';
       else branch = 'standard';
     }
+    if (branch === 'unique') return uniqueColors(level);
     return BRANCH_COLORS[branch] || BRANCH_COLORS.standard;
   }
 

--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -496,6 +496,12 @@
         name: skill.name || row.id.split('/')[1],
         contributor: row.id.split('/')[0],
         type: normType,
+        // Carry the taxonomy-resolved branch off the skills index so
+        // GaiaSemantics.branchOf reads a real value (it reads entry.branch and
+        // otherwise falls back to 'standard'). Without this every allRows-derived
+        // object partitions as 'standard' — ultimates is always empty and the
+        // Suites chart / stacked component overlay never render.
+        branch: skill.branch || null,
         suiteComponents: skill.suiteComponents || null,
         level: row.level || skill.level || '',
         trustMagnitude: row.trustMagnitude || 0,
@@ -1365,6 +1371,7 @@
         name: g.primary.name,
         contributor: g.primary.contributor,
         type: g.primary.type,
+        branch: g.primary.branch || null,
         level: g.primary.level,
         trustMagnitude: g.primary.trustMagnitude,
         grade: g.primary.grade,

--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -147,6 +147,29 @@
     return map[n] || map[0];
   }
 
+  // Rank-colored gradient stops (Named chart — founder decision: standard-branch
+  // main bars color by star level, not the flat blue tier color).
+  // COLOR SOURCE OF TRUTH: the canonical rank palette lives in meta.json's
+  // `levelColors` and is emitted as `--rank-N-rgb` CSS tokens by
+  // scripts/generateCssTokens.py. We read those tokens via TOKENS.rankN so this
+  // chart never forks the palette; rankRgb() is only a defensive floor if a token
+  // failed to load. Returns { top, bot } mirroring BRANCH_COLORS so
+  // buildBarGradientDef reuses the same gradient machinery. `bot` is a darkened
+  // (~55%) form of the rank color so the bottom-to-top gradient still reads.
+  function rankColors(level) {
+    var n = parseInt(level) || 0;
+    var tokenRgb = TOKENS['rank' + n];
+    var raw = (tokenRgb && tokenRgb.trim()) ? tokenRgb : rankRgb(level);
+    var parts = raw.split(',').map(function(s) { return parseInt(s.trim(), 10) || 0; });
+    var top = [parts[0], parts[1], parts[2]];
+    var bot = [
+      Math.round(top[0] * 0.55),
+      Math.round(top[1] * 0.55),
+      Math.round(top[2] * 0.55)
+    ];
+    return { top: top, bot: bot };
+  }
+
   function gradeColor(grade) {
     switch (grade) {
       case 'S': return TOKENS.platinum;
@@ -232,6 +255,27 @@
     return Math.min(vw - 40, 1280);
   }
 
+  // ── MOBILE BAR-FIT (founder decision) ──
+  // On narrow viewports the Named chart must NOT cram every bar into view by
+  // shrinking bar width — bars stay a consistent fixed width and the chart shows
+  // only as many as fit, hiding the overflow (revealed via the "Show all" button).
+  // MOBILE_BREAKPOINT mirrors the 700px mobile cutover in docs/css/styles.css.
+  var MOBILE_BREAKPOINT = 700;
+  var MOBILE_BAR_W = 22;     // fixed bar width on mobile
+  var MOBILE_GAP_RATIO = 0.5; // gap = barW * ratio
+
+  function isMobileViewport() {
+    var vw = (typeof window !== 'undefined' && window.innerWidth) || 1024;
+    return vw <= MOBILE_BREAKPOINT;
+  }
+
+  // How many fixed-width bars fit in the container at mobile bar width.
+  function mobileBarFit(containerW, padL, padR) {
+    var available = Math.max(40, containerW - padL - padR);
+    var pitch = MOBILE_BAR_W * (1 + MOBILE_GAP_RATIO);
+    return Math.max(1, Math.floor(available / pitch));
+  }
+
   // Emit a label <text> with optional rotation. Caller still calls truncLabel.
   function makeLabel(x, y, rotation, fontPx, extraAttrs) {
     var attrs;
@@ -272,9 +316,21 @@
   // ── BAR GRADIENT BUILDER ──
   // Unified: main fill = BRANCH color (bottom→top), mid-stop blends contributor handle hue.
   // `node` is the full skill object carrying the emitted .branch that branchOf reads.
-  function buildBarGradientDef(svg, contributor, grade, level, node, id) {
+  // byRank (optional): when true, color the STANDARD branch by star level via
+  // rankColors(level) instead of the flat blue tier color (founder decision — the
+  // Named chart was a wall of blue). The 'suite' (gold) and 'unique' (purple)
+  // branches KEEP their distinct branch color so those forks stay visible.
+  function buildBarGradientDef(svg, contributor, grade, level, node, id, byRank) {
     var hue = handleHue(contributor);
-    var tc = typeColors(node, level);
+    var tc;
+    if (byRank) {
+      var gs = (typeof window !== 'undefined' && window.GaiaSemantics);
+      var branch = (gs && node && typeof node === 'object') ? gs.branchOf(node) : 'standard';
+      // Only recolor standard-branch bars by rank; preserve suite/unique branch color.
+      tc = (branch === 'standard') ? rankColors(level) : typeColors(node, level);
+    } else {
+      tc = typeColors(node, level);
+    }
     var stopBot = 'rgb(' + rgbStr(tc.bot) + ')';
     var mid = blendHandleMid(tc.top, hue);
     var stopMid = 'rgba(' + rgbStr(mid) + ',0.92)';
@@ -496,12 +552,15 @@
         name: skill.name || row.id.split('/')[1],
         contributor: row.id.split('/')[0],
         type: normType,
-        // Carry the taxonomy-resolved branch off the skills index so
+        // Carry the taxonomy-resolved branch/rankWord off the skills index so
         // GaiaSemantics.branchOf reads a real value (it reads entry.branch and
         // otherwise falls back to 'standard'). Without this every allRows-derived
-        // object partitions as 'standard' — ultimates is always empty and the
-        // Suites chart / stacked component overlay never render.
+        // object partitions as 'standard' — ultimates is always empty, the Suites
+        // chart / stacked overlay never render, AND the Named chart hides the
+        // 'unique' (purple) / 'suite' (gold) forks (founder ruling 2026-07-18:
+        // never re-derive branch on the client).
         branch: skill.branch || null,
+        rankWord: skill.rankWord || undefined,
         suiteComponents: skill.suiteComponents || null,
         level: row.level || skill.level || '',
         trustMagnitude: row.trustMagnitude || 0,
@@ -1371,7 +1430,11 @@
         name: g.primary.name,
         contributor: g.primary.contributor,
         type: g.primary.type,
+        // Carry the emitted branch/rankWord so branchOf() on the collapsed bar
+        // still resolves suite/unique — otherwise a grouped unique/suite bar
+        // falls back to 'standard' and is mis-colored by rank.
         branch: g.primary.branch || null,
+        rankWord: g.primary.rankWord,
         level: g.primary.level,
         trustMagnitude: g.primary.trustMagnitude,
         grade: g.primary.grade,
@@ -1408,6 +1471,21 @@
     var groupedCount = visible.length - collapsed.length; // how many were collapsed away
     state.collapsedNamed = collapsed;
 
+    // Mobile: keep a fixed bar width and HIDE overflow instead of shrinking every
+    // bar to fit (founder decision). Cap toShow to the number that fit at
+    // MOBILE_BAR_W; the "Show all" pagination still reveals the rest.
+    var mobile = isMobileViewport();
+    if (mobile && !state.namedExpanded) {
+      var fit = mobileBarFit(chartContainerW(), NPAD.left, NPAD.right);
+      if (toShow.length > fit) {
+        toShow = toShow.slice(0, fit);
+        collapsedShown = toShow;
+        // Ensure the "Show all" toggle appears even for small datasets that only
+        // overflow because of the mobile fixed-width cap.
+        needsPagination = true;
+      }
+    }
+
     if (countEl) {
       var countText = '(showing ' + collapsedShown.length + ' bars' +
         (groupedCount > 0 ? ', ' + groupedCount + ' grouped' : '') +
@@ -1435,8 +1513,12 @@
       return;
     }
 
-    // Fix 1: dynamic bar metrics
-    var metrics = computeBarMetrics(toShow.length, chartContainerW(), NPAD.left, NPAD.right, 10, 24, 0.5);
+    // Fix 1: dynamic bar metrics. On mobile, pin bar width (min=max=MOBILE_BAR_W)
+    // so bars stay a consistent width and the fitted count (above) governs how
+    // many render — no shrink-to-fit.
+    var metrics = mobile
+      ? computeBarMetrics(toShow.length, chartContainerW(), NPAD.left, NPAD.right, MOBILE_BAR_W, MOBILE_BAR_W, MOBILE_GAP_RATIO)
+      : computeBarMetrics(toShow.length, chartContainerW(), NPAD.left, NPAD.right, 10, 24, 0.5);
     var NB = metrics.barW;
     var NG = metrics.gap;
     var barSpacing = NB + NG;
@@ -1479,9 +1561,10 @@
     appendWatermark(svg, totalW);
     appendUpdatedBadge(svg, state.updatedDate);
 
-    // Build per-bar gradients
+    // Build per-bar gradients — Named bars color by rank/star level (founder decision),
+    // not branch/tier, so the chart isn't a wall of blue standard-branch bars.
     toShow.forEach(function(skill, i) {
-      buildBarGradientDef(svg, skill.contributor, skill.grade, skill.level, skill, 'named-' + i);
+      buildBarGradientDef(svg, skill.contributor, skill.grade, skill.level, skill, 'named-' + i, true);
     });
 
     // Y-axis gridlines


### PR DESCRIPTION
## The bug

Suite skill bars on the Trust leaderboard (`docs/trust/leaderboard/`) never rendered. The Suites chart came up empty and `fetchUltimateComponents` was effectively dead code.

**Root cause:** `GaiaSemantics.branchOf(entry)` (in `docs/js/skill-semantics.js`) reads `entry.branch` and falls back to `'standard'` when the field is absent — the client-side branch resolver was deleted by founder ruling (2026-07-18), so the emitted `branch` field is now the *only* source of truth.

But `boot()` in `leaderboard.js` projected each leaderboard row into a plain object (`allRows`) that **never carried a `branch` field**. So every `branchOf(r)` call on an `allRows`-derived object returned `'standard'`, which meant:

- `ultimates = allRows.filter(r => branchOf(r) === 'suite')` was **always empty**
- `fetchUltimateComponents(ultimates, skillMap)` iterated an empty array → the stacked component overlay never drew
- suite bars never appeared

## The field that was missing

`branch` — the taxonomy-resolved branch string (`'standard'` | `'suite'` | `'unique'`).

## Where it was sourced from

The paginated skills index (`docs/api/v1/skills/index.json` and pages), fetched into `skillMap` during `boot()`. Every skill entry there already carries `branch` (verified: all 50 index entries have it; 16 carry `branch: "suite"`). The fix reads `skill.branch` off the already-fetched `skillMap[row.id]` — no new fetch, no schema change.

## The fix

Two surgical additions, both `branch: <source>.branch || null`:

1. **`boot()` `allRows` projection** — carry `skill.branch` so `branchOf` reads a real value. This is the load-bearing fix that un-empties `ultimates` and the suite partition.
2. **`collapseGroups()` synthetic group object** — carry `g.primary.branch` so grouped Named-chart bars keep their correct branch color (gold for suite) instead of collapsing to standard/blue.

## Verified

Simulated the old vs new projection against the live skills index:

- OLD projection → `0` ultimates (suite bars never render)
- NEW projection → `16` ultimates (garrytan/gstack, ruvnet/ruflo, mattpocock/skills, obra/superpowers, addy-osmani/agent-skills, …)

`node --check` passes. Design tokens only — no hex literals added.

## Entrypoints

No new pages. Existing leaderboard suite-bar rendering restored.
