### PR TITLE
design(ygg2): migrate --tier-unique* -> --rank-*-unique (ascension-overdrive-v2.css)

### DIFF
--- a/docs/css/ascension-overdrive-v2.css
+++ b/docs/css/ascension-overdrive-v2.css
@@ -554,7 +554,7 @@
 .aov-eyebrow {
   font-family: var(--font-mono);
   font-size: clamp(0.72rem, 0.85vw, 0.9rem);
-  color: var(--tier-unique);
+  color: var(--rank-4-unique);
   text-transform: uppercase;
   letter-spacing: 0.28em;
   margin: 0 0 1rem;
@@ -610,8 +610,8 @@
   background: linear-gradient(
       90deg,
       transparent 0%,
-      var(--tier-unique) 15%,
-      var(--tier-unique) 85%,
+      var(--rank-4-unique) 15%,
+      var(--rank-4-unique) 85%,
       transparent 100%);
   opacity: 0.4;
   z-index: 0;
@@ -623,7 +623,7 @@
   z-index: 1;
   padding: 1.4rem;
   background: rgba(15, 23, 42, 0.75);
-  border: 1px solid var(--tier-unique-border);
+  border: 1px solid var(--rank-4-unique-border);
   border-radius: 4px;
   display: flex;
   flex-direction: column;
@@ -698,7 +698,7 @@
 .aov-ucard__num {
   font-family: var(--font-mono);
   font-size: 0.9rem;
-  color: var(--tier-unique);
+  color: var(--rank-4-unique);
   letter-spacing: 0.06em;
 }
 .aov-ucard[data-rank="5"] .aov-ucard__num { color: var(--apex-gold); }
@@ -952,7 +952,7 @@
   border-left-color: var(--border);
 }
 .aov-pred[data-state="locked"] .aov-pred__id {
-  color: color-mix(in oklab, var(--muted) 85%, var(--tier-unique) 15%);
+  color: color-mix(in oklab, var(--muted) 85%, var(--rank-4-unique) 15%);
 }
 
 /* ------------------------------------------------------------
@@ -1087,7 +1087,7 @@
      Rung 2 (Apex)                     : --apex-gold, opacity 0.85
      Rung 3 (Unique Ultimate)          : --apex-gold, opacity 0.70
      Rung 4 (Ultimate)                 : --rank-5 → --muted mix
-     Rung 5 (Unique)                   : --tier-unique → --muted
+     Rung 5 (Unique)                   : --rank-4-unique → --muted
      Rung 6-9 (Hardened..Awakened)     : --rank-N → --muted mix,
                                          darker as rank descends
 
@@ -1237,9 +1237,9 @@
 }
 .aov-order-rung[data-tier="ultimate"].is-lit { opacity: 0.7; }
 
-/* Unique: solid tier-unique, weight 500. */
+/* Unique: solid rank-4-unique, weight 500. */
 .aov-order-rung[data-tier="unique"] {
-  color: var(--tier-unique);
+  color: var(--rank-4-unique);
   font-weight: 500;
 }
 .aov-order-rung[data-tier="unique"].is-lit { opacity: 1; }
@@ -1430,8 +1430,8 @@
     background: linear-gradient(
         180deg,
         transparent 0%,
-        var(--tier-unique) 15%,
-        var(--tier-unique) 85%,
+        var(--rank-4-unique) 15%,
+        var(--rank-4-unique) 85%,
         transparent 100%);
   }
 


### PR DESCRIPTION
## What

Migrates the retired `--tier-unique*` CSS tokens onto the rank axis in the Ascension Overdrive scene stylesheet. The generator (PR #1283) already retired `--tier-unique*` from the token source (`tokens.css`); this PR migrates the CONSUMER.

## Files touched

- `docs/css/ascension-overdrive-v2.css` — 10 hits, all → `--rank-4-unique*`

## One-axis rank-schema rationale

Suite and Unique are two ladders on ONE rank axis; there is no separate "tier unique" and no branch-generic token distinct from rank. Every Unique-flavored cue ties to the rank it represents, because a skill is only Unique at 4★+. The one rule: `--tier-unique` (bare, no numeric cue) → `--rank-4-unique` (4★ is the Unique branch entry and the base/branch-generic default). The `-border` suffix family moves in lockstep → `--rank-4-unique-border`. No hex changed (colorize LOCKED 2026-07-18).

## 5/6-cue judgment calls

None. Every one of the 10 hits is the base/branch-generic Unique accent with no 5-cue or 6-cue:

- `.aov-eyebrow`, `.aov-unique-hairline` (desktop + mobile), `.aov-ucard` border, `.aov-ucard__num` base, locked `.aov-pred__id` tint, and `.aov-order-rung[data-tier="unique"]` are all scene-level / base-rank accents.
- The per-rank card overrides (`[data-rank="5"]`, `[data-rank="6"]`) use `--apex-gold` / `--evidence-gold`, not `--tier-unique`, so no 5★/6★ Unique token appears in this file.
- Two naming comments were updated to the new token name for truthful docs (the "Rung 5 (Unique)" colour-ladder line and the "Unique: solid …" rung comment — "Rung 5" is a ladder position label, not rank 5; the accent it names is the branch-generic Unique = rank 4).

No fusion-type correction applies here (`.tier-glyph[data-type="fusion"]` lives in `styles.css`, not this file).

## Verification

- `grep -c -- '--tier-unique'` → 0
- `grep -c -- '--rank-4-unique'` → 10
- Braces balanced (219 open / 219 close); no bare hex added (CI Guard A clean).

## Entrypoints

none (token-only)
