### PR TITLE
design(ygg2): migrate --tier-unique* → --rank-*-unique (badges legend)

### DIFF
--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -1154,11 +1154,11 @@
             <td>4★</td>
             <td>
               <span style="color:var(--rank-4,#e879f9);font-weight:600;">◆ Extra</span><br>
-              <span style="color:var(--tier-unique,#7c3aed);font-weight:600;">◉ Unique</span>
+              <span style="color:var(--rank-4-unique,#7c3aed);font-weight:600;">◉ Unique</span>
             </td>
             <td>
               <span class="bd-rank-swatch" style="background:var(--rank-4,#e879f9);"></span>Fuchsia<br>
-              <span class="bd-rank-swatch" style="background:var(--tier-unique,#7c3aed);"></span>Deep violet
+              <span class="bd-rank-swatch" style="background:var(--rank-4-unique,#7c3aed);"></span>Deep violet
             </td>
             <td>TM ≥ 100 (A-grade)</td>
             <td>Production-depth mastery. <b>◆ Extra</b> — suite branch, verified capstone with components. <b>◉ Unique</b> — depth alone, no fusion path.</td>
@@ -1171,7 +1171,7 @@
             </td>
             <td>
               <span class="bd-rank-swatch" style="background:var(--rank-5,#fbbf24);"></span>Amber gold<br>
-              <span class="bd-rank-swatch" style="background:var(--tier-unique-5,#b26a3a);"></span>Burnished copper
+              <span class="bd-rank-swatch" style="background:var(--rank-5-unique,#b26a3a);"></span>Burnished copper
             </td>
             <td>TM ≥ 250 (S-grade)<br><small>◆ + Origin on ≥ 1 suite component</small></td>
             <td>Mastery. <b>◆ Ultimate</b> — suite pinnacle, Origin on ≥ 1 of the ≥ 5 components required. <b>◉ Unique Ultimate</b> — same TM bar, solo track.</td>
@@ -1180,11 +1180,11 @@
             <td>6★</td>
             <td>
               <span style="color:var(--apex-gold);font-weight:700;letter-spacing:.02em;text-shadow:var(--glow-VI);">◆ Apex</span><br>
-              <span style="color:var(--tier-unique-6);font-weight:700;letter-spacing:.02em;text-shadow:var(--glow-VI);">◉ Unique Impossible</span>
+              <span style="color:var(--rank-6-unique);font-weight:700;letter-spacing:.02em;text-shadow:var(--glow-VI);">◉ Unique Impossible</span>
             </td>
             <td>
               <span class="bd-rank-swatch" style="background:var(--rank-6,#fbbf24);"></span>Apex gold<br>
-              <span class="bd-rank-swatch" style="background:var(--tier-unique-6,#e0894a);"></span>Ember
+              <span class="bd-rank-swatch" style="background:var(--rank-6-unique,#e0894a);"></span>Ember
             </td>
             <td>TM ≥ 250 (S-grade) + predicate gate</td>
             <td>Pinnacle. <b>◆ Apex</b> — suite, 6-predicate gate, Origin 5★ fusion required. <b>◉ Unique Impossible</b> — solo, 5-predicate gate. Extraordinarily rare.</td>

--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -1167,7 +1167,7 @@
             <td>5★</td>
             <td>
               <span style="color:var(--rank-5,#fbbf24);font-weight:600;">◆ Ultimate</span><br>
-              <span style="color:var(--rank-5);font-weight:600;text-shadow:var(--glow-V);">◉ Unique Ultimate</span>
+              <span style="color:var(--rank-5-unique, #b26a3a);font-weight:600;text-shadow:var(--glow-V);">◉ Unique Ultimate</span>
             </td>
             <td>
               <span class="bd-rank-swatch" style="background:var(--rank-5,#fbbf24);"></span>Amber gold<br>
@@ -1180,7 +1180,7 @@
             <td>6★</td>
             <td>
               <span style="color:var(--apex-gold);font-weight:700;letter-spacing:.02em;text-shadow:var(--glow-VI);">◆ Apex</span><br>
-              <span style="color:var(--rank-6-unique);font-weight:700;letter-spacing:.02em;text-shadow:var(--glow-VI);">◉ Unique Impossible</span>
+              <span style="color:var(--rank-6-unique, #e0894a);font-weight:700;letter-spacing:.02em;text-shadow:var(--glow-VI);">◉ Unique Impossible</span>
             </td>
             <td>
               <span class="bd-rank-swatch" style="background:var(--rank-6,#fbbf24);"></span>Apex gold<br>


### PR DESCRIPTION
## Summary

Migrates the retired `--tier-unique*` CSS tokens onto the rank axis in the badges rank legend, following the ratified Yggdrasil II rank schema. The generator PR (#1283) already retired `--tier-unique*` from the token source; this migrates the consumer.

## Files touched

- `docs/badges/index.html` — 5 hits in the rank legend table

## One-axis rank-schema rationale

Suite and Unique are two ladders on ONE rank axis; there is no separate "tier unique". Every `--tier-unique*` maps to `--rank-N-unique*` keyed to the rank the consumer represents:

- `--tier-unique` (bare, 4-star Unique entry, violet `#7c3aed`) -> `--rank-4-unique` (x2)
- `--tier-unique-5` (5-star, burnished copper `#b26a3a`) -> `--rank-5-unique`
- `--tier-unique-6` (6-star Unique Impossible, ember `#e0894a`) -> `--rank-6-unique` (x2)

All `,#hex` fallbacks preserved exactly. No hex values changed (colorize LOCKED 2026-07-18).

## Judgment calls (5/6 cues)

Every hit had an unambiguous rank cue from its table row:
- The two bare `--tier-unique` hits sit in the 4-star row beside `--rank-4` swatches ("Unique" / "Deep violet") -> `--rank-4-unique`.
- `--tier-unique-5` sits in the 5-star row beside `--rank-5` -> `--rank-5-unique`.
- Both `--tier-unique-6` hits sit in the 6-star row ("Unique Impossible" / "Ember") beside `--rank-6` -> `--rank-6-unique`.

No fusion-type correction applicable here (that special case is styles.css only).

## Entrypoints: none (token-only)
