### PR TITLE
fix(docs): guard Class S graph sync against absent layouts_3d.json + fix okf check-mode gap

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -323,17 +323,79 @@ def build_okf_bundle(check: bool) -> bool:
         res = subprocess.run([sys.executable, str(script_path)], capture_output=True, text=True)
         return res.returncode == 0
 
-    # In --check mode, do NOT compare build_okf_bundle.py's output against the
-    # committed docs/okf/index.json. Two scripts write that same path in main():
-    # build_okf_bundle (registry/gaia.json) runs first, then build_skills_index
-    # (buildSkillsIndex.py, reads docs/okf/skills/*.md) runs last and wins in
-    # write mode — so the committed index.json is buildSkillsIndex's output.
-    # build_okf_bundle.py only classifies `basic` skills (extra/ultimate come out
-    # empty), so its output can never match the committed file, making this check
-    # a permanent false positive (`diff okf_dir diff_files: ['index.json']`).
-    # build_skills_index (the authoritative writer) has its own --check step, so
-    # genuine docs/okf/index.json drift is still caught there.
-    return False
+    # In --check mode, regenerate into a tempdir and diff only the `.md`
+    # outputs (root index.md, per-type skills/{type}/index.md, per-skill
+    # skills/{type}/{id}.md) against the committed docs/okf/.
+    #
+    # index.json is deliberately EXCLUDED from the comparison. Two scripts
+    # write that same path in main(): build_okf_bundle (registry/gaia.json)
+    # runs first, then build_skills_index (buildSkillsIndex.py, reads
+    # docs/okf/skills/*.md) runs last and wins in write mode — so the committed
+    # index.json is buildSkillsIndex's output. build_okf_bundle.py only
+    # classifies `basic` skills (extra/ultimate come out empty), so its output
+    # can never match the committed file, making that comparison a permanent
+    # false positive (`diff okf_dir diff_files: ['index.json']`).
+    # build_skills_index (the authoritative writer) has its own --check step,
+    # so genuine docs/okf/index.json drift is still caught there.
+    #
+    # Previously this branch returned False unconditionally, which silenced the
+    # index.json false positive at the cost of every other OKF output: real
+    # drift in any generated `.md` went undetected.
+    committed = ROOT / "docs" / "okf"
+    if not committed.is_dir():
+        print("diff docs/okf/ (missing)")
+        return True
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = Path(tmp) / "okf"
+        res = subprocess.run(
+            [sys.executable, str(script_path), str(out_dir)],
+            capture_output=True, text=True,
+        )
+        if res.returncode != 0:
+            print(f"diff docs/okf/ (regen failed: rc={res.returncode})")
+            print((res.stdout or "") + (res.stderr or ""))
+            return True
+        if not out_dir.is_dir():
+            # The script exits 0 even when registry/gaia.json (Class P) is
+            # missing, writing nothing at all. Report that rather than
+            # mistaking an empty tempdir for "every committed file drifted".
+            print("diff docs/okf/ (regen produced no output -- missing registry/gaia.json?)")
+            return True
+        drifts = _diff_md_generated(committed, out_dir)
+        for d in drifts:
+            print(f"diff docs/okf/{d}")
+        return bool(drifts)
+
+
+def _diff_md_generated(committed: Path, generated: Path) -> list[str]:
+    """Return relative `.md` paths where `committed` disagrees with a fresh build.
+
+    Scoped counterpart to `_diff_tree` for bundles where only the Markdown
+    outputs are authoritative (see `build_okf_bundle`). Direction is deliberate:
+    only files the generator currently EMITS are compared. A path is reported
+    when the generated file is missing from the committed tree or its contents
+    differ; comparison goes through `_equal_ignoring_dates` so volatile
+    timestamps do not register as drift, matching the rest of this file.
+
+    Committed-only files are ignored on purpose. `build_okf_bundle.py` writes in
+    place and never deletes, so write mode cannot resolve that class of drift —
+    reporting it would leave `--check` permanently red with no fix command to
+    offer, which is the trap the previous unconditional `return False` fell
+    into. Concretely, `docs/okf/skills/extra/` and `docs/okf/skills/ultimate/`
+    are orphans of the Yggdrasil II taxonomy rename (those types folded into
+    `fusion`); they are unreferenced by the regenerated index.md and want a
+    deliberate cleanup commit, not a standing CI warning.
+    """
+    drifts: list[str] = []
+    for gen_path in sorted(generated.rglob("*.md"), key=str):
+        rel = gen_path.relative_to(generated)
+        committed_path = committed / rel
+        if not committed_path.is_file():
+            drifts.append(str(rel))
+            continue
+        if not _equal_ignoring_dates(committed_path, gen_path):
+            drifts.append(str(rel))
+    return drifts
 
 
 def build_skills_index(check: bool) -> bool:

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1414,6 +1414,14 @@ def build_docs_graph_assets(check: bool) -> bool:
         return False
     rc, output = _run_script(script, [])
     if rc != 0:
