### PR TITLE
design(ygg2): migrate --tier-unique* → --rank-*-unique (profile-timeline.js)

### DIFF
--- a/docs/js/profile-timeline.js
+++ b/docs/js/profile-timeline.js
@@ -153,11 +153,11 @@
          not the dead type enum. Tier color via tokens; unique reads its rgb. */
       '.ptl2__dot--standard { border-color: var(--tier-basic);  background: rgba(56,189,248,.15); }',
       '.ptl2__dot--suite    { border-color: var(--tier-fusion); background: rgba(var(--tier-fusion-rgb),.15); }',
-      '.ptl2__dot--unique   { border-color: var(--tier-unique); background: #000; }',
+      '.ptl2__dot--unique   { border-color: var(--rank-4-unique); background: #000; }',
       '.ptl2__dot--rank { width: 9px; height: 9px; border-width: 2px; }',
       '.ptl2__event--rank-up .ptl2__dot--standard { box-shadow: 0 0 6px rgba(56,189,248,.5); }',
       '.ptl2__event--rank-up .ptl2__dot--suite    { box-shadow: 0 0 8px rgba(var(--tier-fusion-rgb),.6); }',
-      '.ptl2__event--rank-up .ptl2__dot--unique   { box-shadow: 0 0 8px rgba(var(--tier-unique-rgb,124,58,237),.7); }',
+      '.ptl2__event--rank-up .ptl2__dot--unique   { box-shadow: 0 0 8px rgba(var(--rank-4-unique-rgb,124,58,237),.7); }',
 
       /* Card */
       '.ptl2__card {',
@@ -288,7 +288,7 @@
   var TIER_COLOR = {
     standard: 'var(--tier-basic)',
     suite:    'var(--tier-fusion)',
-    unique:   'var(--tier-unique)',
+    unique:   'var(--rank-4-unique)',
   };
   // Resolve a `var(--token)` or `var(--token,#fallback)` expression at runtime:
   // prefer the live CSS custom property, fall back to the (optional) inline
@@ -311,7 +311,7 @@
     return {
       standard: cv('var(--tier-basic)'),
       suite:    cv('var(--tier-fusion)'),
-      unique:   cv('var(--tier-unique)'),
+      unique:   cv('var(--rank-4-unique)'),
     };
   }());
 


### PR DESCRIPTION
## Files touched

- `docs/js/profile-timeline.js` — 4 hits migrated

## One-axis rank-schema rationale

Suite and Unique are two ladders on ONE rank axis; there is no separate "tier unique" token. Every `--tier-unique*` reader keyed to the rank the consumer represents. In this file all four hits are the profile-timeline unique dot accent and its runtime `TIER_COLOR` resolver — the base/branch-generic Unique accent with **no 5-cue or 6-cue** present anywhere in the file. By the one rule (bare `--tier-unique` / 4★ / base accent → `--rank-4-unique`), all four map to `--rank-4-unique` — 4★ is where Unique begins.

Changes:
- `.ptl2__dot--unique` border-color: `var(--tier-unique)` → `var(--rank-4-unique)`
- `.ptl2__event--rank-up .ptl2__dot--unique` glow: `var(--tier-unique-rgb,124,58,237)` → `var(--rank-4-unique-rgb,124,58,237)` (fallback rgb preserved exactly)
- `TIER_COLOR.unique`: `'var(--tier-unique)'` → `'var(--rank-4-unique)'`
- runtime resolver `unique: cv('var(--tier-unique)')` → `cv('var(--rank-4-unique)')`

No hex values changed (design-LOCKED). No fusion-type correction applicable (this is not styles.css).

## Judgment calls (5/6 cues)

None. No `--v`/`--vi` selectors, `data-level`, `-5`/`-6` suffixes, `-ink`, or 5★/6★ comments in this file — every hit is the base Unique accent.

`grep -n -- '--tier-unique' docs/js/profile-timeline.js` → 0 residual.

## Entrypoints

Entrypoints: none (token-only).
