### PR TITLE
design(ygg2): retire dead --tier-extra/-ultimate/-unique tokens (P4 sample/support sweep)

### DIFF
--- a/docs/codex.html
+++ b/docs/codex.html
@@ -537,7 +537,7 @@
         </div>
 
         <!-- Node L5 -->
-        <div class="step-node" data-step="5" style="--step-color: var(--tier-unique); --step-glow: rgba(124, 58, 237, 0.25);">
+        <div class="step-node" data-step="5" style="--step-color: var(--rank-4-unique); --step-glow: rgba(124, 58, 237, 0.25);">
           <div class="step-num">L5</div>
           <div class="step-title">Execute Mutations</div>
           <div class="step-agent">CLI Mutations</div>
@@ -713,7 +713,7 @@
         num: "L5",
         title: "Execute Mutations",
         role: "CLI Curation Engine",
-        color: "var(--tier-unique)",
+        color: "var(--rank-4-unique)",
         glow: "rgba(124, 58, 237, 0.25)",
         desc: "Applies mutations exclusively via programmatic CLI tools. Modifying nodes directly by hand is strictly forbidden to prevent registry inconsistency.",
         inputs: [

--- a/docs/js/page-ia.js
+++ b/docs/js/page-ia.js
@@ -51,9 +51,9 @@
   };
   var TYPE_COLOR_VAR = {
     ultimate: 'var(--apex-gold)',
-    unique: 'var(--tier-unique)',
+    unique: 'var(--rank-4-unique)',
     extra: 'var(--rank-4)',
-    basic: 'var(--basic)',
+    basic: 'var(--tier-basic)',
   };
 
   function esc(str) {

--- a/docs/samples/foundation.html
+++ b/docs/samples/foundation.html
@@ -79,7 +79,7 @@
     .icon-state-cell.is-hover .ico { color: var(--tier-basic); filter: drop-shadow(0 0 8px rgba(var(--tier-basic-rgb), .5)); }
     .icon-state-cell.is-active .ico { color: var(--apex-gold); }
     .icon-state-cell.is-disabled .ico { color: var(--muted); opacity: .35; }
-    .icon-state-cell.is-focus { outline: 2px solid var(--tier-extra); outline-offset: 2px; }
+    .icon-state-cell.is-focus { outline: 2px solid var(--rank-4); outline-offset: 2px; }
     .icon-state-cell .ico { width: 28px; height: 28px; }
     .icon-state-cell .lbl { font-family: var(--font-mono); font-size: .7rem; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
 
@@ -102,9 +102,9 @@
       margin-bottom: .8rem;
     }
     .tier-card[data-tier="basic"] .tier-swatch { background: var(--tier-basic-bg); border: 1px solid var(--tier-basic-border); color: var(--tier-basic); }
-    .tier-card[data-tier="extra"] .tier-swatch { background: var(--tier-extra-bg); border: 1px solid var(--tier-extra-border); color: var(--tier-extra); }
-    .tier-card[data-tier="unique"] .tier-swatch { background: var(--tier-unique-bg); border: 1px solid var(--tier-unique-border); color: var(--tier-unique); }
-    .tier-card[data-tier="ultimate"] .tier-swatch { background: var(--tier-ultimate-bg); border: 1px solid var(--tier-ultimate-border); color: var(--tier-ultimate); }
+    .tier-card[data-tier="extra"] .tier-swatch { background: var(--rank-4-bg); border: 1px solid var(--rank-4-border); color: var(--rank-4); }
+    .tier-card[data-tier="unique"] .tier-swatch { background: var(--rank-4-unique-bg); border: 1px solid var(--rank-4-unique-border); color: var(--rank-4-unique); }
+    .tier-card[data-tier="ultimate"] .tier-swatch { background: var(--rank-5-bg); border: 1px solid var(--rank-5-border); color: var(--rank-5); }
     .tier-card h3 { font-family: var(--font-display); font-size: 1.15rem; font-weight: 600; }
     .tier-card .glyphs { font-size: 1.4rem; letter-spacing: .35em; margin: .5rem 0; }
     .tier-card .toks {
@@ -286,7 +286,7 @@
       <div class="tier-card" data-tier="extra">
         <div class="tier-swatch">◇</div>
         <h3>Extra</h3>
-        <div class="glyphs"><svg class="ico" width="22" height="22" style="color:var(--tier-extra)"><use href="../assets/icons.svg#tier-glyph-extra"/></svg></div>
+        <div class="glyphs"><svg class="ico" width="22" height="22" style="color:var(--rank-4)"><use href="../assets/icons.svg#tier-glyph-extra"/></svg></div>
         <div class="toks">
           <code>#c084fc</code> · rgb(<code>192, 132, 252</code>)<br>
           bg <code>rgba(192,132,252,.12)</code><br>
@@ -296,7 +296,7 @@
       <div class="tier-card" data-tier="unique">
         <div class="tier-swatch">◉</div>
         <h3>Unique</h3>
-        <div class="glyphs"><svg class="ico" width="22" height="22" style="color:var(--tier-unique)"><use href="../assets/icons.svg#tier-glyph-unique"/></svg></div>
+        <div class="glyphs"><svg class="ico" width="22" height="22" style="color:var(--rank-4-unique)"><use href="../assets/icons.svg#tier-glyph-unique"/></svg></div>
         <div class="toks">
           <code>#7c3aed</code> · rgb(<code>124, 58, 237</code>)<br>
           bg <code>rgba(124,58,237,.12)</code><br>
@@ -306,7 +306,7 @@
       <div class="tier-card" data-tier="ultimate">
         <div class="tier-swatch">◆</div>
         <h3>Ultimate</h3>
-        <div class="glyphs"><svg class="ico" width="22" height="22" style="color:var(--tier-ultimate)"><use href="../assets/icons.svg#tier-glyph-ultimate"/></svg></div>
+        <div class="glyphs"><svg class="ico" width="22" height="22" style="color:var(--rank-5)"><use href="../assets/icons.svg#tier-glyph-ultimate"/></svg></div>
         <div class="toks">
           <code>#f59e0b</code> · rgb(<code>245, 158, 11</code>)<br>
           bg <code>rgba(245,158,11,.12)</code><br>

--- a/docs/samples/nav.html
+++ b/docs/samples/nav.html
@@ -213,7 +213,7 @@
     <ul class="nav-primary">
       <li style="--nav-i:0"><a href="#" style="color: var(--text);">Home</a></li>
       <li style="--nav-i:1"><a href="#" style="color: var(--apex-gold);">About</a></li>
-      <li style="--nav-i:2"><a href="#" style="color: var(--tier-unique);">GitHub Badges</a></li>
+      <li style="--nav-i:2"><a href="#" style="color: var(--rank-4-unique);">GitHub Badges</a></li>
       <li style="--nav-i:3"><a href="#" style="color: var(--honor-red);">Skills</a></li>
       <li style="--nav-i:4"><a href="#" style="color: var(--tier-basic);">Docs</a></li>
     </ul>

--- a/docs/samples/registry-3d-fonts.html
+++ b/docs/samples/registry-3d-fonts.html
@@ -199,7 +199,7 @@
         ctx.fillStyle = readVar('--honor-red');
         ctx.fillText(handleTxt, paddingX, h / 2);
         var w1 = ctx.measureText(handleTxt).width;
-        ctx.fillStyle = readVar('--tier-ultimate'); // mock rank color
+        ctx.fillStyle = readVar('--rank-5'); // mock rank color
         ctx.fillText(slashTxt, paddingX + w1, h / 2);
         var w2 = ctx.measureText(slashTxt).width;
         

--- a/docs/samples/tree.html
+++ b/docs/samples/tree.html
@@ -89,9 +89,9 @@
 
     /* Tier glyphs — fixed canonical symbols */
     .glyph-basic    { color: var(--tier-basic,    #38bdf8); }
-    .glyph-extra    { color: var(--tier-extra,    #c084fc); }
-    .glyph-unique   { color: var(--tier-unique,   #7c3aed); }
-    .glyph-ultimate { color: var(--tier-ultimate, #f59e0b); }
+    .glyph-extra    { color: var(--rank-4,         #c084fc); }
+    .glyph-unique   { color: var(--rank-4-unique,  #7c3aed); }
+    .glyph-ultimate { color: var(--rank-5,         #f59e0b); }
 
     /* Skill name */
     .tree-name {

--- a/docs/share/styles.css
+++ b/docs/share/styles.css
@@ -171,7 +171,7 @@
 
 .share-skill-row__glyph[data-tier="basic"]    { color: var(--tier-basic); }
 .share-skill-row__glyph[data-tier="extra"]    { color: var(--rank-4); }
-.share-skill-row__glyph[data-tier="unique"]   { color: var(--tier-unique); }
+.share-skill-row__glyph[data-tier="unique"]   { color: var(--rank-4-unique); }
 .share-skill-row__glyph[data-tier="ultimate"] { color: var(--rank-5); }
 
 /* Skill name + contributor, stacked */


### PR DESCRIPTION
## P4 — Dead design-token sweep (EPIC #1002, Yggdrasil II)

Retires the deprecated `--tier-extra` / `--tier-ultimate` (faked Suite ranks, never defined) and stray `--tier-unique` dead tokens across sample/support surfaces, migrating each to the correct rank/type token on the one-axis rank schema.

### Mapping applied
| Dead token | → Live token |
|---|---|
| `--tier-extra[-bg/-border]` | `--rank-4[-bg/-border]` (Suite 4★ Extra, #e879f9) |
| `--tier-ultimate[-bg/-border]` | `--rank-5[-bg/-border]` (Suite 5★ Ultimate, #fbbf24) |
| `--tier-unique` | `--rank-4-unique` (Unique branch 4★, #7c3aed) |
| bare `--unique` (page-ia map) | `--rank-4-unique` |
| bare `--basic` (page-ia map) | `--tier-basic` (normalize) |

### Files touched
- `docs/codex.html` — 2 (`--step-color` + JS step config)
- `docs/js/page-ia.js` — `TYPE_COLOR_VAR` map (`unique`, `basic`)
- `docs/share/styles.css` — 1
- `docs/samples/foundation.html` — 14
- `docs/samples/tree.html` — 3 (hex fallbacks preserved)
- `docs/samples/nav.html` — 1
- `docs/samples/registry-3d-fonts.html` — 1 (mock rank color `readVar('--tier-ultimate')` → `--rank-5`)

### Out of scope (documented)
- `docs/samples/flowchart.html` — attribute-vocab (hardcoded rgba on data-attrs), pre-existing DEFER, NOT this sweep.
- `docs/en/*`, `verification_process.html` local `:root`, TUI `tokens.py` — founder rulings, separate PRs.

### Verification
- `check_hex_colors.py` (Guard A): exit 0.
- Grep gate: ZERO live `--tier-extra`/`--tier-ultimate`/`--tier-unique` in target files (flowchart excluded per spec).

Part of EPIC #1002.
