### PR TITLE
fix(ci): generate Class P registry artifacts before tests in python-package.yml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,6 +50,20 @@ jobs:
       - name: Install development dependencies
         run: python -m pip install -e ".[dev]"
 
+      # Class P artifacts (registry/gaia.json, registry/named-skills.json) are
+      # gitignored — they never exist in a fresh CI checkout. The integration /
+      # slow tier reads them from the real repo (not tmp_path), so without this
+      # step `gaia dev test all` fails with ~29 errors: FileNotFoundError on
+      # registry/gaia.json and "AssertionError: Registry graph not found."
+      # (test_path_command, test_push, test_intake, test_validate, test_timelines,
+      # test_redaction, test_tui_tokens, test_verify_evidence, test_packaging).
+      # `validate.yml` already carries the identical step for the same reason;
+      # this keeps the two workflows consistent. See CLAUDE.md § Class P vs Class S.
+      - name: Build intermediate registry artifacts (Class P)
+        run: |
+          python scripts/assemble_gaia.py
+          python scripts/generateNamedIndex.py
+
       - name: Fast tests (unit gate)
         # -n auto parallelizes the fast tier across cores. Safe here: unmarked
         # tests are pure-Python against tmp_path / in-memory objects (issue #684


### PR DESCRIPTION
## Problem

`registry/gaia.json` and `registry/named-skills.json` are **Class P** — gitignored, so they never exist in a fresh CI checkout. The integration/slow test tier reads them from the *real repo* (not `tmp_path`), so `gaia dev test all` fails on any PR whose fast tier gets far enough to reach it.

`validate.yml` already carries a "Build intermediate registry artifacts" step for exactly this reason. `python-package.yml` was missing it.

## Evidence

Reproduced on `dev/yggdrasil-ii-staging` @ `d8e53f83` by deleting the Class P artifacts to simulate a fresh CI checkout:

| State | Result |
|---|---|
| Class P **absent** (= CI today) | **34 failed**, 1737 passed |
| Class P **present** (after fix) | **1781 passed**, 6 skipped, **0 failed** |

Failure signature: 11x `FileNotFoundError` on `registry/gaia.json` + 5x `AssertionError: Registry graph not found.`, across `test_path_command`, `test_push`, `test_intake`, `test_validate`, `test_timelines`, `test_redaction`, `test_tui_tokens`, `test_verify_evidence`, `test_packaging`.

(The remaining 5 of the 34 were `ModuleNotFoundError: textual` — a local-env-only gap; `textual` is in the `[dev]` extra that CI installs.)

## Fix

One step added before the test steps, mirroring `validate.yml` verbatim:

```yaml
- name: Build intermediate registry artifacts (Class P)
  run: |
    python scripts/assemble_gaia.py
    python scripts/generateNamedIndex.py
```

## Scope

- Single file: `.github/workflows/python-package.yml` (+14 lines, 0 deletions). `infra/` branch scope.
- No test, source, registry, or docs file touched.
- No sdist/wheel side effect — there is no `MANIFEST.in`, and `package-data` references `src/gaia_cli/data/registry/*`, which these generators do not write.

## Entrypoints

N/A — CI workflow change only, no user-facing page or section.

## Not fixed here (documented, out of scope)

This does **not** make PR #1185 green on its own. Two other things are wrong with it:

1. **#1185 is `mergeable_state: dirty`** — 19 conflicting `docs/` files vs `main`. Because GitHub can't compute the merge ref, `pull_request`-triggered workflows (`validate.yml`, `python-package.yml`) **have not run at all since 2026-07-20**. Resolving needs a merge of `main` into the staging branch; the HTML conflicts are real content divergence (`main` dropped `js/skill-semantics.js` and added `js/plaque-reveal.js`; staging still carries `skill-semantics.js`, `world-tree-layout.js`, `ascension-overdrive-v4.css`), not just `?v=` cache-bust drift. That's a founder call on the EPIC branch, not an infra PR.
2. **Class S drift** — `gaia dev docs --check` fails on 48 `docs/u/*/index.html` pages + the README CLI block. Needs `gaia dev docs` + commit, on the same files as the conflicts above, so it should be done as part of that merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEFBjVQ19RPTzJVCggDBQe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEFBjVQ19RPTzJVCggDBQe)_