### PR TITLE
infra(guard-a): harden hex-color guard — NUL fix, binary detector, comment exclusion

### DIFF
--- a/.github/workflows/docs-cohesion.yml
+++ b/.github/workflows/docs-cohesion.yml
@@ -28,6 +28,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      # ── Guard A — Binary-source detector (runs BEFORE the hex scan) ──────
+      # A NUL byte in a .js/.css source makes GNU grep treat the file as binary
+      # and silently skip it, which is exactly how two banned hexes hid in
+      # docs/js/skill-graph.js undetected. Fail loudly if any source under docs/
+      # carries a NUL byte so a skipped-file gap can never recur silently.
+      - name: Guard A — Detect NUL bytes in JS/CSS sources
+        run: |
+          set +e
+          # -a forces grep to scan files it would otherwise treat as binary and
+          # SKIP — without it this detector would itself miss the NUL-carrying
+          # file, reproducing the very blind spot it exists to close.
+          OFFENDERS=$(grep -ralP '\x00' docs/js/ docs/css/ 2>/dev/null | grep -E '\.(js|css)$')
+          if [ -n "$OFFENDERS" ]; then
+            echo "::error::NUL byte found in JS/CSS source(s) under docs/. A NUL"
+            echo "::error::makes grep treat the file as binary and silently skip"
+            echo "::error::it (Guard A hex scan blind spot). Use a text escape"
+            echo "::error::like '\\u0000' instead of a literal NUL byte."
+            echo "Offending files:"
+            echo "$OFFENDERS"
+            exit 1
+          fi
+          echo "No NUL bytes in JS/CSS sources under docs/."
+
       # ── Guard A — Token-only colour enforcement ──────────────────────────
       - name: Guard A — Scan for hardcoded colors
         id: hardcoded-colors

--- a/.github/workflows/docs-cohesion.yml
+++ b/.github/workflows/docs-cohesion.yml
@@ -33,13 +33,16 @@ jobs:
         id: hardcoded-colors
         run: |
           set +e
-          HITS=$(grep -REn '#(38bdf8|c084fc|f59e0b|7c3aed|fbbf24|94a3b8|63cab7|a78bfa|e879f9)' \
-               docs/js/ docs/css/ \
-               --include='*.js' --include='*.css' \
-               --exclude-dir='archive' \
-               2>/dev/null | grep -v 'var(--[^,]*,' || true)
+          # scripts/check_hex_colors.py replaces the old inline grep. grep
+          # silently skips files containing a NUL byte (binary-file skip), so a
+          # source file with a literal '\0' was never scanned; the Python
+          # scanner reads every file as text and strips // and /* */ comments so
+          # a documented hex no longer trips the guard while a live-code literal
+          # still does. Exit 1 + file:line:hex on failure.
+          HITS=$(python scripts/check_hex_colors.py 2>&1)
+          EXIT=$?
 
-          if [ -n "$HITS" ]; then
+          if [ $EXIT -ne 0 ]; then
             echo "found=true" >> $GITHUB_OUTPUT
             echo "hits<<EOF" >> $GITHUB_OUTPUT
             echo "$HITS" >> $GITHUB_OUTPUT