+        # The sync now aborts loudly rather than writing a degraded Class S
+        # gaia.json when its layout inputs are missing (issue #1275). Surface
+        # that as a drift line in --check so the gate fails on the guard
+        # instead of swallowing it into a _run_step warning.
+        if check:
+            print(f"diff docs/graph/ (sync aborted: rc={rc})")
+            print(output)
+            return True
         raise RuntimeError(f"syncDocsGraphAssets.py failed: rc={rc}")
     return False
 

--- a/scripts/syncDocsGraphAssets.py
+++ b/scripts/syncDocsGraphAssets.py
@@ -85,6 +85,36 @@ def sync_docs_graph_assets(root: Path = ROOT) -> None:
         if committed_src.exists():
             layout_nodes = json.loads(committed_src.read_text(encoding="utf-8")).get("nodes", {})
 
+    # Sanity guard (#1275) — same shape as build_badges()'s catastrophic-drop
+    # abort. registry/layouts_3d.json is Class P and gitignored, so a fresh
+    # clone or a CI runner can be missing BOTH layout inputs. Writing
+    # docs/graph/gaia.json without them silently strips positions/cluster from
+    # every skill (plus meta.centroids/clusterNames) — and docs/graph is Class
+    # S, the bytes GitHub Pages serves, so committing that degraded copy
+    # flattens the live 3D graph and World Tree. Refuse to overwrite a
+    # populated artifact with a positionless one. A committed copy that is
+    # already positionless is legitimate and passes through untouched.
+    if not layout_nodes:
+        committed_graph = docs_graph / "gaia.json"
+        positioned = 0
+        if committed_graph.exists():
+            try:
+                committed_data = json.loads(committed_graph.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                committed_data = {}
+            positioned = sum(
+                1 for s in committed_data.get("skills", [])
+                if s.get("positions") or s.get("cluster")
+            )
+        if positioned:
+            raise RuntimeError(
+                "Refusing to write docs/graph/gaia.json without "
+                "registry/layouts_3d.json or generated-output/layouts.json — "
+                f"the committed copy has {positioned} skills with "
+                "positions/cluster; the regenerated copy would have 0. Run "
+                "scripts/exportGexf.py's layout step or `gaia pull` first."
+            )
+
     # Load ultimate gate config for trust grade injection
     _gate_config: dict = {}
     _meta_path = root / "registry" / "schema" / "meta.json"

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -62,6 +62,15 @@ def test_badge_registry_generated_at_mirrors_source(tmp_path, monkeypatch):
 
 
 def test_build_docs_check_message_uses_copyable_python_command(monkeypatch, capsys):
+    # This test inspects stdout only — it has no reason to regenerate real
+    # artifacts. Left unstubbed, `main(["--check"])` runs the whole pipeline
+    # against the live tree and rewrites tracked Class S files (docs/graph/
+    # gaia.json shrank 733533 -> 603305 bytes whenever this test ran, because
+    # the gitignored layout input is absent). Stub every build step, then
+    # re-stub the two the assertions depend on. See issue #1275.
+    for name in dir(build_docs):
+        if name.startswith("build_") and callable(getattr(build_docs, name)):
+            monkeypatch.setattr(build_docs, name, lambda check=False: False)
     monkeypatch.setattr(build_docs, "build_readme", lambda check: True)
     monkeypatch.setattr(build_docs, "build_docs_index", lambda check: False)
 


### PR DESCRIPTION
Fixes #1275

Two pre-existing pipeline bugs on `dev/yggdrasil-ii-staging`, plus a regression re-check of #1274.

## Fix 1 — silent Class S corruption when `registry/layouts_3d.json` is absent

`sync_docs_graph_assets()` loads layout data from `generated-output/layouts.json`, falling back to the committed `registry/layouts_3d.json`. Both are Class P and gitignored, so a fresh clone or CI runner can have neither. `layout_nodes` then stayed `{}` and the function wrote `docs/graph/gaia.json` — the bytes GitHub Pages serves — with no `positions`/`cluster` on any skill and null `meta.centroids`/`meta.clusterNames`. Committing that flattens the live 3D graph and World Tree.

Added a sanity guard in the same shape as `build_badges()`'s catastrophic-drop abort (`scripts/build_docs.py`): if both layout inputs are absent **and** the committed `docs/graph/gaia.json` still carries positions/cluster, raise instead of overwriting. Since this axis is binary rather than proportional, the threshold is simply "committed had positions, regenerated would have none" — no percentage needed. A committed copy that is already positionless is legitimate and passes through untouched.

`build_docs_graph_assets()` now surfaces a non-zero sync as `diff docs/graph/ (sync aborted: rc=N)` in `--check` mode, so the gate fails on the guard instead of swallowing it into a `_run_step` warning.

**Test isolation.** `test_build_docs_check_message_uses_copyable_python_command` asserts on stdout only, but ran the real pipeline against the live tree and rewrote tracked Class S files on every run (`docs/graph/gaia.json` 733533 → 603305 bytes). All build steps are now stubbed via `monkeypatch`, matching the isolation style already used in this file.

## Fix 2 — `build_okf_bundle()` check-mode was a dead check

Check mode returned `False` unconditionally. That silenced one known false positive (`docs/okf/index.json`, whose authoritative writer is `buildSkillsIndex.py`) at the cost of **all** drift detection on the bundle's Markdown outputs.

Check mode now regenerates into a tempdir (`build_okf_bundle.py` takes the output dir as `argv[1]`) and diffs the `.md` outputs against committed `docs/okf/`, printing `diff docs/okf/{relpath}` per mismatch. `index.json` stays excluded with the original rationale kept inline. Write mode is untouched; drift remains warn-only in `main()`.

The new `_diff_md_generated()` helper compares generated → committed only. Committed-only files are ignored deliberately: `build_okf_bundle.py` writes in place and never deletes, so write mode cannot resolve that class of drift, and reporting it would leave `--check` permanently red with no fix command to offer — the trap the original `return False` fell into.

### Pre-existing finding surfaced by this fix

`docs/okf/skills/extra/` and `docs/okf/skills/ultimate/` (≈135 files) are orphans of the Yggdrasil II taxonomy rename — the registry now types skills only `basic` and `fusion`, so the generator no longer emits either directory. They are unreferenced by the regenerated `index.md`. Left in place here: deleting 135 tracked doc files is a deliberate cleanup commit, not a side effect of a check-mode fix. Flagging for a decision.

## Fix 3 — regression re-check of #1274 (no code change)

`gaia init` and `gaia push` were run from this branch's source (`PYTHONPATH=src`) against a scratch git repo, never touching this repo's registry state:

- `gaia init` — clean (the `gaia fetch` HTTP 403 is the sandbox proxy blocking GitHub, handled gracefully).
- `gaia init --force` in a repo with a remote — clean, correctly flips `workspaceMode` to false.
- `gaia scan` — clean.
- `gaia push` — clean; reaches its "No skills to be pushed" guard and exits without a traceback.

The scratch fixture produced no skill detections (no network for `gaia pull`, no real skill corpus), so `push` was not driven through the tree-render path where the KeyError originally lived. Probed that path directly instead: `TIER_COLORS` now contains only `basic` and `fusion`, and every lookup — including `'ultimate'`, the exact key from #1274 — resolves through `.get()` with a fallback. `tier_hex()` and `format_type_colored()` return correctly for `basic`/`extra`/`ultimate`/`fusion`/`unique` and an unknown type. No KeyError; the fix holds.

## Verification

- Guard fires: against a synthetic tree whose committed copy has 243 positioned skills and no layout inputs, it raises and leaves the destination file byte-identical. With a positionless committed copy it writes normally without raising.
- Test isolation: `git status --porcelain` clean before and after; test runs in 0.1s; `docs/graph/gaia.json` stays 733533 bytes.
- OKF check: clean on the unmodified staging tree (no false positives); appending a line to `docs/okf/skills/basic/api-call.md` reports exactly that one path, and nothing else.
- `tests/test_docs_site.py` (3 passed) and `tests/test_seo.py` (12 passed).

## Entrypoints

N/A — no new user-facing page or section. Waived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEFBjVQ19RPTzJVCggDBQe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEFBjVQ19RPTzJVCggDBQe)_