### PR TITLE
fix(explorer): pass emitted taxonomy fields to plaque.renderDetail for unique branch skills

### DIFF
--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -157,15 +157,51 @@
   --plaque-accent-rgb: var(--tier-basic-rgb);
   --plaque-accent-bg: var(--tier-basic-bg);
 }
+.plaque[data-branch="standard"][data-level="1"] {
+  --plaque-accent: var(--rank-1, #38bdf8);
+  --plaque-accent-rgb: var(--rank-1-rgb, 56, 189, 248);
+  --plaque-accent-bg: var(--rank-1-bg, rgba(56, 189, 248, 0.12));
+}
+.plaque[data-branch="standard"][data-level="2"] {
+  --plaque-accent: var(--rank-2, #63cab7);
+  --plaque-accent-rgb: var(--rank-2-rgb, 99, 202, 183);
+  --plaque-accent-bg: var(--rank-2-bg, rgba(99, 202, 183, 0.15));
+}
+.plaque[data-branch="standard"][data-level="3"] {
+  --plaque-accent: var(--rank-3, #a78bfa);
+  --plaque-accent-rgb: var(--rank-3-rgb, 167, 139, 250);
+  --plaque-accent-bg: var(--rank-3-bg, rgba(167, 139, 250, 0.15));
+}
 .plaque[data-branch="suite"] {
   --plaque-accent: var(--tier-fusion);
   --plaque-accent-rgb: var(--tier-fusion-rgb);
   --plaque-accent-bg: var(--tier-fusion-bg);
 }
+.plaque[data-branch="suite"][data-level="4"] {
+  --plaque-accent: var(--rank-4, #e879f9);
+  --plaque-accent-rgb: var(--rank-4-rgb, 232, 121, 249);
+  --plaque-accent-bg: var(--rank-4-bg, rgba(232, 121, 249, 0.15));
+}
+.plaque[data-branch="suite"][data-level="5"],
+.plaque[data-branch="suite"][data-level="6"] {
+  --plaque-accent: var(--apex-gold, #fbbf24);
+  --plaque-accent-rgb: var(--apex-gold-rgb, 251, 191, 36);
+  --plaque-accent-bg: var(--rank-5-bg, rgba(251, 191, 36, 0.15));
+}
 .plaque[data-branch="unique"] {
   --plaque-accent: var(--rank-4-unique);
   --plaque-accent-rgb: var(--rank-4-unique-rgb);
   --plaque-accent-bg: var(--rank-4-unique-bg);
+}
+.plaque[data-branch="unique"][data-level="5"] {
+  --plaque-accent: var(--rank-5-unique, #b26a3a);
+  --plaque-accent-rgb: var(--rank-5-unique-rgb, 178, 106, 58);
+  --plaque-accent-bg: rgba(178, 106, 58, 0.12);
+}
+.plaque[data-branch="unique"][data-level="6"] {
+  --plaque-accent: var(--rank-6-unique, #e0894a);
+  --plaque-accent-rgb: var(--rank-6-unique-rgb, 224, 137, 74);
+  --plaque-accent-bg: rgba(224, 137, 74, 0.12);
 }
 .plaque[data-branch="unique"]:hover {
   box-shadow:

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -157,51 +157,15 @@
   --plaque-accent-rgb: var(--tier-basic-rgb);
   --plaque-accent-bg: var(--tier-basic-bg);
 }
-.plaque[data-branch="standard"][data-level="1"] {
-  --plaque-accent: var(--rank-1, #38bdf8);
-  --plaque-accent-rgb: var(--rank-1-rgb, 56, 189, 248);
-  --plaque-accent-bg: var(--rank-1-bg, rgba(56, 189, 248, 0.12));
-}
-.plaque[data-branch="standard"][data-level="2"] {
-  --plaque-accent: var(--rank-2, #63cab7);
-  --plaque-accent-rgb: var(--rank-2-rgb, 99, 202, 183);
-  --plaque-accent-bg: var(--rank-2-bg, rgba(99, 202, 183, 0.15));
-}
-.plaque[data-branch="standard"][data-level="3"] {
-  --plaque-accent: var(--rank-3, #a78bfa);
-  --plaque-accent-rgb: var(--rank-3-rgb, 167, 139, 250);
-  --plaque-accent-bg: var(--rank-3-bg, rgba(167, 139, 250, 0.15));
-}
 .plaque[data-branch="suite"] {
   --plaque-accent: var(--tier-fusion);
   --plaque-accent-rgb: var(--tier-fusion-rgb);
   --plaque-accent-bg: var(--tier-fusion-bg);
 }
-.plaque[data-branch="suite"][data-level="4"] {
-  --plaque-accent: var(--rank-4, #e879f9);
-  --plaque-accent-rgb: var(--rank-4-rgb, 232, 121, 249);
-  --plaque-accent-bg: var(--rank-4-bg, rgba(232, 121, 249, 0.15));
-}
-.plaque[data-branch="suite"][data-level="5"],
-.plaque[data-branch="suite"][data-level="6"] {
-  --plaque-accent: var(--apex-gold, #fbbf24);
-  --plaque-accent-rgb: var(--apex-gold-rgb, 251, 191, 36);
-  --plaque-accent-bg: var(--rank-5-bg, rgba(251, 191, 36, 0.15));
-}
 .plaque[data-branch="unique"] {
   --plaque-accent: var(--rank-4-unique);
   --plaque-accent-rgb: var(--rank-4-unique-rgb);
   --plaque-accent-bg: var(--rank-4-unique-bg);
-}
-.plaque[data-branch="unique"][data-level="5"] {
-  --plaque-accent: var(--rank-5-unique, #b26a3a);
-  --plaque-accent-rgb: var(--rank-5-unique-rgb, 178, 106, 58);
-  --plaque-accent-bg: rgba(178, 106, 58, 0.12);
-}
-.plaque[data-branch="unique"][data-level="6"] {
-  --plaque-accent: var(--rank-6-unique, #e0894a);
-  --plaque-accent-rgb: var(--rank-6-unique-rgb, 224, 137, 74);
-  --plaque-accent-bg: rgba(224, 137, 74, 0.12);
 }
 .plaque[data-branch="unique"]:hover {
   box-shadow:

--- a/docs/js/named-skills.js
+++ b/docs/js/named-skills.js
@@ -693,11 +693,14 @@
         var word = (window.GaiaSemantics && typeof window.GaiaSemantics.rankWord === 'function')
           ? window.GaiaSemantics.rankWord(rn, branch || SUITE_LADDER)
           : (rn + '★');
-        var colorVar = branch === 'suite'
-          ? 'var(--tier-fusion)'
-          : branch === 'unique'
-            ? 'var(--rank-4-unique)'
-            : 'var(--rank-' + rn + ', var(--muted))';
+        var colorVar;
+        if (branch === 'unique') {
+          colorVar = rn >= 6 ? 'var(--rank-6-unique)' : (rn === 5 ? 'var(--rank-5-unique)' : 'var(--rank-4-unique)');
+        } else if (branch === 'suite' && rn >= 5) {
+          colorVar = 'var(--apex-gold)';
+        } else {
+          colorVar = 'var(--rank-' + rn + ', var(--muted))';
+        }
         var _base = (typeof window.gaiaIconBase === 'function')
           ? window.gaiaIconBase().replace(/assets\/icons\.svg(\?.*)?$/, '') : '';
         var _suiteMap = { 1:'c1-suite-awakened', 2:'c2-suite-named', 3:'c3-suite-evolved',

--- a/docs/js/named-skills.js
+++ b/docs/js/named-skills.js
@@ -246,11 +246,14 @@
       var kind = branch ? (branch === 'unique' ? 'Standalone' : 'Suite') : '';
 
       // Branch-aware zone color token
-      var zoneColor = branch === 'suite'
-        ? 'var(--tier-fusion)'
-        : branch === 'unique'
-          ? 'var(--rank-4-unique)'
-          : 'var(--rank-' + rankNum + ',var(--muted))';
+      var zoneColor;
+      if (branch === 'unique' && rankNum >= 4) {
+        zoneColor = rankNum >= 6 ? 'var(--rank-6-unique)' : (rankNum === 5 ? 'var(--rank-5-unique)' : 'var(--rank-4-unique)');
+      } else if (branch === 'suite' && rankNum >= 5) {
+        zoneColor = 'var(--apex-gold)';
+      } else {
+        zoneColor = 'var(--rank-' + rankNum + ', var(--muted))';
+      }
 
       // AOV4 badge medallion for this rank+branch
       var base = (typeof window.gaiaIconBase === 'function')
@@ -694,7 +697,7 @@
           ? window.GaiaSemantics.rankWord(rn, branch || SUITE_LADDER)
           : (rn + '★');
         var colorVar;
-        if (branch === 'unique') {
+        if (branch === 'unique' && rn >= 4) {
           colorVar = rn >= 6 ? 'var(--rank-6-unique)' : (rn === 5 ? 'var(--rank-5-unique)' : 'var(--rank-4-unique)');
         } else if (branch === 'suite' && rn >= 5) {
           colorVar = 'var(--apex-gold)';

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -375,6 +375,8 @@
     var redacted = window.isRedacted && window.isRedacted(ns.level);
     var repoUrl = (!redacted && (links.github || links.npm)) || '';
 
+    var branch = (ns && ns.branch) || (window.GaiaSemantics && typeof window.GaiaSemantics.branchOf === 'function' ? window.GaiaSemantics.branchOf(ns) : 'standard');
+
     // Build the entry passed to plaque.renderDetail. Use the generic
     // type if the named entry doesn't carry one. Description falls
     // back to the generic description so the right column is never
@@ -385,6 +387,11 @@
       title: ns.title,
       level: ns.level,
       type: type,
+      branch: branch,
+      rank: ns.rank,
+      rankWord: ns.rankWord,
+      medallion: ns.medallion,
+      suiteComponents: ns.suiteComponents,
       contributor: ns.contributor,
       origin: ns.origin,
       description: ns.description || (generic && generic.description) || '',

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -375,7 +375,7 @@
     var redacted = window.isRedacted && window.isRedacted(ns.level);
     var repoUrl = (!redacted && (links.github || links.npm)) || '';
 
-    var branch = (ns && ns.branch) || (window.GaiaSemantics && typeof window.GaiaSemantics.branchOf === 'function' ? window.GaiaSemantics.branchOf(ns) : 'standard');
+    var branch = _seBranchOf(ns);
 
     // Build the entry passed to plaque.renderDetail. Use the generic
     // type if the named entry doesn't carry one. Description falls

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -1593,7 +1593,7 @@
           if (nodeBranch === 'unique' && _nodeRank >= 4) {
             dotColor = _nodeRank >= 6 ? 'var(--rank-6-unique)' : (_nodeRank === 5 ? 'var(--rank-5-unique)' : 'var(--rank-4-unique)');
           } else if (nodeBranch === 'suite' && _nodeRank >= 5) {
-            dotColor = _nodeRank >= 6 ? 'var(--rank-6, var(--apex-gold))' : 'var(--rank-5, var(--apex-gold))';
+            dotColor = 'var(--apex-gold)';
           } else {
             dotColor = 'var(--rank-' + _nodeRank + ', var(--muted))';
           }

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -1587,13 +1587,13 @@
         var nodeType = (nb && nb.type) || s.type || 'basic';
         var nodeLevel = (nb && nb.level) || '';
         var _nodeRank = parseInt(String(nodeLevel).replace(/\D+/g, ''), 10) || 0;
-        var _nodeBranch = nb ? _seBranchOf(nb) : 'standard';
+        var nodeBranch = nb ? _seBranchOf(nb) : 'standard';
         var dotColor;
         if (hasNamed) {
-          if (_nodeBranch === 'unique') {
+          if (nodeBranch === 'unique' && _nodeRank >= 4) {
             dotColor = _nodeRank >= 6 ? 'var(--rank-6-unique)' : (_nodeRank === 5 ? 'var(--rank-5-unique)' : 'var(--rank-4-unique)');
-          } else if (_nodeBranch === 'suite' && _nodeRank >= 5) {
-            dotColor = 'var(--apex-gold)';
+          } else if (nodeBranch === 'suite' && _nodeRank >= 5) {
+            dotColor = _nodeRank >= 6 ? 'var(--rank-6, var(--apex-gold))' : 'var(--rank-5, var(--apex-gold))';
           } else {
             dotColor = 'var(--rank-' + _nodeRank + ', var(--muted))';
           }
@@ -1615,7 +1615,7 @@
         return '<div class="git-node' + extraMainClass + '"' +
             ' data-id="' + esc(id) + '"' +
             ' data-type="' + esc(nodeType) + '"' +
-            ' data-branch="' + esc(_nodeBranch) + '"' +
+            ' data-branch="' + esc(nodeBranch) + '"' +
             ' data-level="' + esc(nodeLevel) + '"' +
             ' data-ghost="' + (hasNamed ? 'false' : 'true') + '"' +
             ' style="--staggerY:' + staggerY + 'px; --staggerX:' + staggerX + 'px"' +

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -1587,7 +1587,19 @@
         var nodeType = (nb && nb.type) || s.type || 'basic';
         var nodeLevel = (nb && nb.level) || '';
         var _nodeRank = parseInt(String(nodeLevel).replace(/\D+/g, ''), 10) || 0;
-        var dotColor = hasNamed ? 'var(--rank-' + _nodeRank + ', var(--muted))' : 'var(--muted)';
+        var _nodeBranch = nb ? _seBranchOf(nb) : 'standard';
+        var dotColor;
+        if (hasNamed) {
+          if (_nodeBranch === 'unique') {
+            dotColor = _nodeRank >= 6 ? 'var(--rank-6-unique)' : (_nodeRank === 5 ? 'var(--rank-5-unique)' : 'var(--rank-4-unique)');
+          } else if (_nodeBranch === 'suite' && _nodeRank >= 5) {
+            dotColor = 'var(--apex-gold)';
+          } else {
+            dotColor = 'var(--rank-' + _nodeRank + ', var(--muted))';
+          }
+        } else {
+          dotColor = 'var(--muted)';
+        }
 
         // Label source: slash-form for named, raw id for ghost.
         var labelSource = hasNamed ? nb.id : id;
@@ -1603,6 +1615,7 @@
         return '<div class="git-node' + extraMainClass + '"' +
             ' data-id="' + esc(id) + '"' +
             ' data-type="' + esc(nodeType) + '"' +
+            ' data-branch="' + esc(_nodeBranch) + '"' +
             ' data-level="' + esc(nodeLevel) + '"' +
             ' data-ghost="' + (hasNamed ? 'false' : 'true') + '"' +
             ' style="--staggerY:' + staggerY + 'px; --staggerX:' + staggerX + 'px"' +


### PR DESCRIPTION
## Summary
- **Target Branch:** `dev/yggdrasil-ii-staging`
- **Fixes:** 
  1. Updated `renderHero` in `docs/js/skill-explorer.js` to forward `branch`, `rank`, `rankWord`, `medallion`, and `suiteComponents` from the named skill entry into `detailNs`.
  2. Resolves issue where opening a skill modal (e.g., `/named/#explorer/pbakaus/impeccable`) defaulted `data-branch` to `standard`, rendering incorrect colors and the wrong medallion stamp (`aov4-c4-suite-extra-hero.webp` instead of `aov4-d4-unique-hero.webp`).