### PR TITLE
design(ygg2): reconcile CLI RANK_COLORS_UNIQUE to CSS-locked Amethyst→Ember

### DIFF
--- a/src/gaia_cli/formatting.py
+++ b/src/gaia_cli/formatting.py
@@ -223,9 +223,9 @@ LEVEL_LABELS_UNIQUE = {
 # tree" — design-v6.1.1 §2.2). Only the 4★-6★ fork carries a distinct color;
 # 1★-3★ share the standard rank ramp.
 RANK_COLORS_UNIQUE = {
-    "4★": (139, 92, 246),   # #8b5cf6 violet
-    "5★": (124, 58, 237),   # #7c3aed deep violet
-    "6★": (109, 40, 217),   # #6d28d9 darkest violet (Impossible)
+    "4★": (124, 58, 237),   # #7c3aed violet (Amethyst — Unique branch entry)
+    "5★": (178, 106, 58),   # #b26a3a burnished copper (Unique Ultimate)
+    "6★": (224, 137, 74),   # #e0894a ember copper (Unique Impossible)
 }
 
 # Evidence Grade colors — single source of truth for grade design tokens.


### PR DESCRIPTION
## What changed

`src/gaia_cli/formatting.py` — `RANK_COLORS_UNIQUE` carried stale violets for 5★/6★. Reconciled to the CSS-locked Amethyst→Ember Unique rank ladder:

| Rank | Before | After | Hex |
|---|---|---|---|
| 4★ | `(139, 92, 246)` #8b5cf6 | `(124, 58, 237)` | #7c3aed violet (Unique branch entry) |
| 5★ | `(124, 58, 237)` #7c3aed | `(178, 106, 58)` | #b26a3a burnished copper |
| 6★ | `(109, 40, 217)` #6d28d9 | `(224, 137, 74)` | #e0894a ember copper |

Inline hex comments updated to match. Dict name unchanged (`RANK_COLORS_UNIQUE` is already rank-framed and correct).

## CSS wins

CSS is the source of truth (colorize LOCKED 2026-07-18, Amethyst→Ember). No hex changed in CSS; the Python palette follows the locked `--rank-{4,5,6}-unique` ladder. Suite and Unique are two ladders on ONE rank axis — a skill is only Unique at 4★+.

## generateBadges verification

`scripts/generateBadges.py` already matches the CSS-locked values — no change needed:
- `_UNIQUE_COLOR = "#7c3aed"`
- `UNIQUE_COPPER_5 = "#b26a3a"`
- `UNIQUE_COPPER_6 = "#e0894a"`
- `UNIQUE_INK = "#2a1206"`

## Tests

`python -m pytest tests/ -x -q`: 509 passed, 2 skipped before hitting an unrelated pre-existing red (`test_sync_upstream_end_to_end_via_subprocess` — subprocess `No module named gaia_cli`, an env/install issue). Color/rank/badge suites: no failures attributable to this change. The 3 remaining reds are pre-existing and unrelated — `textual` not installed (out-of-scope `tui/tokens.py`) and missing gitignored `registry/gaia.json` (Class P; not regenerated per task rules). No test asserted on the old violet values.

## Entrypoints

None (CLI palette).
