### PR TITLE
docs(tokens): fix skill-graph canvas-tokens contract comment (dead --tier-extra/-ultimate)

### DIFF
--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -12,11 +12,10 @@
   // ║ custom property on :root. A host page can override any token  ║
   // ║ to retheme the graph (e.g. local skill-tree views).           ║
   // ║                                                                ║
-  // ║   --tier-basic / -rgb / -edge                                  ║
-  // ║   --tier-extra / -rgb / -edge                                  ║
+  // ║   --tier-basic / -rgb / -edge   (type: basic ○)                ║
+  // ║   --tier-fusion / -rgb / -edge  (type: fusion ◇)               ║
   // ║   --rank-4-unique / -rgb / -edge  (5★ -5, 6★ -6, -ink)         ║
-  // ║   --tier-ultimate / -rgb / -edge                               ║
-  // ║   --rank-0 … --rank-6 / -bg / -border / -edge                  ║
+  // ║   --rank-0 … --rank-6 / -bg / -border / -edge  (Suite ladder)  ║
   // ║   --honor-red / --honor-red-rgb                                ║
   // ║   --apex-gold / --apex-gold-rgb                                ║
   // ║   --muted / --text                                             ║


### PR DESCRIPTION
## What

Fixes the `<canvas-tokens>` contract comment in `docs/js/skill-graph.js` (L15–18). It listed two **dead tokens** — `--tier-extra` and `--tier-ultimate` — that are never defined and never emitted by `generateCssTokens.py`. They were the last dead-token references in a comment anywhere in live JS/CSS.

Replaced with the tokens the canvas **actually reads**:
- `--tier-fusion` (the surviving `type: fusion ◇` token)
- `--rank-0 … --rank-6` (Suite ladder)
- `--rank-4-unique` was already correctly listed

The comment now matches the code body — which after the P5 rename reads `--rank-*-unique` (L134-138, L1226-1321) and `--tier-fusion`, with zero `--tier-extra/-ultimate`.

## Why

Sprint's own remainder for the token-eradication pass (EPIC #1002, Yggdrasil II). Per CLAUDE.md sprint-completeness, doc-accuracy drift the sprint introduced lands in-sprint, not as a follow-up.

## Entrypoints

No user-facing surface changed — comment-only edit inside an existing file. N/A / waived.

## Verification

- `python scripts/check_hex_colors.py` → Guard A OK, exit 0
- `grep --tier-(extra|ultimate)` in skill-graph.js → zero matches
