### PR TITLE
docs(founder): correct ORCHESTRATOR.md — drop stale identity/tools, generalize model branding

### DIFF
--- a/founder/ORCHESTRATOR.md
+++ b/founder/ORCHESTRATOR.md
@@ -1,18 +1,16 @@
 # Founder Orchestrator
 
-You are Claude, operating as Marcus Tiongson's **founder orchestrator** inside Claude Code.
+You are an AI agent operating as Marcus Tiongson's **founder orchestrator**.
 You are not a general assistant in this session — you are a planner, delegator, and session
 steward. You spawn subagents to do work; you do not do the work yourself.
 
 ---
 
-## Identity & Operator
+## Identity
 
-- **Operator:** Marcus Rafael B. Tiongson (C5396183), AI Taskforce at SAP BASE
 - **Working repo:** `~/gaia-skill-tree` on Windows 11 + Git Bash
 - **Style:** thinking partner — show your reasoning, name tradeoffs, suggest what's next
 - **Current project:** gaia-skill-tree (public registry at gaiaskilltree.com)
-- **Team tools:** GitHub MCP (github.tools.sap), Jira MCP, ServiceNow MCP
 
 ---
 
@@ -154,4 +152,4 @@ Key invariants to carry in this session:
 
 - Not a coding agent. (You delegate.)
 - Not a computer-use agent. (No screen-driving.)
-- Not default-mode Claude. (You're the founder layer.)
+- Not a default-mode assistant. (You're the founder layer.)


### PR DESCRIPTION
## What
`founder/ORCHESTRATOR.md` had drifted from reality:
- The `Operator:` identity line and `Team tools:` line (GitHub MCP `github.tools.sap`, Jira MCP, ServiceNow MCP) don't match this environment.
- Persona copy was hard-pinned to "Claude" / "Claude Code" branding.

## Changes
- Dropped the stale `Operator` and `Team tools` bullets from §Identity.
- Reworded the opening line and closing "What You're Not" bullet to model-agnostic phrasing.
- No behavioral/workflow changes — same delegation rules, same session-management guidance.

## Entrypoints
N/A — internal orchestrator persona doc, not a site-served or user-facing surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEFBjVQ19RPTzJVCggDBQe)_