### PR TITLE
design(ygg2): Hall of Heroes Suite/Unique branch-fork color fix

### DIFF
--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -411,6 +411,83 @@
   text-shadow: 0 0 8px rgba(251, 191, 36, 0.5);
 }
 
+/* ---- Unique-branch rail overrides — swap Suite rank color for the Unique token at 4/5/6★.
+   Extra [data-branch="unique"] / [data-active-branch="unique"] attribute raises specificity,
+   so these win over the Suite base rules above. Only color-bearing declarations are re-declared. */
+.heroes-ledger-rail__button[data-branch="unique"][data-level="4"]:hover,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="4"]:focus-visible {
+  background: rgba(124, 58, 237, 0.07);
+}
+.heroes-ledger-rail__button[data-branch="unique"][data-level="5"]:hover,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="5"]:focus-visible,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="6"]:hover,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="6"]:focus-visible {
+  background: rgba(224, 137, 74, 0.07);
+}
+
+.heroes-ledger-rail__button[data-branch="unique"][data-level="4"]:focus-visible {
+  outline-color: var(--rank-4-unique, #7c3aed);
+}
+.heroes-ledger-rail__button[data-branch="unique"][data-level="5"]:focus-visible,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="6"]:focus-visible {
+  outline-color: var(--rank-5-unique, #b26a3a);
+}
+
+.heroes-ledger-rail__button[data-branch="unique"][data-level="4"].is-active {
+  color: var(--rank-4-unique, #7c3aed);
+}
+.heroes-ledger-rail__button[data-branch="unique"][data-level="5"].is-active,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="6"].is-active {
+  color: var(--rank-5-unique, #b26a3a);
+}
+
+.heroes-ledger-rail[data-active-branch="unique"][data-active-level="4"] .heroes-ledger-rail__kicker {
+  color: var(--rank-4-unique, #7c3aed);
+}
+.heroes-ledger-rail[data-active-branch="unique"][data-active-level="4"] .heroes-ledger-rail__plate {
+  border-bottom-color: rgba(124, 58, 237, 0.22);
+}
+.heroes-ledger-rail[data-active-branch="unique"][data-active-level="5"] .heroes-ledger-rail__kicker {
+  color: var(--rank-5-unique, #b26a3a);
+}
+.heroes-ledger-rail[data-active-branch="unique"][data-active-level="6"] .heroes-ledger-rail__kicker {
+  color: var(--rank-6-unique, #e0894a);
+}
+
+.heroes-ledger-rail__button[data-branch="unique"][data-level="4"]:hover .heroes-ledger-rail__avatar,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="4"]:focus-visible .heroes-ledger-rail__avatar,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="4"].is-active .heroes-ledger-rail__avatar {
+  border-color: rgba(124, 58, 237, 0.7);
+}
+.heroes-ledger-rail__button[data-branch="unique"][data-level="5"]:hover .heroes-ledger-rail__avatar,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="5"]:focus-visible .heroes-ledger-rail__avatar,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="5"].is-active .heroes-ledger-rail__avatar,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="6"]:hover .heroes-ledger-rail__avatar,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="6"]:focus-visible .heroes-ledger-rail__avatar,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="6"].is-active .heroes-ledger-rail__avatar {
+  border-color: rgba(224, 137, 74, 0.7);
+}
+
+.heroes-ledger-rail__button[data-branch="unique"][data-level="4"] .heroes-ledger-rail__glyph {
+  color: var(--rank-4-unique, #7c3aed);
+}
+.heroes-ledger-rail[data-active-branch="unique"][data-active-level="4"] .heroes-ledger-rail__button.is-active .heroes-ledger-rail__glyph,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="4"].is-active .heroes-ledger-rail__glyph {
+  color: var(--rank-4-unique, #7c3aed);
+  text-shadow: 0 0 8px rgba(124, 58, 237, 0.5);
+}
+.heroes-ledger-rail__button[data-branch="unique"][data-level="5"] .heroes-ledger-rail__glyph,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="6"] .heroes-ledger-rail__glyph {
+  color: var(--rank-5-unique, #b26a3a);
+}
+.heroes-ledger-rail[data-active-branch="unique"][data-active-level="5"] .heroes-ledger-rail__button.is-active .heroes-ledger-rail__glyph,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="5"].is-active .heroes-ledger-rail__glyph,
+.heroes-ledger-rail[data-active-branch="unique"][data-active-level="6"] .heroes-ledger-rail__button.is-active .heroes-ledger-rail__glyph,
+.heroes-ledger-rail__button[data-branch="unique"][data-level="6"].is-active .heroes-ledger-rail__glyph {
+  color: var(--rank-5-unique, #b26a3a);
+  text-shadow: 0 0 8px rgba(224, 137, 74, 0.5);
+}
+
 .heroes-ledger-rail__entry {
   min-width: 0;
 }
@@ -530,6 +607,20 @@
 .hero-stage[data-level="6"] {
   --stage-accent: var(--rank-6, #fbbf24);
   --stage-accent-rgb: 251, 191, 36;
+}
+
+/* Unique-branch stage accents — override Suite rank color at 4/5/6★ */
+.hero-stage[data-branch="unique"][data-level="4"] {
+  --stage-accent: var(--rank-4-unique, #7c3aed);
+  --stage-accent-rgb: 124, 58, 237;
+}
+.hero-stage[data-branch="unique"][data-level="5"] {
+  --stage-accent: var(--rank-5-unique, #b26a3a);
+  --stage-accent-rgb: 178, 106, 58;
+}
+.hero-stage[data-branch="unique"][data-level="6"] {
+  --stage-accent: var(--rank-6-unique, #e0894a);
+  --stage-accent-rgb: 224, 137, 74;
 }
 
 /* Tier-specific stage backgrounds */

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -570,6 +570,7 @@
     if (!rail) return;
 
     rail.removeAttribute('data-active-level');
+    rail.removeAttribute('data-active-branch');
     rail.classList.add('is-awaiting');
     rail.querySelectorAll('[data-ledger-target]').forEach(function (button) {
       button.classList.remove('is-active');
@@ -630,6 +631,12 @@
 
     var lvl = stage.getAttribute('data-level') || '4';
     rail.setAttribute('data-active-level', lvl);
+    var activeBranch = stage.getAttribute('data-branch') || '';
+    if (activeBranch) {
+      rail.setAttribute('data-active-branch', activeBranch);
+    } else {
+      rail.removeAttribute('data-active-branch');
+    }
 
     buttons.forEach(function (button) {
       var isActive = button.getAttribute('data-ledger-target') === stage.id;

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -468,7 +468,7 @@
       var avatarUrl = githubAvatarUrl(contributor.handle, 80);
       var lvl = levelNum(contributor.topSkill.level);
       return '<li class="heroes-ledger-rail__item">' +
-        '<button class="heroes-ledger-rail__button" type="button" data-ledger-target="' + esc(stageIdFor(contributor)) + '" data-ledger-index="' + esc(index) + '" data-level="' + lvl + '">' +
+        '<button class="heroes-ledger-rail__button" type="button" data-ledger-target="' + esc(stageIdFor(contributor)) + '" data-ledger-index="' + esc(index) + '" data-branch="' + esc(branch) + '" data-level="' + lvl + '">' +
         '<span class="heroes-ledger-rail__avatar" aria-hidden="true"><img src="' + esc(avatarUrl) + '" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" onerror="this.parentElement.hidden=true"></span>' +
         '<span class="heroes-ledger-rail__glyph" aria-hidden="true">' + esc(glyph) + '</span>' +
         '<span class="heroes-ledger-rail__entry">' +


### PR DESCRIPTION
## P2 — Hall of Heroes Suite/Unique branch-fork color bug (EPIC #1002)

The Hall of Heroes rail + stage colored skills purely by `data-level` (rank number). At 4★/5★/6★ color forks by branch: Suite → `--rank-N`, Unique → `--rank-N-unique` (violet/copper/ember). Unique-branch heroes were rendering in Suite gold/fuchsia.

### Fix
- **heroes.js** — emit `data-branch` on the ledger-rail `<button>` (the hero stage already emitted it); propagate `data-active-branch` onto the rail container for kicker/plate accents.
- **heroes.css** — `[data-branch="unique"]` overrides for stage accents (`--stage-accent`), rail-button color-bearing declarations (hover/focus/active border, avatar ring, glyph), and rail kicker/plate. 31 override declarations; 2-attribute specificity beats the 1-attribute Suite base.

All `--rank-N-unique` refs use `var(--x, #hex)` fallback form (Guard A-safe) so they render correctly before generator PR #1283 lands.

### Entrypoints
No new page/section — modifies existing Hall of Heroes rendering only. No nav/mount/footer changes.

Part of EPIC #1002.
