### PR TITLE
design(heroes): windowed-locator rail redesign + /impeccable critique fixes

### DIFF
--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -562,10 +562,10 @@
   gap: 6px;
   min-height: 34px;
   padding: 6px 10px;
-  border: 1px solid rgba(var(--heroes-gold-rgb), 0.24);
+  border: 1px solid rgba(var(--heroes-gold-rgb), 0.42);
   border-radius: 4px;
-  background: rgba(var(--heroes-gold-rgb), 0.04);
-  color: var(--heroes-frost-dim);
+  background: rgba(var(--heroes-gold-rgb), 0.07);
+  color: var(--heroes-frost);
   font-family: var(--heroes-font-mono);
   font-size: 0.64rem;
   letter-spacing: 0.08em;
@@ -576,8 +576,8 @@
 
 .heroes-ledger-rail__all:hover {
   color: var(--heroes-frost);
-  background: rgba(var(--heroes-gold-rgb), 0.08);
-  border-color: rgba(var(--heroes-gold-rgb), 0.4);
+  background: rgba(var(--heroes-gold-rgb), 0.12);
+  border-color: rgba(var(--heroes-gold-rgb), 0.6);
 }
 
 .heroes-ledger-rail__all:focus-visible {

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -19,6 +19,10 @@
   --heroes-font-mono: var(--font-mono, 'Departure Mono', monospace);
   --heroes-stage-gap: 0;
   --heroes-rail-width: clamp(176px, 15vw, 232px);
+  /* Shared content column width so stacked stage sections line up (800px). */
+  --heroes-content-max: 800px;
+  /* Narrower reading measure for the intro title/subtitle prose block. */
+  --heroes-prose-max: 680px;
 }
 
 
@@ -64,7 +68,7 @@
 
 .heroes-header__inner {
   text-align: center;
-  max-width: 680px;
+  max-width: var(--heroes-prose-max);
 }
 
 .heroes-header__title {
@@ -711,7 +715,7 @@
 .hero-card {
   position: relative;
   width: 100%;
-  max-width: 720px;
+  max-width: var(--heroes-content-max);
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -974,7 +978,7 @@
   align-items: center;
   gap: 1.5rem;
   padding: 3rem 2rem;
-  max-width: 800px;
+  max-width: var(--heroes-content-max);
   margin: 0 auto;
 }
 

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -1333,8 +1333,24 @@
     padding: 2px 0;
   }
 
