### PR TITLE
design(ygg2): migrate --tier-unique* → --rank-*-unique (nav/report/share consumers)

### DIFF
--- a/docs/js/docs-nav-mobile.js
+++ b/docs/js/docs-nav-mobile.js
@@ -59,7 +59,7 @@
     '<button type="button" class="close-btn" aria-label="Close menu">×</button>',
     '<a href="' + root + 'index.html" style="color:var(--text)">Home</a>',
     '<a href="' + root + 'about.html" style="color:var(--apex-gold)">About</a>',
-    '<a href="' + root + 'badges/' + v + '" style="color:var(--tier-unique)">GitHub Badges</a>',
+    '<a href="' + root + 'badges/' + v + '" style="color:var(--rank-4-unique)">GitHub Badges</a>',
     '<a href="' + root + 'named/' + v + '" style="color:var(--honor-red)">Skills</a>',
     '<a href="index.html" style="color:var(--tier-basic)">Docs</a>',
     '<div class="group-label">More</div>',

--- a/docs/js/named-skills.js
+++ b/docs/js/named-skills.js
@@ -249,7 +249,7 @@
       var zoneColor = branch === 'suite'
         ? 'var(--tier-fusion)'
         : branch === 'unique'
-          ? 'var(--tier-unique)'
+          ? 'var(--rank-4-unique)'
           : 'var(--rank-' + rankNum + ',var(--muted))';
 
       // AOV4 badge medallion for this rank+branch
@@ -696,7 +696,7 @@
         var colorVar = branch === 'suite'
           ? 'var(--tier-fusion)'
           : branch === 'unique'
-            ? 'var(--tier-unique)'
+            ? 'var(--rank-4-unique)'
             : 'var(--rank-' + rn + ', var(--muted))';
         var _base = (typeof window.gaiaIconBase === 'function')
           ? window.gaiaIconBase().replace(/assets\/icons\.svg(\?.*)?$/, '') : '';

--- a/docs/js/site-nav.js
+++ b/docs/js/site-nav.js
@@ -55,7 +55,7 @@
     {
       href: root + 'badges/',
       label: 'GitHub Badges',
-      color: 'var(--tier-unique)',
+      color: 'var(--rank-4-unique)',
       icon: function() { return '<svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align:-2px;margin-right:.35em"><use href="' + iconBase() + '#github"/></svg>'; },
       i: 2
     },

--- a/docs/named/report.html
+++ b/docs/named/report.html
@@ -462,7 +462,7 @@
        standard borrows the basic tier color, suite the fusion color. ── */
     .report-header-orb[data-branch="standard"] { color: var(--tier-basic);  background: var(--tier-basic-bg);  border-color: var(--tier-basic-border); }
     .report-header-orb[data-branch="suite"]    { color: var(--tier-fusion); background: var(--tier-fusion-bg); border-color: var(--tier-fusion-border); }
-    .report-header-orb[data-branch="unique"]   { color: var(--tier-unique); background: var(--tier-unique-bg); border-color: var(--tier-unique-border); }
+    .report-header-orb[data-branch="unique"]   { color: var(--rank-4-unique); background: var(--rank-4-unique-bg); border-color: var(--rank-4-unique-border); }
 
     /* ── Inherited evidence label ── */
     .ev-inherited-tag {

--- a/docs/share/styles.css
+++ b/docs/share/styles.css
@@ -171,7 +171,7 @@
 
 .share-skill-row__glyph[data-tier="basic"]    { color: var(--tier-basic); }
 .share-skill-row__glyph[data-tier="extra"]    { color: var(--rank-4); }
-.share-skill-row__glyph[data-tier="unique"]   { color: var(--tier-unique); }
+.share-skill-row__glyph[data-tier="unique"]   { color: var(--rank-4-unique); }
 .share-skill-row__glyph[data-tier="ultimate"] { color: var(--rank-5); }
 
 /* Skill name + contributor, stacked */


### PR DESCRIPTION
## What

Migrate retired `--tier-unique*` CSS token names onto the rank axis in the consumer files. The generator PR (#1283) already retired `--tier-unique*` from the token source; this migrates the consumers.

## Files touched

- `docs/js/named-skills.js` — 2 hits (emitDagLayer zone color + groupHeader medallion color): `var(--tier-unique)` → `var(--rank-4-unique)`
- `docs/js/site-nav.js` — 1 hit (GitHub Badges nav accent): `var(--tier-unique)` → `var(--rank-4-unique)`
- `docs/js/docs-nav-mobile.js` — 1 hit (mobile GitHub Badges link accent): `var(--tier-unique)` → `var(--rank-4-unique)`
- `docs/named/report.html` — 1 rule (`report-header-orb[data-branch="unique"]`, color + `-bg` + `-border`): `--tier-unique{,-bg,-border}` → `--rank-4-unique{,-bg,-border}`
- `docs/share/styles.css` — 1 hit (`share-skill-row__glyph[data-tier="unique"]`): `var(--tier-unique)` → `var(--rank-4-unique)`

## Rank-schema rationale (one axis)

Suite and Unique are two ladders on ONE rank axis; there is no "tier unique" and no branch-generic token separate from rank. A skill is only Unique at 4★+, so every Unique-flavored cue ties to rank. Per the one rule: bare `--tier-unique` (no numeric suffix, no other rank cue) → `--rank-4-unique` (4★ = Unique branch ENTRY / base default). Suffix families move too (`-bg`, `-border`). All hex values are design-LOCKED and unchanged.

## 5/6-cue judgment calls

None. Every hit in these 5 files is a bare/base Unique branch cue (`branch === 'unique'`, `[data-branch="unique"]`, `[data-tier="unique"]`, badges accent) with no 5★ (`--v`, Ultimate) or 6★ (`--vi`, Impossible, `-ink`) cue → all resolve to `--rank-4-unique`. No fusion correction applies to this group (`.tier-glyph[data-type="fusion"]` is not present in any of these files). Type-taxonomy tokens (`--tier-basic`, `--tier-fusion`) on sibling selectors were left untouched.

Entrypoints: none (token-only)
