### PR TITLE
fix(heroes): align hero avatar centering and origin wreath mask framing

### DIFF
--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -1191,7 +1191,7 @@ button.plaque__slug {
   box-shadow:
     0 0 18px rgba(var(--plaque-accent-rgb), 0.32),
     inset 0 0 12px rgba(0, 0, 0, 0.55);
-  overflow: hidden;
+  overflow: visible;
   display: grid;
   place-items: center;
   flex-shrink: 0;

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -1113,6 +1113,25 @@ body:has(.heroes-gallery) {
   text-wrap: balance;
 }
 
+.hero-card__name-link,
+.hero-card__handle-link {
+  color: inherit;
+  text-decoration: none;
+  transition: opacity 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.hero-card__name-link:hover,
+.hero-card__name-link:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.hero-card__handle-link:hover,
+.hero-card__handle-link:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .hero-card__handle {
   font-family: var(--heroes-font-mono);
   font-size: 0.9rem;
@@ -1684,12 +1703,12 @@ body:has(.heroes-gallery) {
   border-radius: 50%;
 }
 
-/* Photo inside the avatar wrapper — 82% so the wreath frames it from the outside */
+/* Photo inside the avatar wrapper — 90% to fill the circular crest frame */
 .hero-card__crest-square-front .plaque__avatar-img,
 .hero-card__crest-avatar-img {
   display: block;
-  width: 82% !important;
-  height: 82% !important;
+  width: 90% !important;
+  height: 90% !important;
   object-fit: cover;
   border-radius: 50%;
   filter: saturate(0.86) contrast(1.08);
@@ -1699,10 +1718,10 @@ body:has(.heroes-gallery) {
 .hero-card__crest-square-front .plaque__avatar-wreath,
 .hero-card__crest-avatar-wreath {
   position: absolute;
-  /* Wreath is 112% of the avatar wrapper so it frames the photo outside the circle. */
-  inset: -6%;
-  width: 112%;
-  height: 112%;
+  /* Wreath is 116% of the avatar wrapper so it frames the 90% photo to fit the circular crest. */
+  inset: -8%;
+  width: 116%;
+  height: 116%;
   pointer-events: none;
   display: block;
 }

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -981,8 +981,8 @@ body:has(.heroes-gallery) {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: clamp(110px, 16vw, 140px);
-  height: clamp(110px, 16vw, 140px);
+  width: clamp(120px, 18vw, 150px);
+  height: clamp(120px, 18vw, 150px);
   overflow: visible;
   border-radius: 50%;
   border: 2px solid rgba(var(--stage-accent-rgb), 0.45);
@@ -1664,9 +1664,9 @@ body:has(.heroes-gallery) {
   .hero-card__crest-square-front,
   .hero-card__crest-square-front .plaque__avatar,
   .hero-card__crest-avatar {
-    width: clamp(160px, 20vw, 220px);
-    height: clamp(160px, 20vw, 220px);
-    --avatar-size: clamp(160px, 20vw, 220px);
+    width: clamp(170px, 22vw, 230px);
+    height: clamp(170px, 22vw, 230px);
+    --avatar-size: clamp(170px, 22vw, 230px);
   }
 
   .hero-card__crest-diamond-back {
@@ -1703,12 +1703,12 @@ body:has(.heroes-gallery) {
   border-radius: 50%;
 }
 
-/* Photo inside the avatar wrapper — 90% to fill the circular crest frame */
+/* Photo inside the avatar wrapper — 96% to fill the circular crest frame */
 .hero-card__crest-square-front .plaque__avatar-img,
 .hero-card__crest-avatar-img {
   display: block;
-  width: 90% !important;
-  height: 90% !important;
+  width: 96% !important;
+  height: 96% !important;
   object-fit: cover;
   border-radius: 50%;
   filter: saturate(0.86) contrast(1.08);
@@ -1718,10 +1718,10 @@ body:has(.heroes-gallery) {
 .hero-card__crest-square-front .plaque__avatar-wreath,
 .hero-card__crest-avatar-wreath {
   position: absolute;
-  /* Wreath is 116% of the avatar wrapper so it frames the 90% photo to fit the circular crest. */
-  inset: -8%;
-  width: 116%;
-  height: 116%;
+  /* Wreath is 124% of the avatar wrapper so it frames the 96% photo outside the circle. */
+  inset: -12% !important;
+  width: 124% !important;
+  height: 124% !important;
   pointer-events: none;
   display: block;
 }

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -978,6 +978,9 @@ body:has(.heroes-gallery) {
 .hero-card__crest-square-front {
   position: relative;
   z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: clamp(110px, 16vw, 140px);
   height: clamp(110px, 16vw, 140px);
   overflow: visible;
@@ -1663,27 +1666,30 @@ body:has(.heroes-gallery) {
 .hero-card__crest-square-front {
   /* Allow the wreath and medallion to spill outside the circle. */
   overflow: visible;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Avatar wrapper (either plaque__avatar or hero-card__crest-avatar) */
 .hero-card__crest-square-front .plaque__avatar,
 .hero-card__crest-avatar {
-  --avatar-size: clamp(110px, 16vw, 140px);
+  --avatar-size: 100%;
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: var(--avatar-size);
-  height: var(--avatar-size);
+  width: 100% !important;
+  height: 100% !important;
   border-radius: 50%;
 }
 
-/* Photo inside the avatar wrapper */
+/* Photo inside the avatar wrapper — 82% so the wreath frames it from the outside */
 .hero-card__crest-square-front .plaque__avatar-img,
 .hero-card__crest-avatar-img {
   display: block;
-  width: 100%;
-  height: 100%;
+  width: 82% !important;
+  height: 82% !important;
   object-fit: cover;
   border-radius: 50%;
   filter: saturate(0.86) contrast(1.08);
@@ -1693,7 +1699,7 @@ body:has(.heroes-gallery) {
 .hero-card__crest-square-front .plaque__avatar-wreath,
 .hero-card__crest-avatar-wreath {
   position: absolute;
-  /* Wreath is 112% of the avatar so it frames the photo. */
+  /* Wreath is 112% of the avatar wrapper so it frames the photo outside the circle. */
   inset: -6%;
   width: 112%;
   height: 112%;

--- a/docs/heroes/heroes.css
+++ b/docs/heroes/heroes.css
@@ -1003,13 +1003,13 @@ body:has(.heroes-gallery) {
 
 .hero-card__crest-seal {
   position: absolute;
-  bottom: -4px;
-  right: -4px;
+  bottom: -2px;
+  right: -2px;
   left: auto;
   transform: none;
   z-index: 10;
-  width: 44px;
-  height: 44px;
+  width: 42px;
+  height: 42px;
   border-radius: 50%;
   display: grid;
   place-items: center;
@@ -1025,10 +1025,10 @@ body:has(.heroes-gallery) {
    supersedes the legacy ◆ glyph (hidden below); the seal grows slightly so
    the rank medallion reads. The shared .plaque-orb--medallion img fills it. */
 .hero-card__crest-seal:has(.plaque-orb--medallion) {
-  width: 56px;
-  height: 56px;
-  bottom: -8px;
-  right: -8px;
+  width: 46px;
+  height: 46px;
+  bottom: -4px;
+  right: -4px;
   background: transparent;
   border: none;
   box-shadow: none;
@@ -1065,7 +1065,8 @@ body:has(.heroes-gallery) {
     0 0 54px rgba(var(--stage-accent-rgb), 0.22);
 }
 
-.hero-stage.is-active .hero-card__crest-square-front {
+.hero-stage.is-active .hero-card__crest-square-front,
+.hero-stage.is-active .hero-card__crest-seal {
   transform: scale(1.04);
   border-color: rgba(var(--stage-accent-rgb), 0.45);
 }
@@ -1078,7 +1079,8 @@ body:has(.heroes-gallery) {
     0 0 60px rgba(var(--stage-accent-rgb), 0.28);
 }
 
-.hero-card__crest-wrapper:hover .hero-card__crest-square-front {
+.hero-card__crest-wrapper:hover .hero-card__crest-square-front,
+.hero-card__crest-wrapper:hover .hero-card__crest-seal {
   transform: translateY(-4px) scale(1.06);
   border-color: var(--stage-accent);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.75);
@@ -1277,7 +1279,8 @@ body:has(.heroes-gallery) {
   animation: hero-cascade 1.3s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.hero-stage.is-visible .hero-card__crest-square-front {
+.hero-stage.is-visible .hero-card__crest-square-front,
+.hero-stage.is-visible .hero-card__crest-seal {
   animation: hero-unique-enter 0.8s ease-out both;
   animation-delay: 0.25s;
 }
@@ -1313,7 +1316,10 @@ body:has(.heroes-gallery) {
 
 .hero-stage--apex.is-visible .hero-card__crest-square-front,
 .hero-stage--unique.is-visible .hero-card__crest-square-front,
-.hero-stage--named.is-visible .hero-card__crest-square-front {
+.hero-stage--named.is-visible .hero-card__crest-square-front,
+.hero-stage--apex.is-visible .hero-card__crest-seal,
+.hero-stage--unique.is-visible .hero-card__crest-seal,
+.hero-stage--named.is-visible .hero-card__crest-seal {
   animation: hero-unique-enter 0.8s ease-out both;
   animation-delay: 0.25s;
 }

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -24,6 +24,7 @@
   var API_URL = '../api/v1/contributors/index.json';
   var TRUST_LEDGER_URL = '../graph/ledger/data.json';
   var NAMED_INDEX_URL = '../graph/named/index.json';
+  var GRAPH_URL = '../graph/gaia.json';
   var DETAIL_URL_TEMPLATE = '../api/v1/contributors/{handle}.json';
   var INTERSECTION_THRESHOLD = 0.3;
   var SCROLL_TICKING = false;
@@ -36,6 +37,7 @@
   var LEDGER_WINDOW_BEFORE = 2;
   var LEDGER_WINDOW_AFTER = 3;
   var LEDGER_ACTIVE_INDEX = -1;
+  var GAIA_SKILL_MAP = {};
 
   // Hero → bespoke animation mapping (keyed by named-skill id, not type)
   var ULTIMATE_ANIMS = {
@@ -385,11 +387,29 @@
   }
 
   function fusedCount(contributor) {
-    var skill = contributor && contributor.topSkill;
-    if (skill && Array.isArray(skill.suiteComponents)) {
-      return skill.suiteComponents.length;
+    var topSkill = contributor && contributor.topSkill;
+    if (!topSkill) return 0;
+    var genericRef = topSkill.genericSkillRef || (topSkill.id ? topSkill.id.split('/').pop() : '');
+    var generic = GAIA_SKILL_MAP[genericRef];
+    if (!generic || generic.type !== 'fusion') return 0;
+
+    var visited = {};
+    function walk(id) {
+      if (!id || visited[id] || !GAIA_SKILL_MAP[id]) return;
+      visited[id] = true;
+      var node = GAIA_SKILL_MAP[id];
+      var prereqs = Array.isArray(node.prerequisites) ? node.prerequisites : [];
+      prereqs.forEach(function (p) {
+        walk(p);
+      });
     }
-    return 0;
+
+    var directPrereqs = Array.isArray(generic.prerequisites) ? generic.prerequisites : [];
+    directPrereqs.forEach(function (p) {
+      walk(p);
+    });
+
+    return Object.keys(visited).length;
   }
 
   function renderHeroStage(contributor, tier, index, total) {
@@ -907,12 +927,26 @@
       }).catch(function (err) {
         console.warn('[heroes] Named index unavailable; falling back to basic/extra metadata from contributors API:', err);
         return {};
+      }),
+      fetch(GRAPH_URL).then(function (r) {
+        if (!r.ok) throw new Error('Graph gaia.json fetch failed: ' + r.status);
+        return r.json();
+      }).catch(function (err) {
+        console.warn('[heroes] Graph gaia.json unavailable:', err);
+        return { skills: [] };
       })
     ])
       .then(function (results) {
         var ledgerBySkill = trustLedgerMap(results[1]);
         var namedData = results[2];
+        var gaiaData = results[3];
         var namedBySkill = namedSkillMap(namedData);
+
+        GAIA_SKILL_MAP = {};
+        var gList = (gaiaData && Array.isArray(gaiaData.skills)) ? gaiaData.skills : [];
+        gList.forEach(function (s) {
+          if (s && s.id) GAIA_SKILL_MAP[s.id] = s;
+        });
 
         // §8: build one hero per qualifying named skill (rank >= 4) from the
         // named index — NOT one-per-contributor off the capped topSkill blob.

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -220,6 +220,7 @@
           medallion: entry.medallion,
           origin: entry.origin,
           links: entry.links,
+          genericSkillRef: entry.genericSkillRef,
           suiteComponents: entry.suiteComponents,
           trustMagnitude: entry.trustMagnitude
         }
@@ -274,6 +275,7 @@
     if (typeof named.branch === 'string' && named.branch) contributor.topSkill.branch = named.branch;
     if (typeof named.rankWord === 'string' && named.rankWord) contributor.topSkill.rankWord = named.rankWord;
     if (typeof named.medallion === 'string' && named.medallion) contributor.topSkill.medallion = named.medallion;
+    if (named.genericSkillRef) contributor.topSkill.genericSkillRef = named.genericSkillRef;
     if (named.suiteComponents) contributor.topSkill.suiteComponents = named.suiteComponents;
     if (named.links) contributor.topSkill.links = named.links;
     return contributor;

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -469,8 +469,8 @@
     // Meta
     html += '<div class="hero-card__meta">';
     html += '<div class="hero-card__tier-mark" aria-label="' + esc(tierLabel) + '"><span aria-hidden="true">' + esc(glyph) + '</span>' + esc(tierLabel) + '</div>';
-    html += '<h2 class="hero-card__name" id="' + esc(titleId) + '">' + esc(slug) + '</h2>';
-    html += '<div class="hero-card__handle">@' + esc(handle) + '</div>';
+    html += '<h2 class="hero-card__name" id="' + esc(titleId) + '"><a class="hero-card__name-link" href="../named/#explorer/' + esc(skillId) + '">' + esc(slug) + '</a></h2>';
+    html += '<div class="hero-card__handle"><a class="hero-card__handle-link" href="../u/' + esc(handle) + '/">@' + esc(handle) + '</a></div>';
     if (epithet) {
       html += '<p class="hero-card__epithet">' + esc(epithet) + '</p>';
     }

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -384,6 +384,14 @@
     return s.charAt(0) === '/' ? s : '/' + s;
   }
 
+  function fusedCount(contributor) {
+    var skill = contributor && contributor.topSkill;
+    if (skill && Array.isArray(skill.suiteComponents)) {
+      return skill.suiteComponents.length;
+    }
+    return 0;
+  }
+
   function renderHeroStage(contributor, tier, index, total) {
     var handle = contributor.handle;
     var skillId = contributor.topSkill.id;
@@ -445,7 +453,7 @@
     }
     html += '<div class="hero-card__stats">';
     html += '<span><span class="hero-card__stat-value">' + contributor.namedSkills + '</span> named skills</span>';
-    html += '<span><span class="hero-card__stat-value">' + contributor.topSkill.level + '</span> top rank</span>';
+    html += '<span><span class="hero-card__stat-value">' + fusedCount(contributor) + '</span> fused</span>';
     html += '<span><span class="hero-card__stat-value">' + formatTrustMagnitude(trustMagnitude(contributor)) + '</span> Trust Magnitude</span>';
     html += '</div>';
     html += '</div>';

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -378,10 +378,16 @@
 
   // ── Render functions ──────────────────────────────────────────
 
+  function namedSlugText(id) {
+    if (!id) return '';
+    var s = String(id).indexOf('/') !== -1 ? String(id).split('/', 2)[1] : String(id);
+    return s.charAt(0) === '/' ? s : '/' + s;
+  }
+
   function renderHeroStage(contributor, tier, index, total) {
     var handle = contributor.handle;
     var skillId = contributor.topSkill.id;
-    var slug = skillId.split('/').pop();
+    var slug = namedSlugText(skillId);
     var lvl = levelNum(contributor.topSkill.level);
     var branch = computeBranchForTopSkill(contributor);
     var anim = tier === 'ultimate' ? getAnim(skillId) : '';
@@ -469,7 +475,7 @@
       var contributor = entry.contributor;
       var tier = entry.tier;
       var skillId = contributor.topSkill.id || '';
-      var slug = skillId.split('/').pop() || contributor.handle;
+      var slug = namedSlugText(skillId) || contributor.handle;
       // E1: glyph keyed by branch, not type.
       var branch = computeBranchForTopSkill(contributor);
       var glyph = BRANCH_GLYPH[branch] || BRANCH_GLYPH.standard;
@@ -700,7 +706,7 @@
     });
 
     if (entry && current) {
-      var slug = (entry.contributor.topSkill.id || '').split('/').pop() || entry.contributor.handle;
+      var slug = namedSlugText(entry.contributor.topSkill.id) || entry.contributor.handle;
       current.textContent = slug;
     }
 
@@ -800,7 +806,7 @@
     listEl.innerHTML = LEDGER_ITEMS.map(function (entry, index) {
       var contributor = entry.contributor;
       var skillId = contributor.topSkill.id || '';
-      var slug = skillId.split('/').pop() || contributor.handle;
+      var slug = namedSlugText(skillId) || contributor.handle;
       var branch = computeBranchForTopSkill(contributor);
       var glyph = BRANCH_GLYPH[branch] || BRANCH_GLYPH.standard;
       var lvl = levelNum(contributor.topSkill.level);

--- a/docs/heroes/heroes.js
+++ b/docs/heroes/heroes.js
@@ -360,6 +360,7 @@
       contributor: contributor && contributor.handle,
       level: skill.level,
       type: skill.type,
+      branch: computeBranchForTopSkill(contributor),
       suiteComponents: skill.suiteComponents,
     };
     // 'lg' size modifier → the AOV4 'hero' tier asset (largest stamp).


### PR DESCRIPTION
## Summary
- **Target Branch:** `dev/yggdrasil-ii-staging`
- **Fixes:** 
  1. Flexbox alignment added to `.hero-card__crest-square-front` and avatar wrappers in `docs/heroes/heroes.css` to ensure full centering of contributor avatars.
  2. Changed `.plaque--hall .plaque__hall-crest` overflow from `hidden` to `visible` in `docs/css/plaque.css` so gold laurel wreaths are not clipped inside circular frames.
  3. Adjusted avatar image sizing inside hero crests to 82% so the origin wreath frames the avatar photo from the outside as a laurel ring.