--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -921,8 +921,8 @@
     // + a wandering hot-spot offset — no particles, a handful of sin/frame.
     function drawNodeIV(sx, sy, r, alpha, t, p) {
       const tok = getCanvasTokens();
-      const flame = tok.rank[4].rgb;                    // magenta flame (#e879f9)
-      const violet = tok.rank[3].rgb;                   // cooler violet (#a78bfa)
+      const flame = tok.rank[4].rgb;                    // rank-4 token (magenta)
+      const violet = tok.rank[3].rgb;                   // rank-3 token (violet)
       const core = _mixRgb(flame, '255,255,255', 0.6);  // white-hot centre
       const phase = p.phase || 0;
       // Combustion flicker: three detuned sines → irregular, fire-like. High
@@ -1710,7 +1710,7 @@
         // needs a faint direct-arc echo at rest — the route is the resting
         // silhouette. On neighbor-highlight it flares to full weight.
         const drapedRoute = structural && structuralRouteKeys
-          && structuralRouteKeys.has(edge.from + ' ' + edge.to);
+          && structuralRouteKeys.has(edge.from + '\u0000' + edge.to);
         const structuralArcScale = (drapedRoute && !isNeighborEdge) ? 0.35 : 1;
         const baseEdgeAlpha = (isNeighborEdge
           ? 0.78

--- a/docs/js/world-tree-layout.js
+++ b/docs/js/world-tree-layout.js
@@ -90,6 +90,7 @@
     return String(a).localeCompare(String(b));
   }
 
+  // KEY FORMAT: "<source>\u0000<target>" — NUL separator; must use text escape \u0000, never a literal NUL byte (causes grep binary-skip in Guard A).
   function edgeKey(source, target) {
     return source + '\u0000' + target;
   }

--- a/scripts/check_hex_colors.py
+++ b/scripts/check_hex_colors.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+scripts/check_hex_colors.py — Guard A hex-colour enforcement for docs-cohesion.yml
+
+Rejects hardcoded hex colour literals from the banned set in LIVE CODE, failing
+(exit 1) if any remain. This replaces the inline grep Guard A used to run, fixing
+two gaps that grep could not close:
+
+  1. NUL-byte binary skip — GNU grep silently skips any file containing a NUL
+     byte ('\\0'). docs/js/skill-graph.js carried a literal NUL as an edge-key
+     separator, so grep never scanned it and two banned hexes hid there in `//`
+     comments. Python reads every file as text regardless of control bytes, so
+     no source file is ever silently skipped. (A separate NUL detector step in
+     docs-cohesion.yml, and scripts/check_no_binary_sources.py, guard against a
+     NUL ever being reintroduced.)
+
+  2. No comment exclusion — grep could not tell a hex in a `//` comment
+     (documentation) from a hex in live code. This script strips `//` line
+     comments and `/* */` block comments before matching, so a documented hex in
+     a comment no longer trips the guard while a live-code literal still does.
+
+Allowed forms (not flagged):
+  - Hexes inside `//` or `/* */` comments (documentation).
+  - The self-documenting `var(--token, #hex)` fallback form — the token is
+    authoritative; the hex is an inline default. Any line that references a CSS
+    custom-property fallback (`var(--x, ...)`) is treated as token-anchored, the
+    same allowance the original inline grep encoded with `grep -v 'var(--[^,]*,'`.
+
+Scanned scope: docs/js/**/*.js and docs/css/**/*.css — the live design-system
+code Guard A has always enforced. Two categories are exempt:
+  - docs/css/tokens.css — the GENERATED token-definition source (built by
+    scripts/generateCssTokens.py from registry/gaia.json). It is *supposed* to
+    contain every raw hex; it is the single place they are allowed to live.
+  - docs/**/archive/** — historical snapshots (matched the original
+    --exclude-dir='archive').
+
+NOTE on HTML: inline `<style>` blocks and SVG fills across docs/**/*.html carry a
+large body of pre-existing hex literals that predate this guard and were never in
+its scope. Bringing them under enforcement is a separate content-migration effort,
+not part of hardening the guard mechanism, so HTML is intentionally out of scope
+here — matching the JS/CSS-only surface Guard A actually gated.
+
+Run locally: python scripts/check_hex_colors.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS = REPO_ROOT / "docs"
+
+# Banned hex set — the exact literals the original Guard A inline grep rejected.
+BANNED_HEXES = [
+    "38bdf8", "c084fc", "f59e0b", "7c3aed", "fbbf24",
+    "94a3b8", "63cab7", "a78bfa", "e879f9",
+]
+BANNED_RE = re.compile(r"#(?:" + "|".join(BANNED_HEXES) + r")\b", re.IGNORECASE)
+
+# Path parts that exclude a file from scanning.
+EXCLUDED_DIR_PARTS = {"archive"}
+
+# Generated token-definition source — the one file allowed to hold raw hexes.
+EXEMPT_FILES = {(DOCS / "css" / "tokens.css").resolve()}
+
+# A line that anchors a hex to a CSS custom property via the var() fallback form
+# is token-derived and allowed (original grep: `grep -v 'var(--[^,]*,'`).
+VAR_FALLBACK_LINE_RE = re.compile(r"var\(\s*--[^,]*,")
+
+
+def strip_comments(text: str) -> str:
+    """Blank out // line comments and /* */ block comments, preserving newlines
+    so reported line numbers stay accurate. A pragmatic stripper (not a full
+    JS/CSS parser): it treats // and /* */ as comments wherever they appear. The
+    goal is to stop flagging a documented hex; any banned hex that survives
+    stripping is a genuine live-code literal."""
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        two = text[i:i + 2]
+        if two == "//":
+            j = text.find("\n", i)
+            if j == -1:
+                out.append(" " * (n - i))
+                i = n
+            else:
+                out.append(" " * (j - i))
+                i = j
+        elif two == "/*":
+            j = text.find("*/", i + 2)
+            end = (j + 2) if j != -1 else n
+            for ch in text[i:end]:
+                out.append("\n" if ch == "\n" else " ")
+            i = end
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def scan_file(path: Path):
+    """Return [(lineno, matched_hex), ...] for banned hexes in live code."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    text = strip_comments(text)
+    hits = []
+    for lineno, line in enumerate(text.split("\n"), start=1):
+        if VAR_FALLBACK_LINE_RE.search(line):
+            continue  # token-anchored via var() fallback — allowed
+        for m in BANNED_RE.finditer(line):
+            hits.append((lineno, m.group(0)))
+    return hits
+
+
+def iter_target_files():
+    for pattern in ("js/**/*.js", "css/**/*.css"):
+        for path in DOCS.glob(pattern):
+            if not path.is_file():
+                continue
+            if EXCLUDED_DIR_PARTS & set(path.parts):
+                continue
+            if path.resolve() in EXEMPT_FILES:
+                continue
+            yield path
+
+
+def main() -> int:
+    failures = []
+    for path in sorted(set(iter_target_files())):
+        for lineno, hexval in scan_file(path):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            failures.append(f"{rel}:{lineno}: {hexval}")
+
+    if failures:
+        print("Guard A FAIL: hardcoded hex colour literals found in live code.")
+        print("Use design tokens from docs/css/tokens.css instead "
+              "(or the var(--token, #hex) fallback form).")
+        print()
+        for line in failures:
+            print(f"  {line}")
+        return 1
+
+    print("Guard A OK: no banned hex literals in live JS/CSS code.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_no_binary_sources.py
+++ b/scripts/check_no_binary_sources.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+scripts/check_no_binary_sources.py — standalone NUL-byte validator for docs/ sources.
+
+A literal NUL byte ('\\0') in a text source is a footgun: GNU grep treats any file
+containing one as binary and SILENTLY SKIPS it, so grep-based CI guards (notably
+Guard A's hex-colour scan in .github/workflows/docs-cohesion.yml) never see the
+file's contents. That is exactly how two banned hex literals hid undetected in a
+`//` comment inside docs/js/skill-graph.js — the file carried a literal NUL as an
+edge-key separator, so Guard A's grep skipped it entirely.
+
+This script scans every .js, .css, and .html file under docs/ for a NUL byte and
+fails (exit 1) listing the offenders, so a maintainer or agent can catch the
+problem locally before pushing. Use a text escape (e.g. '\\u0000' in JS) instead
+of embedding a literal NUL in source.
+
+Usage:
+    python scripts/check_no_binary_sources.py
+
+Exit 0 if clean; exit 1 with the list of offending files if any contain a NUL.
+
+Related: docs-cohesion.yml has a CI step ("Guard A — Detect NUL bytes in JS/CSS
+sources") that enforces the same invariant for .js/.css in the pipeline; this
+standalone script additionally covers .html and is runnable outside CI.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS = REPO_ROOT / "docs"
+
+SCANNED_SUFFIXES = {".js", ".css", ".html"}
+
+
+def find_offenders():
+    offenders = []
+    for path in sorted(DOCS.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in SCANNED_SUFFIXES:
+            continue
+        if b"\x00" in path.read_bytes():
+            offenders.append(path.relative_to(REPO_ROOT).as_posix())
+    return offenders
+
+
+def main() -> int:
+    offenders = find_offenders()
+    if offenders:
+        print("FAIL: NUL byte found in docs/ source file(s).")
+        print("A NUL makes grep treat the file as binary and silently skip it, "
+              "blinding grep-based CI guards (e.g. Guard A hex scan).")
+        print("Use a text escape like '\\u0000' instead of a literal NUL byte.")
+        print()
+        for rel in offenders:
+            print(f"  {rel}")
+        return 1
+
+    print("OK: no NUL bytes in docs/ .js/.css/.html sources.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What was broken

Guard A (the CI check that rejects hardcoded hex colour literals in `docs/js/` and `docs/css/`) had two silent gaps:

1. **Silent binary-file skip.** `docs/js/skill-graph.js` carried a literal NUL byte (`'\0'`) used as an edge-key separator. GNU grep treats any file containing a NUL as *binary* and silently skips it, so Guard A never scanned this file at all. Two banned hex literals sat undetected in `//` comments inside it.

2. **No comment exclusion.** Guard A's inline grep could not tell a hex in a `//` comment (documentation) from a hex in live code. Once the NUL was fixed, those comment-form hexes would have tripped the guard for no reason.

3. **No binary-file detector.** Nothing in CI warned that a source file had been silently skipped, so the blind spot could recur unnoticed.

## What each commit does

- **1 — `fix(skill-graph)`**: replaces the literal NUL edge-key separator on `docs/js/skill-graph.js:1713` with the text escape `` (matching `world-tree-layout.js`, which already stores the escape rather than a literal NUL), and strips the hex values from two inline comments (lines 924–925). The file is now plain text — grep no longer skips it.
- **2 — `docs(world-tree-layout)`**: documents the `edgeKey()` NUL-separator convention with a one-line comment warning that the separator must use the `` text escape, never a literal NUL byte (which causes the grep binary-skip Guard A relies on).
- **3 — `infra(guard-a)`**: replaces Guard A's inline grep with `scripts/check_hex_colors.py`. The Python scanner reads every file as text (no binary-skip), strips `//` and `/* */` comments before matching, keeps the allowed `var(--token, #hex)` fallback form, and prints `file:line:hex` on failure. Scope is the live design-system JS/CSS Guard A has always enforced; the generated token-definition file `docs/css/tokens.css` is exempt (it is the one place raw hexes are supposed to live).
- **4 — `infra(guard-a)`**: adds a binary-file NUL detector step that runs *before* the hex scan. It uses `grep -ralP '\x00'` (the `-a` flag forces grep to scan files it would otherwise skip) and fails CI with a clear message listing any `.js`/`.css` under `docs/` that carries a NUL byte.
- **5 — `infra(guard-a)`**: adds `scripts/check_no_binary_sources.py`, a standalone validator (runnable locally: `python scripts/check_no_binary_sources.py`) that checks all `.js`/`.css`/`.html` under `docs/` for NUL bytes and exits non-zero listing offenders.

## Verification

- `python scripts/check_hex_colors.py` exits 0 on the current codebase (comment-form hexes ignored, live-code literals flagged — unit-tested).
- `python scripts/check_no_binary_sources.py` exits 0 (no NUL bytes remain).
- The NUL detector one-liner returns empty on the clean tree and matches a planted NUL file.
- `node --check` passes on both edited JS files; workflow YAML parses.

## Entrypoints

No new user-facing pages. Guard A workflow change only.

## Note on branch scope

This branch is `infra/` but touches `docs/js/*.js` (the NUL fix and the `edgeKey` doc comment — deliverables 1 and 2). The `branch-scope.yml` `infra` allowlist matches `docs/*.html` but not `docs/js/*.js`, so the `skip-scope-check` label is applied for this PR (the JS edits are the core of the sprint and cannot be relocated).
