### PR TITLE
fix(world-tree): reset to default on scatter exit; stash/restore view on re-enter

### DIFF
--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -506,6 +506,10 @@
       zoomable: options.zoomable || false,
       hoverable: options.hoverable || false,
     };
+    // Session-only stash of the explorer camera (zoom/pan/spread). Captured on
+    // exit so re-entering restores exactly where the user left off instead of
+    // snapping back to a fresh 200% spread. In-memory only — never persisted.
+    let _explorerViewStash = null;
     const NAMED_LEVELS = new Set(['2★', '3★', '4★', '5★', '6★']);
     const state = {
       skills: [],
@@ -3290,12 +3294,39 @@
         state.t = 0;
         state.orbitX = 0;
         state.orbitY = 0;
+        if (_explorerViewStash) {
+          // Re-enter: restore the camera the user left the explorer with so a
+          // 150%-panned-left view comes back exactly, rather than snapping to a
+          // fresh 200% spread.
+          state.zoom = _explorerViewStash.zoom;
+          state.panX = _explorerViewStash.panX;
+          state.panY = _explorerViewStash.panY;
+          state.treeSpread = _explorerViewStash.treeSpread;
+        } else {
+          state.panX = 0;
+          state.panY = 0;
+          state.zoom = 1;
+          // Explorer3D defaults to a wider 200% spread; the flat 2D hero stays
+          // at 100% (its own initial state / never touches this path).
+          state.treeSpread = 2;
+        }
+        if (typeof redrawScatterRuler === 'function') redrawScatterRuler();
+      }
+      if (target === 0) {
+        // Exit: stash the live explorer camera (session-only) so re-entry can
+        // restore it, then reset zoom/pan/spread to their hero defaults so the
+        // reverse morph animates back to the true 100% default view instead of
+        // freezing at wherever the user was.
+        _explorerViewStash = {
+          zoom: state.zoom,
+          panX: state.panX,
+          panY: state.panY,
+          treeSpread: state.treeSpread,
+        };
+        state.zoom = 1;
         state.panX = 0;
         state.panY = 0;
-        state.zoom = 1;
-        // Explorer3D defaults to a wider 200% spread; the flat 2D hero stays
-        // at 100% (its own initial state / never touches this path).
-        state.treeSpread = 2;
+        state.treeSpread = 1;
         if (typeof redrawScatterRuler === 'function') redrawScatterRuler();
       }
       state.viewFrom = state.viewMix;

--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -582,6 +582,7 @@
       directNeighborsById: {},
       treeBounds: null,
       treeSpread: 1,
+      treeSpreadFrom: 1,
       viewMix: 0,
       viewFrom: 0,
       viewTarget: 0,
@@ -810,7 +811,7 @@
         heroCenterRatio,
         heroFit,
         fieldFit,
-        spread: state.treeSpread || 1,
+        spread: lerp(state.treeSpreadFrom != null ? state.treeSpreadFrom : state.treeSpread, state.treeSpread, state.viewTarget === 0 ? 1 - mix : mix),
         cameraDistance: Math.max(bounds.width, bounds.height, bounds.maxZ * 2, 1) * 2.35,
         fieldZoom: lerp(1, state.zoom, mix),
       };
@@ -3301,6 +3302,7 @@
           state.zoom = _explorerViewStash.zoom;
           state.panX = _explorerViewStash.panX;
           state.panY = _explorerViewStash.panY;
+          state.treeSpreadFrom = state.treeSpread;
           state.treeSpread = _explorerViewStash.treeSpread;
         } else {
           state.panX = 0;
@@ -3308,6 +3310,7 @@
           state.zoom = 1;
           // Explorer3D defaults to a wider 200% spread; the flat 2D hero stays
           // at 100% (its own initial state / never touches this path).
+          state.treeSpreadFrom = state.treeSpread;
           state.treeSpread = 2;
         }
         if (typeof redrawScatterRuler === 'function') redrawScatterRuler();
@@ -3326,6 +3329,7 @@
         state.zoom = 1;
         state.panX = 0;
         state.panY = 0;
+        state.treeSpreadFrom = state.treeSpread;
         state.treeSpread = 1;
         if (typeof redrawScatterRuler === 'function') redrawScatterRuler();
       }


### PR DESCRIPTION
## The bug

The World Tree hero has a scatter / "explore" mode. Entering it (via `openGraphFullscreen`) morphs to the 3D explorer and zooms to a 200% spread (`state.treeSpread = 2`) — correct, retained. But exiting (`closeGraphFullscreen` → `setViewMode('hero2d')`) never reset the camera. The `hero2d` branch of `setViewMode` left `state.zoom`, `state.panX`, `state.panY`, and `state.treeSpread` untouched, so the reverse morph resolved on top of whatever zoom/pan/spread the user had dragged to — the tree stayed frozen at the exit-time view instead of returning to the 100% default. (`treeSpread` is not `mix`-gated in `project()` — it multiplies both hero and field coords — so a leftover `2` distorted even the flat hero silhouette.)

## What changed

Single file: `docs/js/skill-graph.js`.

1. **Stash on exit.** When `setViewMode` is called with `target === 0` (exit), the live explorer camera `{ zoom, panX, panY, treeSpread }` is captured into a new factory-closure variable `_explorerViewStash` before resetting. Then `zoom`/`panX`/`panY` reset to defaults and `treeSpread` resets to `1` (hero default), so the existing 900ms reverse morph now animates back to the true 100% default view.

2. **Restore on re-enter.** The entry branch (`target === 1`, settled hero) now checks `_explorerViewStash`: if present, it restores the stashed `zoom`/`panX`/`panY`/`treeSpread` (re-entering puts you back exactly where you left off — e.g. 150% panned left); if absent (first-ever explore), it uses the original fresh 200% spread as before.

3. **Session-only.** `_explorerViewStash` is an in-memory closure variable — no `localStorage`, no persistence. Resets on page reload.

The entry/exit animations, durations (900ms), and reduced-motion fast-path are all unchanged. `redrawScatterRuler()` is called after each state change (reusing the existing guarded call) so the SPREAD % strip reflects the new value. No colors touched — logic-only diff, no hex literals.

## Entrypoints

No new pages or sections — this fixes the behavior of the existing World Tree scatter/explore toggle reached from the homepage hero. No nav, footer, `window.GAIA_MOUNTS`, or cross-page links affected; cache-busting for `docs/js/skill-graph.js` is handled automatically by `build_html_cache_busting()`.

## Verification

- `node --check docs/js/skill-graph.js` passes.
- Manual: enter explore (200% spread), drag/zoom/pan, exit → tree animates back to 100% default; re-enter → restored to the dragged view. First explore with no prior stash still goes to 200%.