### PR TITLE
design(ygg2): migrate --tier-unique* → --rank-*-unique (skill-explorer.js)

### DIFF
--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -20,7 +20,7 @@
   // Branch → dot/slug color token. Apex (6★) is white regardless of branch.
   function _seBranchColor(branch, isApex) {
     if (isApex) return '#ffffff';
-    if (branch === SE_UNIQUE) return 'var(--tier-unique)';
+    if (branch === SE_UNIQUE) return 'var(--rank-4-unique)';
     if (branch === SE_SUITE) return 'var(--apex-gold)';
     return 'var(--tier-basic)';
   }
@@ -2298,7 +2298,7 @@
     var glyph = skillGlyph(skill);
     // Glyph colour from the emitted/derived branch via the shared branch→token
     // map (_seBranchColor). Standard→--tier-basic, suite→--apex-gold,
-    // unique→--tier-unique — never --tier-<type> (type is basic|fusion only).
+    // unique→--rank-4-unique — never --tier-<type> (type is basic|fusion only).
     var _uspBranch = _seBranchOf(skill);
     var glyphColor = _seBranchColor(_uspBranch, false);
     document.getElementById('uspGlyph').textContent = glyph;
@@ -2557,7 +2557,7 @@
       if (handleRedacted) {
         color = 'var(--rank-' + _effRank + ', var(--tier-basic))';
       } else {
-        if (_branch === SE_UNIQUE) { color = 'var(--tier-unique)'; }
+        if (_branch === SE_UNIQUE) { color = 'var(--rank-4-unique)'; }
         else if (_branch === SE_SUITE) { color = 'var(--apex-gold)'; }
       }
 
@@ -2580,7 +2580,7 @@
         if (_branch === SE_SUITE) {
           slugStyle += ' animation: tree-rainbow-glow 4s linear infinite;';
         } else if (_branch === SE_UNIQUE) {
-          slugStyle += ' text-shadow: 0 0 12px rgba(var(--tier-unique-rgb,124,58,237),0.6), 0 0 4px rgba(var(--tier-unique-rgb,124,58,237),0.3);';
+          slugStyle += ' text-shadow: 0 0 12px rgba(var(--rank-4-unique-rgb,124,58,237),0.6), 0 0 4px rgba(var(--rank-4-unique-rgb,124,58,237),0.3);';
         }
       }
       bHtml += '<span class="plaque__slug" style="' + slugStyle + '">' + esc(skillName) + '</span>';


### PR DESCRIPTION
Migrates retired `--tier-unique*` token references onto the ratified rank axis in the Skill Explorer consumer. The generator PR (#1283) already retired `--tier-unique*` from the token source; this migrates the consumer.

## Files touched
- `docs/js/skill-explorer.js` — 4 hits renamed

## One-axis rank-schema rationale
Suite and Unique are two ladders on ONE rank axis; there is no separate "tier unique" and no branch-generic token distinct from rank. Every Unique-flavored cue ties to the rank it represents. A skill is only Unique at 4★+, so the base/branch-generic Unique accent maps to `--rank-4-unique` (4★ = Unique branch ENTRY, also the base default; violet #7c3aed).

## Hits (all `--rank-4-unique`)
- L23 `_seBranchColor`: `SE_UNIQUE` branch dot/slug color → `var(--rank-4-unique)`
- L2301 comment naming the old token → updated to `--rank-4-unique` (truthful docs)
- L2560 `openNamedPopup` slug color for `SE_UNIQUE` branch → `var(--rank-4-unique)`
- L2583 slug `text-shadow` glow: `var(--tier-unique-rgb,124,58,237)` ×2 → `var(--rank-4-unique-rgb,124,58,237)` (violet fallback preserved exactly)

## Judgment calls
All 4 hits are keyed to the `SE_UNIQUE` **branch** accent (branch-generic Unique color/glow), not to any explicit 5★/6★ cue (no `--v`/`--vi`, no `data-level`, no `-5`/`-6` suffix, no `-ink`). Per the one rule, branch-generic / bare Unique → `--rank-4-unique`. The `-rgb` violet fallback `124,58,237` confirms the 4★ base color and is preserved unchanged.

No `.tier-glyph[data-type="fusion"]` rule exists in this file (that fusion-type correction belongs to the styles.css group), so no fusion correction applied here.

`grep -n -- '--tier-unique' docs/js/skill-explorer.js` returns zero. `node --check` passes.

## Entrypoints: none (token-only)
