### PR TITLE
design(ygg2): migrate --tier-unique* → --rank-*-unique (leaderboard.js)

### DIFF
--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -118,9 +118,9 @@
     rank6: tok('--rank-6-rgb') || '251, 191, 36',
     honorRed: tok('--honor-red-rgb') || '239, 68, 68',
     basic: tok('--tier-basic-rgb') || '56, 189, 248',
-    unique4: tok('--tier-unique-rgb') || '124, 58, 237',
-    unique5: tok('--tier-unique-5-rgb') || '178, 106, 58',
-    unique6: tok('--tier-unique-6-rgb') || '224, 137, 74',
+    unique4: tok('--rank-4-unique-rgb') || '124, 58, 237',
+    unique5: tok('--rank-5-unique-rgb') || '178, 106, 58',
+    unique6: tok('--rank-6-unique-rgb') || '224, 137, 74',
     muted: tok('--muted') || 'rgb(100, 116, 139)',
     text: tok('--text') || 'rgb(226, 232, 240)',
     border: tok('--border') || 'rgb(30, 41, 59)'
@@ -195,8 +195,8 @@
   };
 
   // Level-sensitive color stops for the unique branch.
-  // 4★ = --tier-unique-rgb (violet), 5★ = --tier-unique-5-rgb (burnished copper),
-  // 6★ = --tier-unique-6-rgb (ember copper). Deliberately off the suite gold axis.
+  // 4★ = --rank-4-unique-rgb (violet), 5★ = --rank-5-unique-rgb (burnished copper),
+  // 6★ = --rank-6-unique-rgb (ember copper). Deliberately off the suite gold axis.
   function uniqueColors(level) {
     var n = parseInt(level) || 0;
     var rawMap = {


### PR DESCRIPTION
## What

Migrate retired `--tier-unique*` CSS tokens onto the rank axis in the trust leaderboard renderer.

**File touched:**
- `docs/trust/leaderboard/leaderboard.js` — 5 hits (3 color-stop lookups in the `TOKENS` map + 2 comment lines documenting the `uniqueColors(level)` stops)

## One-axis rank-schema rationale

Suite and Unique are two ladders on ONE rank axis. There is no "tier unique" — a skill is only Unique at 4★+, so every Unique-flavored token ties to the rank it represents. The generator PR (#1283) retired `--tier-unique*` from the token source; this migrates the consumer.

Applied the one rule keyed to the rank each hit represents:

| Old token | New token | Rank |
|---|---|---|
| `--tier-unique-rgb` | `--rank-4-unique-rgb` | 4★ (Unique branch entry, violet) |
| `--tier-unique-5-rgb` | `--rank-5-unique-rgb` | 5★ (burnished copper) |
| `--tier-unique-6-rgb` | `--rank-6-unique-rgb` | 6★ (ember copper) |

Hex fallback triplets are design-LOCKED (colorize LOCKED 2026-07-18) and were preserved exactly. Comments naming the old tokens were updated to the new names (truthful docs).

## 5/6-cue judgment calls

The three color-stop entries carry explicit numeric cues:
- `unique5` / `-5-rgb` suffix + "5★" comment → `--rank-5-unique-rgb`
- `unique6` / `-6-rgb` suffix + "6★" comment → `--rank-6-unique-rgb`
- bare `unique4` / `--tier-unique-rgb` (no suffix, 4★ is where Unique begins) → `--rank-4-unique-rgb`

No `.tier-glyph[data-type="fusion"]` rule exists in this file, so the fusion-type correction was not applicable here.

## Verification

- `grep -- '--tier-unique' docs/trust/leaderboard/leaderboard.js` returns 0 residual.
- Read back both edited regions: no merged lines, balanced braces, hex fallbacks intact (Guard A clean — hex only inside `|| '...'` fallbacks).

Note: `--rank-*-unique-rgb` may resolve to the JS fallback triplet at runtime until #1283 lands — that's expected; this is the source rename.

## Entrypoints

Entrypoints: none (token-only)
