### PR TITLE
design(ygg2): migrate --tier-unique* → --rank-*-unique (skill-graph.js)

### DIFF
--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -14,7 +14,7 @@
   // ║                                                                ║
   // ║   --tier-basic / -rgb / -edge                                  ║
   // ║   --tier-extra / -rgb / -edge                                  ║
-  // ║   --tier-unique / -rgb / -edge                                 ║
+  // ║   --rank-4-unique / -rgb / -edge  (5★ -5, 6★ -6, -ink)         ║
   // ║   --tier-ultimate / -rgb / -edge                               ║
   // ║   --rank-0 … --rank-6 / -bg / -border / -edge                  ║
   // ║   --honor-red / --honor-red-rgb                                ║
@@ -129,6 +129,16 @@
         edge: _readVar('--tier-' + name + '-edge') || ('rgba(' + rgb + ',.55)'),
       };
     }
+    // Unique is a RANK-axis branch (4★ = Unique entry / base), so its base hue
+    // reads the --rank-4-unique* ladder tokens, not a --tier-* token.
+    function uniqueTier() {
+      const rgb = _rgbOnly(_readVar('--rank-4-unique-rgb'));
+      return {
+        hex: _readVar('--rank-4-unique'),
+        rgb: rgb,
+        edge: _readVar('--rank-4-unique-edge') || ('rgba(' + rgb + ',.55)'),
+      };
+    }
     function rank(n) {
       // §6 color-by-rank re-axis. tokens.css DOES emit --rank-N-rgb (grey
       // 148,163,184 at 0★ … apex-gold 251,191,36 at 6★); read it so the canvas
@@ -146,7 +156,7 @@
       tier: {
         basic: tier('basic'),
         extra: tier('extra'),
-        unique: tier('unique'),
+        unique: uniqueTier(),
         ultimate: tier('ultimate'),
       },
       rank: {
@@ -1203,19 +1213,19 @@
     function drawNodeUnique(sx, sy, r, alpha, t, p, rank) {
       // §PR3b §C — the Unique singularity forks by RANK. ESCALATION reads
       // CALMER + DENSER, never more frantic:
-      //   4★ (--tier-unique, violet): the base singularity, toned DOWN from the
+      //   4★ (--rank-4-unique, violet): the base singularity, toned DOWN from the
       //       historical render — fewer particles, slower spin, tighter pulse.
-      //   5★ (--tier-unique-5, copper): smaller radius, tighter/denser disk,
+      //   5★ (--rank-5-unique, copper): smaller radius, tighter/denser disk,
       //       calmer than 4★.
-      //   6★ (--tier-unique-6 copper + -ink): PLACEHOLDER — near-still core with
+      //   6★ (--rank-6-unique copper + -ink): PLACEHOLDER — near-still core with
       //       a cheap "inverted"/lensing hint. No 6★ Unique exists today; wire it
       //       so it renders when earned. Kept intentionally cheap.
       const rk = (typeof rank === 'number' && rank >= 4) ? Math.min(6, rank | 0) : 4;
       const tok = getCanvasTokens();
       // Rank-specific hue: read the ladder token, fall back to the 4★ violet.
       function _uniqueRgbFor(n) {
-        if (n >= 6) return _rgbOnly(_readVar('--tier-unique-6-rgb')) || tok.tier.unique.rgb;
-        if (n >= 5) return _rgbOnly(_readVar('--tier-unique-5-rgb')) || tok.tier.unique.rgb;
+        if (n >= 6) return _rgbOnly(_readVar('--rank-6-unique-rgb')) || tok.tier.unique.rgb;
+        if (n >= 5) return _rgbOnly(_readVar('--rank-5-unique-rgb')) || tok.tier.unique.rgb;
         return tok.tier.unique.rgb;
       }
       const uniqueRgb = _uniqueRgbFor(rk);
@@ -1309,7 +1319,7 @@
       // in the 6★ ink tone. Kept minimal (single stroked rim, no per-pixel work)
       // since no 6★ Unique exists yet; it just needs to render when one is earned.
       if (rk >= 6) {
-        const ink = _readVar('--tier-unique-6-ink');
+        const ink = _readVar('--rank-6-unique-ink');
         ctx.save();
         ctx.globalCompositeOperation = 'difference';
         ctx.beginPath(); ctx.arc(sx, sy, r * 0.92, 0, Math.PI * 2);


### PR DESCRIPTION
## What

Migrate retired `--tier-unique*` CSS tokens onto the rank axis in `docs/js/skill-graph.js`. The generator PR (#1283) already retired `--tier-unique*` from the token source (`tokens.css`); this migrates the graph-canvas consumer.

## Files touched

- `docs/js/skill-graph.js` — 7 hits (canvas-token contract comment + reader + `drawNodeUnique` reads/comments)

## One-axis rank-schema rationale

Suite and Unique are two ladders on ONE rank axis. There is no "tier unique" — every Unique-flavored thing ties to RANK because a skill is only Unique at 4★+. One rule, keyed to the rank each consumer represents:

- base/`--tier-unique` (no numeric suffix, 4★ = Unique branch entry / base default) → `--rank-4-unique`
- `--tier-unique-5` (5★ copper) → `--rank-5-unique`
- `--tier-unique-6` (6★ ember copper, `-ink`) → `--rank-6-unique`

Suffix families (`-rgb`, `-ink`, `-edge`) move with the base name. Hex values are design-LOCKED (colorize LOCKED 2026-07-18) — no hex changed.

## Changes in detail

1. **Canvas-token contract comment (L15-18):** `--tier-unique / -rgb / -edge` line rewritten to `--rank-4-unique / -rgb / -edge (5★ -5, 6★ -6, -ink)` so the documented contract is truthful.
2. **`getCanvasTokens()`:** the generic `tier(name)` helper reads `--tier-` + name and still serves `basic`/`extra`/`ultimate` (type taxonomy — unchanged). `unique` now reads the `--rank-4-unique*` ladder via a dedicated `uniqueTier()` reader, since Unique is rank-axis, not a `--tier-*` type. This is the base/branch-generic 4★ default.
3. **`drawNodeUnique()` per-rank hue reads:** `--tier-unique-6-rgb` → `--rank-6-unique-rgb`, `--tier-unique-5-rgb` → `--rank-5-unique-rgb`, `--tier-unique-6-ink` → `--rank-6-unique-ink`. The explicit 5-cue (`n >= 5`) and 6-cue (`n >= 6`, `-ink`) selectors made these unambiguous.
4. **Comment block naming the old tokens** updated to the new names (truthful docs).

## Judgment calls

- The base `--tier-unique` (via the generic `tier('unique')` call and the contract comment) had no numeric cue, so → `--rank-4-unique` (4★ is where Unique begins; also the base/branch-generic default). To keep `basic`/`extra`/`ultimate` on the `--tier-*` path while moving only `unique`, I extracted a dedicated `uniqueTier()` reader rather than re-plumbing the shared `tier()` helper.
- The `.tier.unique.rgb` accesses elsewhere in the file are JS property reads on the cached token map (the map key stays `unique`), not CSS token names — left untouched.

## Verification

- `grep -n -- '--tier-unique' docs/js/skill-graph.js` → zero hits.
- `node --check docs/js/skill-graph.js` → OK (balanced braces, no merged lines).
- No bare hex introduced (Guard A clean); hex values unchanged.

## Note

Base is `origin/dev/yggdrasil-ii-staging`; the generator PR (#1283) is not yet merged, so `--rank-*-unique` may resolve to the runtime fallback (`tok.tier.unique.rgb`) until it lands — expected. This PR is the source rename only.

Entrypoints: none (token-only)