+  /* Windowed locator: at desktop the rail shows only the neighborhood of rows
+     around the active plate (set by applyLedgerWindow). Non-windowed rows are
+     removed from flow so the rail stays bounded regardless of hero count. The
+     full <ol> remains in the DOM — the "all plates" panel and prev/next walk
+     every item. Mobile (<820px) keeps all chips (this rule is desktop-only). */
   .heroes-ledger-rail__item {
+    display: none;
     flex: initial;
+  }
+
+  .heroes-ledger-rail__item.is-in-window {
+    display: block;
+    animation: heroes-ledger-row-in 200ms ease-out both;
+  }
+
+  @keyframes heroes-ledger-row-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
   }
 
   .heroes-ledger-rail__button {
@@ -1485,6 +1501,10 @@
   .hero-stage::after,
   .hero-card {
     transition: none !important;
+  }
+
+  .heroes-ledger-rail__item.is-in-window {
+    animation: none !important;
   }
 
   .hero-stage {

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -564,6 +564,218 @@
 }
 
 
+/* ── "All plates" trigger (opens the full index dialog) ──────────
+   Spans its own full-width row in both the mobile strip and the desktop rail
+   grid (grid-column: 1 / -1). Injected by heroes.js after the list.          */
+.heroes-ledger-rail__all {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 1px solid rgba(var(--heroes-gold-rgb), 0.24);
+  border-radius: 4px;
+  background: rgba(var(--heroes-gold-rgb), 0.04);
+  color: var(--heroes-frost-dim);
+  font-family: var(--heroes-font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 180ms ease, background 180ms ease, border-color 180ms ease;
+}
+
+.heroes-ledger-rail__all:hover {
+  color: var(--heroes-frost);
+  background: rgba(var(--heroes-gold-rgb), 0.08);
+  border-color: rgba(var(--heroes-gold-rgb), 0.4);
+}
+
+.heroes-ledger-rail__all:focus-visible {
+  outline: 2px solid var(--heroes-gold-warm);
+  outline-offset: 2px;
+}
+
+.heroes-ledger-rail__all-caret {
+  font-family: var(--heroes-font-mono);
+  line-height: 1;
+}
+
+
+/* ── "All plates" full-index dialog ──────────────────────────────
+   Native <dialog>: Esc dismiss + focus trap for free. Scrollable list of every
+   hero, keyed to the same scroll-to path as the rail.                         */
+.heroes-ledger-all {
+  width: min(92vw, 460px);
+  max-height: min(80vh, 640px);
+  padding: 0;
+  border: 1px solid rgba(var(--heroes-gold-rgb), 0.28);
+  border-radius: 12px;
+  background: var(--heroes-bg-ink);
+  color: var(--heroes-frost);
+  overflow: hidden;
+}
+
+.heroes-ledger-all::backdrop {
+  background: rgba(0, 0, 0, 0.62);
+}
+
+.heroes-ledger-all[open] {
+  display: flex;
+  flex-direction: column;
+  animation: heroes-all-in 180ms ease-out both;
+}
+
+@keyframes heroes-all-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.heroes-ledger-all__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(var(--heroes-gold-rgb), 0.18);
+}
+
+.heroes-ledger-all__title {
+  margin: 0;
+  font-family: var(--heroes-font-display);
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--heroes-gold-warm);
+}
+
+.heroes-ledger-all__close {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid rgba(var(--heroes-gold-rgb), 0.28);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--heroes-frost-dim);
+  cursor: pointer;
+  transition: color 180ms ease, border-color 180ms ease;
+}
+
+.heroes-ledger-all__close:hover {
+  color: var(--heroes-frost);
+  border-color: var(--heroes-gold-warm);
+}
+
+.heroes-ledger-all__close:focus-visible {
+  outline: 2px solid var(--heroes-gold-warm);
+  outline-offset: 2px;
+}
+
+.heroes-ledger-all__list {
+  margin: 0;
+  padding: 0.5rem;
+  list-style: none;
+  overflow-y: auto;
+}
+
+.heroes-ledger-all__item {
+  list-style: none;
+}
+
+.heroes-ledger-all__entry {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--heroes-frost);
+  text-align: left;
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+
+.heroes-ledger-all__entry:hover {
+  background: rgba(var(--heroes-gold-rgb), 0.07);
+}
+
+.heroes-ledger-all__entry:focus-visible {
+  outline: 2px solid var(--heroes-gold-warm);
+  outline-offset: -2px;
+}
+
+.heroes-ledger-all__entry[data-level="4"]:focus-visible {
+  outline-color: var(--rank-4, #e879f9);
+}
+
+.heroes-ledger-all__entry[data-level="5"]:focus-visible,
+.heroes-ledger-all__entry[data-level="6"]:focus-visible {
+  outline-color: var(--rank-5, #fbbf24);
+}
+
+.heroes-ledger-all__entry[data-branch="unique"][data-level="4"]:focus-visible {
+  outline-color: var(--rank-4-unique, #7c3aed);
+}
+
+.heroes-ledger-all__entry[data-branch="unique"][data-level="5"]:focus-visible,
+.heroes-ledger-all__entry[data-branch="unique"][data-level="6"]:focus-visible {
+  outline-color: var(--rank-5-unique, #b26a3a);
+}
+
+.heroes-ledger-all__glyph {
+  font-family: var(--heroes-font-mono);
+  font-size: 0.9rem;
+  text-align: center;
+  color: var(--rank-5, #fbbf24);
+}
+
+.heroes-ledger-all__entry[data-level="4"] .heroes-ledger-all__glyph {
+  color: var(--rank-4, #e879f9);
+}
+
+.heroes-ledger-all__entry[data-branch="unique"][data-level="4"] .heroes-ledger-all__glyph {
+  color: var(--rank-4-unique, #7c3aed);
+}
+
+.heroes-ledger-all__entry[data-branch="unique"][data-level="5"] .heroes-ledger-all__glyph,
+.heroes-ledger-all__entry[data-branch="unique"][data-level="6"] .heroes-ledger-all__glyph {
+  color: var(--rank-5-unique, #b26a3a);
+}
+
+.heroes-ledger-all__body {
+  min-width: 0;
+}
+
+.heroes-ledger-all__name {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--heroes-font-body);
+  font-size: 0.95rem;
+  line-height: 1.2;
+}
+
+.heroes-ledger-all__by {
+  display: block;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--heroes-font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  color: var(--heroes-frost-dim);
+}
+
+
 /* ── Stages container ────────────────────────────────────────── */
 .heroes-stages {
   display: flex;
@@ -1504,6 +1716,10 @@
   }
 
   .heroes-ledger-rail__item.is-in-window {
+    animation: none !important;
+  }
+
+  .heroes-ledger-all[open] {
     animation: none !important;
   }
 

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -641,8 +641,8 @@
 .heroes-ledger-all__close {
   display: grid;
   place-items: center;
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   border: 1px solid rgba(var(--heroes-gold-rgb), 0.28);
   border-radius: 6px;
   background: transparent;

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -178,21 +178,19 @@
 }
 
 .heroes-ledger-rail__kicker,
-.heroes-ledger-rail__meta,
-.heroes-ledger-rail__byline {
+.heroes-ledger-rail__meta {
   font-family: var(--heroes-font-mono);
   font-size: 0.64rem;
   letter-spacing: 0.08em;
   color: var(--heroes-frost-dim);
 }
 
-/* meta always visible; kicker + byline hidden on mobile, restored at 560px+. */
+/* meta always visible; kicker hidden on mobile, restored at 560px+. */
 .heroes-ledger-rail__meta {
   display: block;
 }
 
-.heroes-ledger-rail__kicker,
-.heroes-ledger-rail__byline {
+.heroes-ledger-rail__kicker {
   display: none;
 }
 
@@ -492,26 +490,15 @@
   text-shadow: 0 0 8px rgba(224, 137, 74, 0.5);
 }
 
-.heroes-ledger-rail__entry {
-  min-width: 0;
-}
-
 .heroes-ledger-rail__name {
   display: block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--heroes-font-body);
   font-size: 0.84rem;
   line-height: 1.1;
-}
-
-.heroes-ledger-rail__byline {
-  margin-top: 2px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: color-mix(in oklch, var(--heroes-frost-dim) 78%, transparent);
 }
 
 .heroes-ledger-rail__controls {
@@ -1459,8 +1446,7 @@
     bottom: 1rem;
   }
 
-  .heroes-ledger-rail__kicker,
-  .heroes-ledger-rail__byline {
+  .heroes-ledger-rail__kicker {
     display: block;
   }
 
@@ -1576,8 +1562,7 @@
     display: block;
   }
 
-  .heroes-ledger-rail__kicker,
-  .heroes-ledger-rail__byline {
+  .heroes-ledger-rail__kicker {
     display: block;
   }
 

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -474,6 +474,15 @@
       var branch = computeBranchForTopSkill(contributor);
       var glyph = BRANCH_GLYPH[branch] || BRANCH_GLYPH.standard;
       var avatarUrl = githubAvatarUrl(contributor.handle, 80);
+      // Degrade to the GitHub identicon on avatar error (same fallback the stage
+      // crest uses) rather than hiding the cell — hiding collapsed the 26px grid
+      // gutter and shifted glyph+name left, misaligning the row vs neighbors.
+      // The identicon keeps SOMETHING in the cell so the gutter never empties;
+      // the data-fbk guard stops an infinite onerror loop if it also 404s.
+      var cleanHandle = String(contributor.handle || '').replace(/^@/, '');
+      var identicon = 'https://github.com/identicons/' + encodeURIComponent(cleanHandle) + '.png';
+      var avatarErr = "if(this.dataset.fbk){this.onerror=null;}else{this.dataset.fbk='1';this.src='" +
+        jsStr(identicon) + "';}";
       var lvl = levelNum(contributor.topSkill.level);
       // The rail row shows only the (truncatable) slug, so carry the full
       // identifier on the button title for hover recovery: full skill name plus
@@ -483,7 +492,7 @@
       var title = fullName + (handle ? ' — @' + handle : '');
       return '<li class="heroes-ledger-rail__item">' +
         '<button class="heroes-ledger-rail__button" type="button" title="' + esc(title) + '" data-ledger-target="' + esc(stageIdFor(contributor)) + '" data-ledger-index="' + esc(index) + '" data-branch="' + esc(branch) + '" data-level="' + lvl + '">' +
-        '<span class="heroes-ledger-rail__avatar" aria-hidden="true"><img src="' + esc(avatarUrl) + '" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" onerror="this.parentElement.hidden=true"></span>' +
+        '<span class="heroes-ledger-rail__avatar" aria-hidden="true"><img src="' + esc(avatarUrl) + '" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" onerror="' + esc(avatarErr) + '"></span>' +
         '<span class="heroes-ledger-rail__glyph" aria-hidden="true">' + esc(glyph) + '</span>' +
         '<span class="heroes-ledger-rail__name">' + esc(slug) + '</span>' +
         '</button>' +

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -138,10 +138,6 @@
     return 'hero-' + String(raw).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
   }
 
-  function rankText(contributor) {
-    return contributor.topSkill && contributor.topSkill.level ? contributor.topSkill.level : 'Unranked';
-  }
-
   function trustMagnitude(contributor) {
     if (contributor.heroTrustMagnitude != null) return contributor.heroTrustMagnitude;
     return contributor.topSkill && contributor.topSkill.trustMagnitude != null
@@ -478,10 +474,7 @@
         '<button class="heroes-ledger-rail__button" type="button" data-ledger-target="' + esc(stageIdFor(contributor)) + '" data-ledger-index="' + esc(index) + '" data-branch="' + esc(branch) + '" data-level="' + lvl + '">' +
         '<span class="heroes-ledger-rail__avatar" aria-hidden="true"><img src="' + esc(avatarUrl) + '" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" onerror="this.parentElement.hidden=true"></span>' +
         '<span class="heroes-ledger-rail__glyph" aria-hidden="true">' + esc(glyph) + '</span>' +
-        '<span class="heroes-ledger-rail__entry">' +
         '<span class="heroes-ledger-rail__name">' + esc(slug) + '</span>' +
-        '<span class="heroes-ledger-rail__byline">@' + esc(contributor.handle) + '</span>' +
-        '</span>' +
         '</button>' +
         '</li>';
     }).join('');

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -686,8 +686,13 @@
 
     if (entry && meta) {
       // E2: rankLabel via GaiaSemantics — no banned words in ledger meta.
+      // Plate ordinal matches the stage ordinal EXACTLY (zero-padded "Plate NN
+      // / NN") so the two "Plate N" strings on screen never disagree — both
+      // derive from index+1 off the same active index.
       var displayLabel = topSkillRankLabel(entry.contributor);
-      meta.textContent = displayLabel + ' · Plate ' + (index + 1) + ' of ' + total;
+      var plateOrdinal = 'Plate ' + String(index + 1).padStart(2, '0') +
+        ' / ' + String(total).padStart(2, '0');
+      meta.textContent = displayLabel + ' · ' + plateOrdinal;
     }
 
     if (progress) {

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -489,6 +489,7 @@
     LEDGER_ITEMS = heroes;
     LEDGER_ACTIVE_INDEX = -1;
     applyLedgerWindow(-1);
+    ensureAllPlatesPanel();
     setLedgerAwaiting();
     rail.hidden = false;
   }
@@ -701,6 +702,111 @@
     }
 
     rail.style.setProperty('--heroes-ledger-progress', ((index + 1) / total).toFixed(4));
+  }
+
+  // ── "All plates" full index (opened on demand from the rail) ──
+  // The windowed rail only shows a neighborhood; this native <dialog> is how
+  // EVERY hero stays reachable. It reads LEDGER_ITEMS (the full list), reuses
+  // the data-ledger-target scroll-to path, and gets Esc dismiss + focus trap
+  // for free from <dialog>.showModal(). Trigger + dialog are injected here so
+  // the static index.html markup is untouched.
+  var ALL_PLATES_TRIGGER = null;
+  var ALL_PLATES_DIALOG = null;
+
+  function ensureAllPlatesPanel() {
+    var rail = document.getElementById('heroesLedgerRail');
+    if (!rail) return;
+
+    if (!ALL_PLATES_TRIGGER) {
+      var trigger = document.createElement('button');
+      trigger.type = 'button';
+      trigger.className = 'heroes-ledger-rail__all';
+      trigger.id = 'heroesLedgerAll';
+      trigger.setAttribute('aria-haspopup', 'dialog');
+      trigger.setAttribute('aria-controls', 'heroesLedgerAllPanel');
+      trigger.innerHTML =
+        '<span class="heroes-ledger-rail__all-caret" aria-hidden="true">▾</span>' +
+        '<span class="heroes-ledger-rail__all-label">all plates</span>';
+      // Insert after the list, before the controls, so it reads as "expand the
+      // ledger" beneath the windowed rows.
+      var controls = rail.querySelector('.heroes-ledger-rail__controls');
+      if (controls) {
+        rail.insertBefore(trigger, controls);
+      } else {
+        rail.appendChild(trigger);
+      }
+      trigger.addEventListener('click', openAllPlates);
+      ALL_PLATES_TRIGGER = trigger;
+    }
+
+    if (!ALL_PLATES_DIALOG && typeof document.createElement('dialog').showModal === 'function') {
+      var dialog = document.createElement('dialog');
+      dialog.className = 'heroes-ledger-all';
+      dialog.id = 'heroesLedgerAllPanel';
+      dialog.setAttribute('aria-label', 'All plates in the Hall of Heroes');
+      dialog.innerHTML =
+        '<div class="heroes-ledger-all__head">' +
+        '<h2 class="heroes-ledger-all__title">All Plates</h2>' +
+        '<button class="heroes-ledger-all__close" type="button" aria-label="Close all-plates index">' +
+        '<svg class="ico" width="16" height="16" aria-hidden="true"><use href="../assets/icons.svg#close-x"></use></svg>' +
+        '</button>' +
+        '</div>' +
+        '<ol class="heroes-ledger-all__list" id="heroesLedgerAllList"></ol>';
+      document.body.appendChild(dialog);
+
+      // Close on the X, on backdrop click, and (native) on Esc.
+      dialog.querySelector('.heroes-ledger-all__close').addEventListener('click', closeAllPlates);
+      dialog.addEventListener('click', function (e) {
+        if (e.target === dialog) closeAllPlates();
+      });
+      // Clicking an entry scrolls to that plate, then dismisses.
+      dialog.addEventListener('click', function (e) {
+        var btn = e.target.closest('[data-ledger-target]');
+        if (!btn) return;
+        closeAllPlates();
+        scrollToStage(document.getElementById(btn.getAttribute('data-ledger-target')));
+      });
+      ALL_PLATES_DIALOG = dialog;
+    }
+  }
+
+  function renderAllPlatesList() {
+    var listEl = document.getElementById('heroesLedgerAllList');
+    if (!listEl) return;
+    listEl.innerHTML = LEDGER_ITEMS.map(function (entry, index) {
+      var contributor = entry.contributor;
+      var skillId = contributor.topSkill.id || '';
+      var slug = skillId.split('/').pop() || contributor.handle;
+      var branch = computeBranchForTopSkill(contributor);
+      var glyph = BRANCH_GLYPH[branch] || BRANCH_GLYPH.standard;
+      var lvl = levelNum(contributor.topSkill.level);
+      // The full index CAN carry @handle + rank — it is the reference view, not
+      // the scannable rail. rankLabel is branch-forked (E2), no banned words.
+      var rankLabel = topSkillRankLabel(contributor);
+      return '<li class="heroes-ledger-all__item">' +
+        '<button class="heroes-ledger-all__entry" type="button" data-ledger-target="' + esc(stageIdFor(contributor)) + '" data-ledger-index="' + esc(index) + '" data-branch="' + esc(branch) + '" data-level="' + lvl + '">' +
+        '<span class="heroes-ledger-all__glyph" aria-hidden="true">' + esc(glyph) + '</span>' +
+        '<span class="heroes-ledger-all__body">' +
+        '<span class="heroes-ledger-all__name">' + esc(slug) + '</span>' +
+        '<span class="heroes-ledger-all__by">@' + esc(contributor.handle) + ' &middot; ' + esc(rankLabel) + '</span>' +
+        '</span>' +
+        '</button>' +
+        '</li>';
+    }).join('');
+  }
+
+  function openAllPlates() {
+    if (!ALL_PLATES_DIALOG) return;
+    renderAllPlatesList();
+    ALL_PLATES_DIALOG.showModal();
+    // Land focus on the active entry so keyboard users start in context.
+    var active = ALL_PLATES_DIALOG.querySelector('[data-ledger-index="' + LEDGER_ACTIVE_INDEX + '"]');
+    if (active) active.focus();
+  }
+
+  function closeAllPlates() {
+    if (ALL_PLATES_DIALOG && ALL_PLATES_DIALOG.open) ALL_PLATES_DIALOG.close();
+    if (ALL_PLATES_TRIGGER) ALL_PLATES_TRIGGER.focus();
   }
 
   function setupLedgerRail() {

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -364,7 +364,12 @@
 
   function scrollToStage(stage) {
     if (!stage) return;
-    stage.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Honor prefers-reduced-motion: skip the smooth animation for users who
+    // asked for reduced motion. Gated once here so every caller (dialog entry,
+    // rail row, nav arrow) inherits the behavior.
+    var prefersReduced = window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    stage.scrollIntoView({ behavior: prefersReduced ? 'auto' : 'smooth', block: 'center' });
   }
 
   function notifyStageVisible(stage) {

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -29,6 +29,13 @@
   var SCROLL_TICKING = false;
   var ACTIVE_STAGE = null;
   var LEDGER_ITEMS = [];
+  // Windowed locator (desktop ≥820px): show only a neighborhood of rows around
+  // the active plate instead of all N. Chosen as prev 2 / current / next 3 — a
+  // 6-row window reads as "where am I + what's next" without overflowing the
+  // fixed rail at ~820–900px, while still previewing the immediate ascent path.
+  var LEDGER_WINDOW_BEFORE = 2;
+  var LEDGER_WINDOW_AFTER = 3;
+  var LEDGER_ACTIVE_INDEX = -1;
 
   // Hero → bespoke animation mapping (keyed by named-skill id, not type)
   var ULTIMATE_ANIMS = {
@@ -473,13 +480,15 @@
         '<span class="heroes-ledger-rail__glyph" aria-hidden="true">' + esc(glyph) + '</span>' +
         '<span class="heroes-ledger-rail__entry">' +
         '<span class="heroes-ledger-rail__name">' + esc(slug) + '</span>' +
-        '<span class="heroes-ledger-rail__byline">@' + esc(contributor.handle) + ' · ' + esc(rankText(contributor)) + '</span>' +
+        '<span class="heroes-ledger-rail__byline">@' + esc(contributor.handle) + '</span>' +
         '</span>' +
         '</button>' +
         '</li>';
     }).join('');
 
     LEDGER_ITEMS = heroes;
+    LEDGER_ACTIVE_INDEX = -1;
+    applyLedgerWindow(-1);
     setLedgerAwaiting();
     rail.hidden = false;
   }
@@ -617,6 +626,31 @@
     requestAnimationFrame(updateActiveStage);
   }
 
+  // Reveal only the window of rows around the active index (desktop rail). Cheap
+  // on scroll: toggles a class per <li> rather than rebuilding innerHTML. The
+  // full list stays in the DOM (the "all plates" panel and prev/next walk it);
+  // CSS hides non-windowed rows at ≥820px only, so the mobile carousel is
+  // unaffected (it keeps showing every chip and scrolls horizontally).
+  function applyLedgerWindow(activeIndex) {
+    var list = document.getElementById('heroesLedgerList');
+    if (!list) return;
+    var items = list.children;
+    var total = items.length;
+    if (!total) return;
+
+    var lo = activeIndex - LEDGER_WINDOW_BEFORE;
+    var hi = activeIndex + LEDGER_WINDOW_AFTER;
+    // Slide the window so it stays full-width at the ends (clamp, then shift).
+    if (lo < 0) { hi += -lo; lo = 0; }
+    if (hi > total - 1) { lo -= (hi - (total - 1)); hi = total - 1; }
+    if (lo < 0) lo = 0;
+
+    for (var i = 0; i < total; i++) {
+      var inWindow = (activeIndex < 0) ? (i <= LEDGER_WINDOW_BEFORE + LEDGER_WINDOW_AFTER) : (i >= lo && i <= hi);
+      items[i].classList.toggle('is-in-window', inWindow);
+    }
+  }
+
   function updateLedgerForStage(stage) {
     var rail = document.getElementById('heroesLedgerRail');
     if (!rail) return;
@@ -628,6 +662,9 @@
     var progress = document.getElementById('heroesLedgerProgress');
     var buttons = rail.querySelectorAll('[data-ledger-target]');
     var total = LEDGER_ITEMS.length || buttons.length || 1;
+
+    LEDGER_ACTIVE_INDEX = index;
+    applyLedgerWindow(index);
 
     var lvl = stage.getAttribute('data-level') || '4';
     rail.setAttribute('data-active-level', lvl);

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -475,8 +475,14 @@
       var glyph = BRANCH_GLYPH[branch] || BRANCH_GLYPH.standard;
       var avatarUrl = githubAvatarUrl(contributor.handle, 80);
       var lvl = levelNum(contributor.topSkill.level);
+      // The rail row shows only the (truncatable) slug, so carry the full
+      // identifier on the button title for hover recovery: full skill name plus
+      // @handle when available.
+      var fullName = contributor.topSkill.name || slug;
+      var handle = contributor.handle;
+      var title = fullName + (handle ? ' — @' + handle : '');
       return '<li class="heroes-ledger-rail__item">' +
-        '<button class="heroes-ledger-rail__button" type="button" data-ledger-target="' + esc(stageIdFor(contributor)) + '" data-ledger-index="' + esc(index) + '" data-branch="' + esc(branch) + '" data-level="' + lvl + '">' +
+        '<button class="heroes-ledger-rail__button" type="button" title="' + esc(title) + '" data-ledger-target="' + esc(stageIdFor(contributor)) + '" data-ledger-index="' + esc(index) + '" data-branch="' + esc(branch) + '" data-level="' + lvl + '">' +
         '<span class="heroes-ledger-rail__avatar" aria-hidden="true"><img src="' + esc(avatarUrl) + '" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" onerror="this.parentElement.hidden=true"></span>' +
         '<span class="heroes-ledger-rail__glyph" aria-hidden="true">' + esc(glyph) + '</span>' +
         '<span class="heroes-ledger-rail__name">' + esc(slug) + '</span>' +

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -729,7 +729,7 @@
       trigger.setAttribute('aria-controls', 'heroesLedgerAllPanel');
       trigger.innerHTML =
         '<span class="heroes-ledger-rail__all-caret" aria-hidden="true">▾</span>' +
-        '<span class="heroes-ledger-rail__all-label">all plates</span>';
+        '<span class="heroes-ledger-rail__all-label"></span>';
       // Insert after the list, before the controls, so it reads as "expand the
       // ledger" beneath the windowed rows.
       var controls = rail.querySelector('.heroes-ledger-rail__controls');
@@ -741,6 +741,12 @@
       trigger.addEventListener('click', openAllPlates);
       ALL_PLATES_TRIGGER = trigger;
     }
+
+    // Surface the real count so the button reads as the primary "see everything"
+    // affordance ("all N plates"). Derived from LEDGER_ITEMS.length, not a
+    // hardcoded 24, and refreshed on every render so it tracks the live list.
+    var allLabel = ALL_PLATES_TRIGGER.querySelector('.heroes-ledger-rail__all-label');
+    if (allLabel) allLabel.textContent = 'all ' + LEDGER_ITEMS.length + ' plates';
 
     if (!ALL_PLATES_DIALOG && typeof document.createElement('dialog').showModal === 'function') {
       var dialog = document.createElement('dialog');
@@ -802,8 +808,13 @@
     if (!ALL_PLATES_DIALOG) return;
     renderAllPlatesList();
     ALL_PLATES_DIALOG.showModal();
-    // Land focus on the active entry so keyboard users start in context.
-    var active = ALL_PLATES_DIALOG.querySelector('[data-ledger-index="' + LEDGER_ACTIVE_INDEX + '"]');
+    // Land focus on the active entry so keyboard users start in context. When
+    // LEDGER_ACTIVE_INDEX is -1 (awaiting state, before any scroll) that lookup
+    // matches nothing — fall back to the first entry, then the close button, so
+    // focus always lands somewhere inside the dialog.
+    var active = ALL_PLATES_DIALOG.querySelector('[data-ledger-index="' + LEDGER_ACTIVE_INDEX + '"]') ||
+      ALL_PLATES_DIALOG.querySelector('.heroes-ledger-all__entry') ||
+      ALL_PLATES_DIALOG.querySelector('.heroes-ledger-all__close');
     if (active) active.focus();
   }
 

--- a/scripts/check_hex_colors.py
+++ b/scripts/check_hex_colors.py
@@ -26,8 +26,9 @@ Allowed forms (not flagged):
     custom-property fallback (`var(--x, ...)`) is treated as token-anchored, the
     same allowance the original inline grep encoded with `grep -v 'var(--[^,]*,'`.
 
-Scanned scope: docs/js/**/*.js and docs/css/**/*.css — the live design-system
-code Guard A has always enforced. Two categories are exempt:
+Scanned scope: docs/**/*.js and docs/**/*.css — every live design-system JS/CSS
+file under docs/, not just docs/js and docs/css (so section-local stylesheets
+like docs/heroes/heroes.css are covered too). Two categories are exempt:
   - docs/css/tokens.css — the GENERATED token-definition source (built by
     scripts/generateCssTokens.py from registry/gaia.json). It is *supposed* to
     contain every raw hex; it is the single place they are allowed to live.
@@ -113,7 +114,7 @@ def scan_file(path: Path):
 
 
 def iter_target_files():
-    for pattern in ("js/**/*.js", "css/**/*.css"):
+    for pattern in ("**/*.js", "**/*.css"):
         for path in DOCS.glob(pattern):
             if not path.is_file():
                 continue


### PR DESCRIPTION
## Hall of Heroes — /impeccable redesign (windowed locator rail)

Final Hall-of-Heroes design pass for Yggdrasil II. Stacked on #1297 (branch-fork color fix); merges into `design/ygg2-heroes-branchfork`.

### What & why
The desktop left rail was an **uncapped vertical list of all 24 heroes** — overpopulated, and at ~900px it truncated names mid-word. The redesign replaces it with a **windowed locator**:

- **Active-plate header** — name · rank · `Plate NN / 24`
- **Windowed neighborhood** — ~6 nearby heroes (prev 2 / current / next 3), fades on scroll
- **Prev/next arrows** + per-row jump
- **`▾ ALL N PLATES`** native `<dialog>` — full index of all 24 heroes (handle + rank), so every hero stays reachable regardless of the window

`LEDGER_ITEMS` retains the full list (never mutated) — the window is a view, not a data cap. Mobile keeps its bounded bottom strip. Section max-widths (previously mismatched 680/720/800px) are tokenized to `--heroes-prose-max` / `--heroes-content-max` so stacked stages align.

### /impeccable critique — resolved in this PR
Two independent assessments (design review 33/40, no P0/P1 code defects). All convergent findings fixed:

- **P1** — dual plate-number readouts unified to zero-padded `Plate NN / 24` (rail header == stage ordinal, same active index)
- **P2** — `scrollToStage` now honors `prefers-reduced-motion` (all callers inherit)
- **P2** — `ALL N PLATES` dynamic count + contrast bump + `-1` awaiting-state focus fallback
- **P3** — rail row `title` tooltip recovers truncated slugs
- **P3** — 44px close button; avatar `onerror` degrades to identicon (keeps the 26px grid gutter, no misalignment)
- **P2 (infra)** — `check_hex_colors.py` (Guard A) glob broadened to `docs/**/*.{js,css}` so `docs/heroes/` is actually scanned (was a coverage blind spot; heroes CSS verified clean, exits 0)

### Verification
- Render-verified at desktop-1440, breakpoint-900, mobile-390 + the "All Plates" dialog open (screenshots in `screenshots/impeccable-v3/`)
- `node --check docs/heroes/heroes.js` → OK
- `python scripts/check_hex_colors.py` → exit 0
- Dead code (`rankText`, `__byline`) confirmed removed; no orphan refs
- Branch glyphs render correct (gold ◆ Suite / violet ◉ Unique)

### Entrypoints
- **No new page/section** — this restructures the existing `/heroes/` rail in place. Nav, footer, `window.GAIA_MOUNTS`, homepage links: **unchanged / N/A** (heroes already mounted).
- `docs/heroes/index.html` cache-bust `?v=` unchanged (assets edited in place, version already current at 6.8.15 — no new referencing page).
- The `<dialog>` is injected by `heroes.js` (no new HTML entrypoint to register).

### Scope note
Touches `scripts/check_hex_colors.py` (Guard-A coverage fix) — out of the `design/` lane, so **`skip-scope-check` applied** (pre-authorized for generator/script touches this sprint).

Part of EPIC #1002 (Yggdrasil II) — Workstream B (Hall of Heroes).
